### PR TITLE
Issue 258

### DIFF
--- a/src/nodes/confluence_node.rs
+++ b/src/nodes/confluence_node.rs
@@ -41,6 +41,7 @@ pub struct ConfluenceNode {
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
     recorder_idx_ds_1_order: Option<usize>,
+    recorder_idx_harmony_fraction: Option<usize>,
 }
 
 impl ConfluenceNode {
@@ -85,6 +86,9 @@ impl Node for ConfluenceNode {
         self.recorder_idx_ds_1_order = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_1_order").as_str(), false
         );
+        self.recorder_idx_harmony_fraction = data_cache.get_series_idx(
+            make_result_name(&self.name, "harmony_fraction").as_str(), false
+        );
 
         // Return
         Ok(())
@@ -97,6 +101,9 @@ impl Node for ConfluenceNode {
         // Record downstream orders
         if let Some(idx) = self.recorder_idx_ds_1_order {
             data_cache.add_value_at_index(idx, self.dsorders[0]);
+        }
+        if let Some(idx) = self.recorder_idx_harmony_fraction {
+            data_cache.add_value_at_index(idx, self.harmony_fraction_value);
         }
     }
 

--- a/src/nodes/gauge_node.rs
+++ b/src/nodes/gauge_node.rs
@@ -28,6 +28,7 @@ pub struct GaugeNode {
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
     recorder_idx_ds_1_order: Option<usize>,
+    recorder_idx_reference_flow: Option<usize>,
 }
 
 impl GaugeNode {
@@ -65,6 +66,9 @@ impl Node for GaugeNode {
         );
         self.recorder_idx_ds_1_order = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_1_order").as_str(), false
+        );
+        self.recorder_idx_reference_flow = data_cache.get_series_idx(
+            make_result_name(&self.name, "reference_flow").as_str(), false
         );
 
         // Return
@@ -107,14 +111,20 @@ impl Node for GaugeNode {
         }
 
         // Record results
-        if let Some(idx) = self.recorder_idx_delta {
-            let mut reference_flow_value = f64::NAN;
+        let needs_reference_flow = self.recorder_idx_delta.is_some() || self.recorder_idx_reference_flow.is_some();
+        let reference_flow_value = if needs_reference_flow {
             match self.reference_flow_input {
-                DynamicInput::None { .. } => {},
-                _ => { reference_flow_value = self.reference_flow_input.get_value(data_cache); }
+                DynamicInput::None { .. } => f64::NAN,
+                _ => self.reference_flow_input.get_value(data_cache),
             }
-            let delta = self.usflow - reference_flow_value;
-            data_cache.add_value_at_index(idx, delta);
+        } else {
+            f64::NAN
+        };
+        if let Some(idx) = self.recorder_idx_delta {
+            data_cache.add_value_at_index(idx, self.usflow - reference_flow_value);
+        }
+        if let Some(idx) = self.recorder_idx_reference_flow {
+            data_cache.add_value_at_index(idx, reference_flow_value);
         }
         if let Some(idx) = self.recorder_idx_dsflow {
             data_cache.add_value_at_index(idx, self.dsflow_primary);
@@ -122,9 +132,6 @@ impl Node for GaugeNode {
         if let Some(idx) = self.recorder_idx_ds_1 {
             data_cache.add_value_at_index(idx, self.dsflow_primary);
         }
-        // if let Some(idx) = self.recorder_idx_ds_1_order {
-        //     data_cache.add_value_at_index(idx, self.dsorders[0]);
-        // }
 
         // Reset upstream inflow for next timestep
         self.usflow = 0.0;

--- a/src/nodes/gauge_node.rs
+++ b/src/nodes/gauge_node.rs
@@ -28,6 +28,7 @@ pub struct GaugeNode {
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
     recorder_idx_ds_1_order: Option<usize>,
+    recorder_idx_force_flow: Option<usize>,
     recorder_idx_reference_flow: Option<usize>,
 }
 
@@ -67,6 +68,9 @@ impl Node for GaugeNode {
         self.recorder_idx_ds_1_order = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_1_order").as_str(), false
         );
+        self.recorder_idx_force_flow = data_cache.get_series_idx(
+            make_result_name(&self.name, "force_flow").as_str(), false
+        );
         self.recorder_idx_reference_flow = data_cache.get_series_idx(
             make_result_name(&self.name, "reference_flow").as_str(), false
         );
@@ -95,22 +99,21 @@ impl Node for GaugeNode {
         }
 
         // Force flows if required, otherwise pass upstream value
-        match self.force_flow_input {
-            DynamicInput::None { .. } => {
-                self.dsflow_primary = self.usflow;
-            },
-            _ => {
-                let force_flow_value = self.force_flow_input.get_value(data_cache);
-                if force_flow_value.is_nan() {
-                    self.dsflow_primary = self.usflow;
-                } else {
-                    self.dsflow_primary = force_flow_value;
-                    self.mbal += self.dsflow_primary - self.usflow;
-                }
-            }
+        let force_flow_value = match self.force_flow_input {
+            DynamicInput::None { .. } => f64::NAN,
+            _ => self.force_flow_input.get_value(data_cache),
+        };
+        if force_flow_value.is_nan() {
+            self.dsflow_primary = self.usflow;
+        } else {
+            self.dsflow_primary = force_flow_value;
+            self.mbal += self.dsflow_primary - self.usflow;
         }
 
         // Record results
+        if let Some(idx) = self.recorder_idx_force_flow {
+            data_cache.add_value_at_index(idx, force_flow_value);
+        }
         let needs_reference_flow = self.recorder_idx_delta.is_some() || self.recorder_idx_reference_flow.is_some();
         let reference_flow_value = if needs_reference_flow {
             match self.reference_flow_input {

--- a/src/nodes/gr4j_node.rs
+++ b/src/nodes/gr4j_node.rs
@@ -39,6 +39,8 @@ pub struct Gr4jNode {
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
     recorder_idx_ds_1_order: Option<usize>,
+    recorder_idx_evap_mm: Option<usize>,
+    recorder_idx_rain_mm: Option<usize>,
 }
 
 impl Gr4jNode {
@@ -96,6 +98,12 @@ impl Node for Gr4jNode {
         self.recorder_idx_ds_1_order = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_1_order").as_str(), false
         );
+        self.recorder_idx_rain_mm = data_cache.get_series_idx(
+            make_result_name(&self.name, "rain").as_str(), false
+        );
+        self.recorder_idx_evap_mm = data_cache.get_series_idx(
+            make_result_name(&self.name, "evap").as_str(), false
+        );
 
         // Return
         Ok(())
@@ -144,6 +152,12 @@ impl Node for Gr4jNode {
         }
         if let Some(idx) = self.recorder_idx_ds_1 {
             data_cache.add_value_at_index(idx, self.dsflow_primary);
+        }
+        if let Some(idx) = self.recorder_idx_rain_mm {
+            data_cache.add_value_at_index(idx, self.rain);
+        }
+        if let Some(idx) = self.recorder_idx_evap_mm {
+            data_cache.add_value_at_index(idx, self.pet);
         }
         // if let Some(idx) = self.recorder_idx_ds_1_order {
         //     data_cache.add_value_at_index(idx, self.dsorders[0]);

--- a/src/nodes/regulated_user_node.rs
+++ b/src/nodes/regulated_user_node.rs
@@ -77,7 +77,7 @@ impl Node for RegulatedUserNode {
             make_result_name(&self.name, "usflow").as_str(), false
         );
         self.recorder_idx_pump_capacity = data_cache.get_series_idx(
-            make_result_name(&self.name, "pump_capacity").as_str(), false
+            make_result_name(&self.name, "pump").as_str(), false
         );
         self.recorder_idx_order = data_cache.get_series_idx(
             make_result_name(&self.name, "order").as_str(), false

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -564,7 +564,7 @@ impl Node for StorageNode {
             make_result_name(&self.name, "ds_1").as_str(), false
         );
         self.recorder_idx_ds_1_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_1_outlet").as_str(), false
+            make_result_name(&self.name, "ds_1_release").as_str(), false
         );
         self.recorder_idx_ds_1_spill = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_1_spill").as_str(), false
@@ -573,7 +573,7 @@ impl Node for StorageNode {
             make_result_name(&self.name, "ds_2").as_str(), false
         );
         self.recorder_idx_ds_2_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_2_outlet").as_str(), false
+            make_result_name(&self.name, "ds_2_release").as_str(), false
         );
         self.recorder_idx_ds_2_spill = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_2_spill").as_str(), false
@@ -585,13 +585,13 @@ impl Node for StorageNode {
             make_result_name(&self.name, "ds_3_spill").as_str(), false
         );
         self.recorder_idx_ds_3_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_3_outlet").as_str(), false
+            make_result_name(&self.name, "ds_3_release").as_str(), false
         );
         self.recorder_idx_ds_4 = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_4").as_str(), false
         );
         self.recorder_idx_ds_4_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_4_outlet").as_str(), false
+            make_result_name(&self.name, "ds_4_release").as_str(), false
         );
         self.recorder_idx_ds_4_spill = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_4_spill").as_str(), false

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -564,7 +564,7 @@ impl Node for StorageNode {
             make_result_name(&self.name, "ds_1").as_str(), false
         );
         self.recorder_idx_ds_1_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_1_release").as_str(), false
+            make_result_name(&self.name, "ds_1_outlet").as_str(), false
         );
         self.recorder_idx_ds_1_spill = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_1_spill").as_str(), false
@@ -573,7 +573,7 @@ impl Node for StorageNode {
             make_result_name(&self.name, "ds_2").as_str(), false
         );
         self.recorder_idx_ds_2_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_2_release").as_str(), false
+            make_result_name(&self.name, "ds_2_outlet").as_str(), false
         );
         self.recorder_idx_ds_2_spill = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_2_spill").as_str(), false
@@ -585,13 +585,13 @@ impl Node for StorageNode {
             make_result_name(&self.name, "ds_3_spill").as_str(), false
         );
         self.recorder_idx_ds_3_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_3_release").as_str(), false
+            make_result_name(&self.name, "ds_3_outlet").as_str(), false
         );
         self.recorder_idx_ds_4 = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_4").as_str(), false
         );
         self.recorder_idx_ds_4_outlet = data_cache.get_series_idx(
-            make_result_name(&self.name, "ds_4_release").as_str(), false
+            make_result_name(&self.name, "ds_4_outlet").as_str(), false
         );
         self.recorder_idx_ds_4_spill = data_cache.get_series_idx(
             make_result_name(&self.name, "ds_4_spill").as_str(), false

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -83,6 +83,7 @@ pub struct StorageNode {
     recorder_idx_seep_mm: Option<usize>,
     recorder_idx_evap_mm: Option<usize>,
     recorder_idx_rain_mm: Option<usize>,
+    recorder_idx_pond_demand: Option<usize>,
     recorder_idx_pond_diversion: Option<usize>,
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
@@ -553,6 +554,9 @@ impl Node for StorageNode {
         self.recorder_idx_pond_diversion = data_cache.get_series_idx(
             make_result_name(&self.name, "pond_diversion").as_str(), false
         );
+        self.recorder_idx_pond_demand = data_cache.get_series_idx(
+            make_result_name(&self.name, "pond_demand").as_str(), false
+        );
         self.recorder_idx_dsflow = data_cache.get_series_idx(
             make_result_name(&self.name, "dsflow").as_str(), false
         );
@@ -775,6 +779,9 @@ impl Node for StorageNode {
         }
         if let Some(idx) = self.recorder_idx_pond_diversion {
             data_cache.add_value_at_index(idx, self.pond_diversion);
+        }
+        if let Some(idx) = self.recorder_idx_pond_demand {
+            data_cache.add_value_at_index(idx, pond_demand);
         }
         if let Some(idx) = self.recorder_idx_dsflow {
             data_cache.add_value_at_index(idx, self.dsflow);

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -80,6 +80,9 @@ pub struct StorageNode {
     recorder_idx_seep_megs: Option<usize>,
     recorder_idx_evap_megs: Option<usize>,
     recorder_idx_rain_megs: Option<usize>,
+    recorder_idx_seep_mm: Option<usize>,
+    recorder_idx_evap_mm: Option<usize>,
+    recorder_idx_rain_mm: Option<usize>,
     recorder_idx_pond_diversion: Option<usize>,
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
@@ -538,6 +541,15 @@ impl Node for StorageNode {
         self.recorder_idx_evap_megs = data_cache.get_series_idx(
             make_result_name(&self.name, "evap_vol").as_str(), false
         );
+        self.recorder_idx_rain_mm = data_cache.get_series_idx(
+            make_result_name(&self.name, "rain").as_str(), false
+        );
+        self.recorder_idx_evap_mm = data_cache.get_series_idx(
+            make_result_name(&self.name, "evap").as_str(), false
+        );
+        self.recorder_idx_seep_mm = data_cache.get_series_idx(
+            make_result_name(&self.name, "seep").as_str(), false
+        );
         self.recorder_idx_pond_diversion = data_cache.get_series_idx(
             make_result_name(&self.name, "pond_diversion").as_str(), false
         );
@@ -751,6 +763,15 @@ impl Node for StorageNode {
         }
         if let Some(idx) = self.recorder_idx_evap_megs {
             data_cache.add_value_at_index(idx, self.evap_vol);
+        }
+        if let Some(idx) = self.recorder_idx_seep_mm {
+            data_cache.add_value_at_index(idx, seep_mm);
+        }
+        if let Some(idx) = self.recorder_idx_rain_mm {
+            data_cache.add_value_at_index(idx, rain_mm);
+        }
+        if let Some(idx) = self.recorder_idx_evap_mm {
+            data_cache.add_value_at_index(idx, evap_mm);
         }
         if let Some(idx) = self.recorder_idx_pond_diversion {
             data_cache.add_value_at_index(idx, self.pond_diversion);

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -77,9 +77,9 @@ pub struct StorageNode {
     recorder_idx_level: Option<usize>,
     recorder_idx_target_level: Option<usize>,
     recorder_idx_area: Option<usize>,
-    recorder_idx_seep: Option<usize>,
-    recorder_idx_evap: Option<usize>,
-    recorder_idx_rain: Option<usize>,
+    recorder_idx_seep_megs: Option<usize>,
+    recorder_idx_evap_megs: Option<usize>,
+    recorder_idx_rain_megs: Option<usize>,
     recorder_idx_pond_diversion: Option<usize>,
     recorder_idx_dsflow: Option<usize>,
     recorder_idx_ds_1: Option<usize>,
@@ -529,14 +529,14 @@ impl Node for StorageNode {
         self.recorder_idx_area = data_cache.get_series_idx(
             make_result_name(&self.name, "area").as_str(), false
         );
-        self.recorder_idx_seep = data_cache.get_series_idx(
-            make_result_name(&self.name, "seep").as_str(), false
+        self.recorder_idx_seep_megs = data_cache.get_series_idx(
+            make_result_name(&self.name, "seep_vol").as_str(), false
         );
-        self.recorder_idx_rain = data_cache.get_series_idx(
-            make_result_name(&self.name, "rain").as_str(), false
+        self.recorder_idx_rain_megs = data_cache.get_series_idx(
+            make_result_name(&self.name, "rain_vol").as_str(), false
         );
-        self.recorder_idx_evap = data_cache.get_series_idx(
-            make_result_name(&self.name, "evap").as_str(), false
+        self.recorder_idx_evap_megs = data_cache.get_series_idx(
+            make_result_name(&self.name, "evap_vol").as_str(), false
         );
         self.recorder_idx_pond_diversion = data_cache.get_series_idx(
             make_result_name(&self.name, "pond_diversion").as_str(), false
@@ -743,13 +743,13 @@ impl Node for StorageNode {
         if let Some(idx) = self.recorder_idx_area {
             data_cache.add_value_at_index(idx, area_km2);
         }
-        if let Some(idx) = self.recorder_idx_seep {
+        if let Some(idx) = self.recorder_idx_seep_megs {
             data_cache.add_value_at_index(idx, self.seep_vol);
         }
-        if let Some(idx) = self.recorder_idx_rain {
+        if let Some(idx) = self.recorder_idx_rain_megs {
             data_cache.add_value_at_index(idx, self.rain_vol);
         }
-        if let Some(idx) = self.recorder_idx_evap {
+        if let Some(idx) = self.recorder_idx_evap_megs {
             data_cache.add_value_at_index(idx, self.evap_vol);
         }
         if let Some(idx) = self.recorder_idx_pond_diversion {

--- a/src/nodes/unregulated_user_node.rs
+++ b/src/nodes/unregulated_user_node.rs
@@ -107,7 +107,7 @@ impl Node for UnregulatedUserNode {
             make_result_name(&self.name, "usflow").as_str(), false
         );
         self.recorder_idx_pump_capacity = data_cache.get_series_idx(
-            make_result_name(&self.name, "pump_capacity").as_str(), false
+            make_result_name(&self.name, "pump").as_str(), false
         );
         self.recorder_idx_flow_threshold = data_cache.get_series_idx(
             make_result_name(&self.name, "flow_threshold").as_str(), false


### PR DESCRIPTION
This PR addresses #258 

The list of outputs I identified are as follows.

A list of existing outputs that use node property names that THEY SHOULDN'T BE USING (because they don't mean the same thing).
- Storage 
	- 'rain', 'evap', 'seep' (ML) - proposed change to 'x_vol'. (addressed in PR)
		- Also added 'rain', 'evap' and 'seep' (mm) recorders (addressed in PR)
	- ds_X_outlet - left unchanged; the name is unambiguous as it is tied to the outlet specifically.
- Unregulated users
	- demand_carryover - also likely OK. Not changed in PR.

A list of existing outputs that use their own names, when they SHOULD BE USING THE PROPERTY NAME (because they do mean the same thing).
- Regulated/unregulated users
	- 'pump_capacity' -> 'pump' (addressed in PR)

A list of node properties that accept expressions, and therefore maybe should be node outputs, but are currently not available as node outputs.
- Storage
	- pond_demand (addressed in PR)
- Gauge
	- force_flow (addressed in PR)
	- reference_flow (addressed in PR)
- Confluence
	- harmony_fraction (addressed in PR)