### PR TITLE
Enforce MAX_DS_LINKS/MAX_US_LINKS for nodes

### DIFF
--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -612,7 +612,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
     }
 
     // -------------------------------------------------------------------------------------
-    // Create all the links
+    // Create all the links, respecting constraints
     // -------------------------------------------------------------------------------------
     for link_helper in vec_link_defs {
         let from_node_idx = model.get_node_idx(&link_helper.from_node_name)
@@ -621,6 +621,32 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
             .ok_or(format!("Node '{}' not found", link_helper.to_node_name))?;
         model.add_link(from_node_idx, to_node_idx, link_helper.from_outlet, link_helper.to_inlet);
     }
+
+    // Enforce maximum upstream and downstream node counts
+    let check_links = |links: &Vec<Vec<_>>, get_max: fn(&_) -> usize, direction: &str| {
+        links
+            .iter()
+            .enumerate()
+            .try_for_each(|(index, value)| {
+                model
+                    .nodes
+                    .get(index)
+                    .ok_or_else(|| format!("Error (bug): Attempted to validate {} links at position {} but no node was found", direction, index))
+                    .and_then(|node| {
+                        let count = value.len();
+                        let max = get_max(node);
+                        if count > max {
+                            Err(format!("Error: node {} has {} {} links but may at most have {}",
+                                node.get_name(), count, direction, max))
+                        } else {
+                            Ok(())
+                        }
+                    })
+            })
+    };
+
+    check_links(&model.outgoing_links, Node::get_max_ds_links, "ds")?;
+    check_links(&model.incoming_links, Node::get_max_us_links, "us")?;
 
     // -------------------------------------------------------------------------------------
     // Return the model

--- a/src/nodes/blackhole_node.rs
+++ b/src/nodes/blackhole_node.rs
@@ -108,4 +108,12 @@ impl Node for BlackholeNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/confluence_node.rs
+++ b/src/nodes/confluence_node.rs
@@ -6,7 +6,7 @@ use crate::misc::location::Location;
 use crate::model_inputs::DynamicInput;
 use crate::numerical::fifo_buffer::FifoBuffer;
 
-const MAX_US_LINKS: usize = 2; //TODO: not sure how to police this
+const MAX_US_LINKS: usize = 2;
 const MAX_DS_LINKS: usize = 1;
 
 #[derive(Default, Clone)]
@@ -156,6 +156,14 @@ impl Node for ConfluenceNode {
 
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
+    }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        MAX_US_LINKS
     }
 }
 

--- a/src/nodes/gauge_node.rs
+++ b/src/nodes/gauge_node.rs
@@ -162,4 +162,12 @@ impl Node for GaugeNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/gr4j_node.rs
+++ b/src/nodes/gr4j_node.rs
@@ -206,6 +206,14 @@ impl Node for Gr4jNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }
 
 // ============================================================================

--- a/src/nodes/inflow_node.rs
+++ b/src/nodes/inflow_node.rs
@@ -158,4 +158,12 @@ impl Node for InflowNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/loss_node.rs
+++ b/src/nodes/loss_node.rs
@@ -223,4 +223,12 @@ impl Node for LossNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/node_enum.rs
+++ b/src/nodes/node_enum.rs
@@ -183,5 +183,41 @@ impl Node for NodeEnum {
             NodeEnum::OrderConstraintNode(node) => node.dsorders_mut(),
         }
     }
+
+    fn get_max_us_links(&self) -> usize {
+        match self {
+            NodeEnum::BlackholeNode(node) => node.get_max_us_links(),
+            NodeEnum::ConfluenceNode(node) => node.get_max_us_links(),
+            NodeEnum::GaugeNode(node) => node.get_max_us_links(),
+            NodeEnum::LossNode(node) => node.get_max_us_links(),
+            NodeEnum::SplitterNode(node) => node.get_max_us_links(),
+            NodeEnum::UnregulatedUserNode(node) => node.get_max_us_links(),
+            NodeEnum::RegulatedUserNode(node) => node.get_max_us_links(),
+            NodeEnum::Gr4jNode(node) => node.get_max_us_links(),
+            NodeEnum::InflowNode(node) => node.get_max_us_links(),
+            NodeEnum::RoutingNode(node) => node.get_max_us_links(),
+            NodeEnum::SacramentoNode(node) => node.get_max_us_links(),
+            NodeEnum::StorageNode(node) => node.get_max_us_links(),
+            NodeEnum::OrderConstraintNode(node) => node.get_max_us_links(),
+        }
+    }
+
+    fn get_max_ds_links(&self) -> usize {
+        match self {
+            NodeEnum::BlackholeNode(node) => node.get_max_ds_links(),
+            NodeEnum::ConfluenceNode(node) => node.get_max_ds_links(),
+            NodeEnum::GaugeNode(node) => node.get_max_ds_links(),
+            NodeEnum::LossNode(node) => node.get_max_ds_links(),
+            NodeEnum::SplitterNode(node) => node.get_max_ds_links(),
+            NodeEnum::UnregulatedUserNode(node) => node.get_max_ds_links(),
+            NodeEnum::RegulatedUserNode(node) => node.get_max_ds_links(),
+            NodeEnum::Gr4jNode(node) => node.get_max_ds_links(),
+            NodeEnum::InflowNode(node) => node.get_max_ds_links(),
+            NodeEnum::RoutingNode(node) => node.get_max_ds_links(),
+            NodeEnum::SacramentoNode(node) => node.get_max_ds_links(),
+            NodeEnum::StorageNode(node) => node.get_max_ds_links(),
+            NodeEnum::OrderConstraintNode(node) => node.get_max_ds_links(),
+        }
+    }
 }
 

--- a/src/nodes/node_trait.rs
+++ b/src/nodes/node_trait.rs
@@ -11,6 +11,9 @@ pub trait Node: DynClone + Sync + Send {
     fn remove_dsflow(&mut self, outlet: u8) -> f64;
     fn get_mass_balance(&self) -> f64;
     fn dsorders_mut(&mut self) -> &mut [f64];
+    // Note: You can only have as many ds and us nodes as you have outlets/inlets
+    fn get_max_us_links(&self) -> usize;
+    fn get_max_ds_links(&self) -> usize;
 }
 
 clone_trait_object!(Node);

--- a/src/nodes/order_constraint_node.rs
+++ b/src/nodes/order_constraint_node.rs
@@ -206,4 +206,12 @@ impl Node for OrderConstraintNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/regulated_user_node.rs
+++ b/src/nodes/regulated_user_node.rs
@@ -204,4 +204,12 @@ impl Node for RegulatedUserNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/routing_node.rs
+++ b/src/nodes/routing_node.rs
@@ -547,4 +547,12 @@ impl Node for RoutingNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/sacramento_node.rs
+++ b/src/nodes/sacramento_node.rs
@@ -231,6 +231,14 @@ impl Node for SacramentoNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }
 
 // ============================================================================

--- a/src/nodes/splitter_node.rs
+++ b/src/nodes/splitter_node.rs
@@ -154,4 +154,12 @@ impl Node for SplitterNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
 }

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -856,4 +856,12 @@ impl Node for StorageNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.ds_orders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/nodes/unregulated_user_node.rs
+++ b/src/nodes/unregulated_user_node.rs
@@ -304,4 +304,12 @@ impl Node for UnregulatedUserNode {
     fn dsorders_mut(&mut self) -> &mut [f64] {
         &mut self.dsorders
     }
+
+    fn get_max_ds_links(&self) -> usize {
+        MAX_DS_LINKS
+    }
+
+    fn get_max_us_links(&self) -> usize {
+        usize::MAX
+    }
 }

--- a/src/tests/test_input_validation.rs
+++ b/src/tests/test_input_validation.rs
@@ -183,3 +183,51 @@ fn test_multiple_invalid_references_caught() {
         error_message
     );
 }
+
+
+/// Test that linking three gauge nodes to a confluence is rejected,
+/// since ConfluenceNode::MAX_US_LINKS == 2.
+#[test]
+fn test_confluence_three_us_links_rejected() {
+    let io = crate::io::ini_model_io::IniModelIO::new();
+
+    let ini = "
+[kalix]
+
+[node.gauge1]
+type = gauge
+ds_1 = confluence
+
+[node.gauge2]
+type = gauge
+ds_1 = confluence
+
+[node.gauge3]
+type = gauge
+ds_1 = confluence
+
+[node.confluence]
+type = confluence
+ds_1 = blackhole
+
+[node.blackhole]
+type = blackhole
+";
+
+    let result = io.read_model_string(ini);
+    // Note: Model does not derive Debug so manual panic is necessary
+    let msg = match result {
+        Ok(_) => panic!("Expected an error when three gauges link to a confluence"),
+        Err(e) => e,
+    };
+    assert!(
+        msg.to_lowercase().contains("us"),
+        "Error message should mention upstream links. Got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("confluence"),
+        "Error message should name the offending node. Got: {}",
+        msg
+    );
+}


### PR DESCRIPTION
`confluence_node.rs` contained the following:
```rust 
const MAX_US_LINKS: usize = 2; //TODO: not sure how to police this
```

This pull request addresses this TODO by adding validation in the model creation step (`ini_doc_model_io_0_0_1.rs`, specifically after creating links).

If preferred as a solution, it would be easy to move this responsibility to `model.rs`, either by changing the type signature of `add_link()` to `Result<_, String>` (for large models, it is possible validation could be expensive for initial model loading as this function is called for every link - not checked), or by adding a function e.g. `model.validate()` returning a `Result<_, String>` to be called before returning the model at the end. 

I've also added a test for a basic check of validation functionality (i.e. rejects models with >2 nodes us of a confluence).