### PR TITLE
Add project-level kalix executable discovery

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/KalixIDE.java
+++ b/kalixide/src/main/java/com/kalix/ide/KalixIDE.java
@@ -1540,11 +1540,8 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
     public void showOptimisation() {
         OptimisationWindow.showOptimisationWindow(this, stdioTaskManager, this::updateStatus,
             progressBar,
-            () -> {
-                // Working directory supplier
-                File currentFile = fileOperations.getCurrentFile();
-                return currentFile != null ? currentFile.getParentFile() : null;
-            },
+            fileOperations::getCurrentWorkingDirectory,
+            fileOperations::getCurrentProjectDirectory,
             () -> {
                 // Model text supplier
                 return textEditor.getText();

--- a/kalixide/src/main/java/com/kalix/ide/KalixIDE.java
+++ b/kalixide/src/main/java/com/kalix/ide/KalixIDE.java
@@ -157,6 +157,8 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
         setupDragAndDrop();
         setupWindowListeners();
         setupGlobalKeyBindings();
+
+        finaliseComponents();
         
         // Note: Split pane divider position loading removed - using simple grid layout now
 
@@ -262,6 +264,7 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
             this::onActiveDocumentFileChanged,
             fileWatcherManager
         );
+        // NOTE: projectDirectorySupplier is registered in the finaliseComponents step
 
         fileDropHandler = new FileDropHandler(fileOperations, this::updateStatus);
         versionChecker = new VersionChecker(this::updateStatus);
@@ -272,7 +275,8 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
             this::updateStatus,
             progressBar,
             this,
-            fileOperations::getCurrentWorkingDirectory
+            fileOperations::getCurrentWorkingDirectory,
+            fileOperations::getCurrentProjectDirectory
         );
 
         // Suppliers for auxiliary windows always reflect the active document.
@@ -294,6 +298,10 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
         // Keep the file watcher tracking every open document's file (all tabs auto-reload).
         documentManager.addDocumentOpenedListener(doc -> refreshWatchedFiles());
         documentManager.addDocumentClosedListener(doc -> refreshWatchedFiles());
+    }
+
+    private void finaliseComponents() {
+        fileOperations.registerProjectDirectorySupplier(projectTreePanel::getRootFile);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/cli/KalixCliLocator.java
+++ b/kalixide/src/main/java/com/kalix/ide/cli/KalixCliLocator.java
@@ -45,9 +45,9 @@ public class KalixCliLocator {
      * Attempts to locate kalix using a simplified strategy.
      * <p>
      * Search order:
-     * 1. Current folder (if provided and applicable)
-     * 2. Project folder
-     * 3. User-configured paths (if provided)
+     * 1. User-configured paths (if provided)
+     * 2. Current folder (if provided and applicable)
+     * 3. Project folder
      * 4. System PATH (if no user-configured path)
      * <p>
      * If userConfiguredPath is provided:
@@ -65,22 +65,6 @@ public class KalixCliLocator {
      * @return Optional containing CliLocation if found, empty otherwise
      */
     public static Optional<CliLocation> findKalixCli(String userConfiguredPath, String currentFolder, String projectFolder) {
-        // First, check the currently open folder if provided
-        if (currentFolder != null && !currentFolder.trim().isEmpty()) {
-            Optional<CliLocation> found = findKalixInDirectory(currentFolder.trim());
-            if (found.isPresent()) {
-                return found;
-            }
-        }
-
-        // Second, check the project folder if provided
-        if (projectFolder != null && !projectFolder.trim().isEmpty()) {
-            Optional<CliLocation> found = findKalixInDirectory(projectFolder.trim());
-            if (found.isPresent()) {
-                return found;
-            }
-        }
-
         // If user specified a path, ONLY use those paths (no fallback)
         if (userConfiguredPath != null && !userConfiguredPath.trim().isEmpty()) {
             // Split by ';' to support multiple paths
@@ -101,6 +85,21 @@ public class KalixCliLocator {
 
             // No valid kalix found in any of the specified paths
             return Optional.empty();
+        }
+        // First, check the currently open folder if provided
+        if (currentFolder != null && !currentFolder.trim().isEmpty()) {
+            Optional<CliLocation> found = findKalixInDirectory(currentFolder.trim());
+            if (found.isPresent()) {
+                return found;
+            }
+        }
+
+        // Second, check the project folder if provided
+        if (projectFolder != null && !projectFolder.trim().isEmpty()) {
+            Optional<CliLocation> found = findKalixInDirectory(projectFolder.trim());
+            if (found.isPresent()) {
+                return found;
+            }
         }
 
         // No user path configured - use unqualified "kalix" from system PATH

--- a/kalixide/src/main/java/com/kalix/ide/cli/KalixCliLocator.java
+++ b/kalixide/src/main/java/com/kalix/ide/cli/KalixCliLocator.java
@@ -1,5 +1,6 @@
 package com.kalix.ide.cli;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,7 +49,8 @@ public class KalixCliLocator {
      * 1. User-configured paths (if provided)
      * 2. Current folder (if provided and applicable)
      * 3. Project folder
-     * 4. System PATH (if no user-configured path)
+     * 4. KalixIDE location
+     * 5. System PATH (if no user-configured path)
      * <p>
      * If userConfiguredPath is provided:
      * - Splits the path by ';' delimiter (supports multiple directories)
@@ -86,7 +88,8 @@ public class KalixCliLocator {
             // No valid kalix found in any of the specified paths
             return Optional.empty();
         }
-        // First, check the currently open folder if provided
+
+        // 2. Check the currently open folder if provided
         if (currentFolder != null && !currentFolder.trim().isEmpty()) {
             Optional<CliLocation> found = findKalixInDirectory(currentFolder.trim());
             if (found.isPresent()) {
@@ -94,7 +97,7 @@ public class KalixCliLocator {
             }
         }
 
-        // Second, check the project folder if provided
+        // 3. Check the project folder if provided
         if (projectFolder != null && !projectFolder.trim().isEmpty()) {
             Optional<CliLocation> found = findKalixInDirectory(projectFolder.trim());
             if (found.isPresent()) {
@@ -102,7 +105,17 @@ public class KalixCliLocator {
             }
         }
 
-        // No user path configured - use unqualified "kalix" from system PATH
+        // 4. Check where KalixIDE executable is located
+        Optional<File> ideExeLoc = getExecutableLocation();
+        if (ideExeLoc.isPresent()){
+            File exe = ideExeLoc.get();
+            Optional<CliLocation> found = findKalixInDirectory(exe.getParent().trim());
+            if (found.isPresent()) {
+                return found;
+            }
+        }
+
+        // 5. Use unqualified "kalix" from system PATH
         return findInPath();
     }
 
@@ -296,5 +309,22 @@ public class KalixCliLocator {
         findInPath().ifPresent(installations::add);
 
         return installations;
+    }
+
+    /**
+     * Returns the location of the native launcher executable created by jpackage.
+     * Falls back to the current working directory if not running from a jpackage image
+     * (e.g. when running directly from IntelliJ/Gradle during development).
+     */
+    public static Optional<File> getExecutableLocation() {
+        String appPath = System.getProperty("jpackage.app-path");
+        if (appPath == null || appPath.isBlank()) {
+            return Optional.empty();
+        }
+        File exeFile = new File(appPath);
+        if (!exeFile.exists()) {
+            return Optional.empty();
+        }
+        return Optional.of(exeFile);
     }
 }

--- a/kalixide/src/main/java/com/kalix/ide/cli/KalixCliLocator.java
+++ b/kalixide/src/main/java/com/kalix/ide/cli/KalixCliLocator.java
@@ -43,29 +43,39 @@ public class KalixCliLocator {
     
     /**
      * Attempts to locate kalix using a simplified strategy.
-     *
+     * <p>
      * Search order:
      * 1. Current folder (if provided and applicable)
-     * 2. User-configured paths (if provided)
-     * 3. System PATH (if no user-configured path)
-     *
+     * 2. Project folder
+     * 3. User-configured paths (if provided)
+     * 4. System PATH (if no user-configured path)
+     * <p>
      * If userConfiguredPath is provided:
-     *   - Splits the path by ';' delimiter (supports multiple directories)
-     *   - Searches each directory sequentially for kalix executable
-     *   - Returns the first valid kalix found
-     *   - Returns empty if none found (no fallback to system PATH)
-     *
+     * - Splits the path by ';' delimiter (supports multiple directories)
+     * - Searches each directory sequentially for kalix executable
+     * - Returns the first valid kalix found
+     * - Returns empty if none found (no fallback to system PATH)
+     * <p>
      * If no userConfiguredPath:
-     *   - Uses unqualified "kalix" command (relies on system PATH)
+     * - Uses unqualified "kalix" command (relies on system PATH)
      *
      * @param userConfiguredPath Optional user-configured path (supports ';' delimiter for multiple paths)
-     * @param currentFolder Optional currently open folder to check first
+     * @param currentFolder      Optional currently open file directory to check first
+     * @param projectFolder      Optional currently open folder in IDE to check second
      * @return Optional containing CliLocation if found, empty otherwise
      */
-    public static Optional<CliLocation> findKalixCli(String userConfiguredPath, String currentFolder) {
+    public static Optional<CliLocation> findKalixCli(String userConfiguredPath, String currentFolder, String projectFolder) {
         // First, check the currently open folder if provided
         if (currentFolder != null && !currentFolder.trim().isEmpty()) {
             Optional<CliLocation> found = findKalixInDirectory(currentFolder.trim());
+            if (found.isPresent()) {
+                return found;
+            }
+        }
+
+        // Second, check the project folder if provided
+        if (projectFolder != null && !projectFolder.trim().isEmpty()) {
+            Optional<CliLocation> found = findKalixInDirectory(projectFolder.trim());
             if (found.isPresent()) {
                 return found;
             }
@@ -105,7 +115,7 @@ public class KalixCliLocator {
      * @return Optional containing CliLocation if found, empty otherwise
      */
     public static Optional<CliLocation> findKalixCli(String userConfiguredPath) {
-        return findKalixCli(userConfiguredPath, null);
+        return findKalixCli(userConfiguredPath, null, null);
     }
 
     /**
@@ -140,17 +150,18 @@ public class KalixCliLocator {
      * This method checks user settings and falls back to auto-discovery.
      *
      * @param currentFolder Optional currently open folder to check first
+     * @param projectFolder Optional currently open project folder to check second
      * @return Optional containing CliLocation if found, empty otherwise
      */
-    public static Optional<CliLocation> findKalixCliWithPreferences(String currentFolder) {
+    public static Optional<CliLocation> findKalixCliWithPreferences(String currentFolder, String projectFolder) {
         try {
             // Use the file-based preference system instead of OS preferences
             String configuredPath = com.kalix.ide.preferences.PreferenceManager.getFileString(
                 com.kalix.ide.preferences.PreferenceKeys.CLI_BINARY_PATH, "");
-            return findKalixCli(configuredPath, currentFolder);
+            return findKalixCli(configuredPath, currentFolder, projectFolder);
         } catch (Exception e) {
             // Fall back to standard discovery if preferences fail
-            return findKalixCli(null, currentFolder);
+            return findKalixCli(null, currentFolder, projectFolder);
         }
     }
 
@@ -161,7 +172,7 @@ public class KalixCliLocator {
      * @return Optional containing CliLocation if found, empty otherwise
      */
     public static Optional<CliLocation> findKalixCliWithPreferences() {
-        return findKalixCliWithPreferences(null);
+        return findKalixCliWithPreferences(null, null);
     }
     
     /**

--- a/kalixide/src/main/java/com/kalix/ide/dialogs/PreferencesDialog.java
+++ b/kalixide/src/main/java/com/kalix/ide/dialogs/PreferencesDialog.java
@@ -1,5 +1,6 @@
 package com.kalix.ide.dialogs;
 
+import com.kalix.ide.cli.KalixCliLocator;
 import com.kalix.ide.constants.AppConstants;
 import com.kalix.ide.editor.EnhancedTextEditor;
 import com.kalix.ide.linter.LinterPreferencesPanel;
@@ -638,9 +639,11 @@ public class PreferencesDialog extends JDialog {
             infoArea.setWrapStyleWord(true);
             infoArea.setLineWrap(true);
             infoArea.setFocusable(false);
-            infoArea.setText("Specify directories to search for the Kalix CLI binary. Multiple directories can be " +
-                "specified using ';' as a delimiter (e.g., /usr/local/bin;/opt/kalix/bin). If left empty, the system will " +
-                "search for 'kalix' in the system PATH.");
+            infoArea.setText(
+                    "Specify directories to search for the Kalix CLI binary. " +
+                    "Multiple directories can be specified using ';' as a delimiter " +
+                    "(e.g., /usr/local/bin;/opt/kalix/bin). " +
+                    "If left empty, the system will search for 'kalix' in the system PATH.");
             formPanel.add(infoArea, gbc);
 
             // Binary path
@@ -679,8 +682,25 @@ public class PreferencesDialog extends JDialog {
             pathLabel.setForeground(Color.GRAY);
             pathLabel.setFocusable(false);  // Prevent cursor from appearing
             formPanel.add(pathLabel, gbc);
-
             add(formPanel, BorderLayout.CENTER);
+
+            gbc.gridx = 0; gbc.gridy = 4; gbc.gridwidth = 2; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 0;
+            JTextArea exeLocInfoArea = new JTextArea();
+            exeLocInfoArea.setEditable(false);
+            exeLocInfoArea.setOpaque(false);
+            exeLocInfoArea.setWrapStyleWord(true);
+            exeLocInfoArea.setLineWrap(true);
+            exeLocInfoArea.setFocusable(false);
+            StringBuilder exeLocInfoAreaTextBuilder = new StringBuilder();
+            Optional<File> exeLoc = KalixCliLocator.getExecutableLocation();
+            if (exeLoc.isPresent()) {
+                exeLocInfoAreaTextBuilder.append("\n");
+                exeLocInfoAreaTextBuilder.append("KalixIDE executable located at: ");
+                exeLocInfoAreaTextBuilder.append(exeLoc.get());
+            }
+            String infoAreaText = exeLocInfoAreaTextBuilder.toString();
+            exeLocInfoArea.setText(infoAreaText);
+            formPanel.add(exeLocInfoArea, gbc);
         }
 
         private void browseBinary(ActionEvent e) {

--- a/kalixide/src/main/java/com/kalix/ide/managers/FileOperationsManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/FileOperationsManager.java
@@ -32,26 +32,27 @@ public class FileOperationsManager {
     private final Consumer<String> addRecentFileCallback;
     private final Runnable fileChangedCallback;
     private final FileWatcherManager fileWatcherManager;
+    private Supplier<File> projectDirectorySupplier;
 
     /**
      * Creates a new FileOperationsManager instance.
      *
-     * @param parentComponent The parent component for dialogs
-     * @param documentManager The document set / active-document owner
-     * @param documentFactory Creates and registers a fresh (configured) document
-     * @param statusUpdateCallback Callback for status updates
-     * @param addRecentFileCallback Callback for adding recent files
-     * @param fileChangedCallback Callback when the active document's file identity changes
-     *                            without an active-document switch (e.g. Save As, reload)
-     * @param fileWatcherManager The file watcher manager for coordinating auto-reload
+     * @param parentComponent          The parent component for dialogs
+     * @param documentManager          The document set / active-document owner
+     * @param documentFactory          Creates and registers a fresh (configured) document
+     * @param statusUpdateCallback     Callback for status updates
+     * @param addRecentFileCallback    Callback for adding recent files
+     * @param fileChangedCallback      Callback when the active document's file identity changes
+     *                                 without an active-document switch (e.g. Save As, reload)
+     * @param fileWatcherManager       The file watcher manager for coordinating auto-reload
      */
     public FileOperationsManager(Component parentComponent,
-                               DocumentManager documentManager,
-                               Supplier<KalixDocument> documentFactory,
-                               Consumer<String> statusUpdateCallback,
-                               Consumer<String> addRecentFileCallback,
-                               Runnable fileChangedCallback,
-                               FileWatcherManager fileWatcherManager) {
+                                 DocumentManager documentManager,
+                                 Supplier<KalixDocument> documentFactory,
+                                 Consumer<String> statusUpdateCallback,
+                                 Consumer<String> addRecentFileCallback,
+                                 Runnable fileChangedCallback,
+                                 FileWatcherManager fileWatcherManager) {
         this.parentComponent = parentComponent;
         this.documentManager = documentManager;
         this.documentFactory = documentFactory;
@@ -59,6 +60,7 @@ public class FileOperationsManager {
         this.addRecentFileCallback = addRecentFileCallback;
         this.fileChangedCallback = fileChangedCallback;
         this.fileWatcherManager = fileWatcherManager;
+        this.projectDirectorySupplier = null;
     }
 
     /**
@@ -417,5 +419,20 @@ public class FileOperationsManager {
     public File getCurrentWorkingDirectory() {
         KalixDocument document = document();
         return document != null ? document.getWorkingDirectory() : null;
+    }
+
+    public void registerProjectDirectorySupplier(Supplier<File> supplier) {
+        this.projectDirectorySupplier = supplier;
+    }
+
+    /**
+     * Gets the directory of the current project directory.
+     * This is used as an option to discover KalixCLI executable.
+     */
+    public File getCurrentProjectDirectory() {
+        if (projectDirectorySupplier == null) {
+            return null;
+        }
+        return projectDirectorySupplier.get();
     }
 }

--- a/kalixide/src/main/java/com/kalix/ide/managers/StdioTaskManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/StdioTaskManager.java
@@ -87,7 +87,7 @@ public class StdioTaskManager {
                 String currentFolder = workingDir != null ? workingDir.getAbsolutePath() : null;
 
                 // Locate kalix using preferences, checking current folder first
-                Optional<KalixCliLocator.CliLocation> cliLocation = KalixCliLocator.findKalixCliWithPreferences(currentFolder);
+                Optional<KalixCliLocator.CliLocation> cliLocation = KalixCliLocator.findKalixCliWithPreferences(currentFolder, null);
                 if (cliLocation.isEmpty()) {
                     handleCliNotFound();
                     throw new RuntimeException("kalix not found");

--- a/kalixide/src/main/java/com/kalix/ide/managers/StdioTaskManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/StdioTaskManager.java
@@ -30,6 +30,7 @@ public class StdioTaskManager {
     private final JFrame parentFrame;
     private final SessionManager sessionManager;
     private final Supplier<File> workingDirectorySupplier;
+    private final Supplier<File> projectDirectorySupplier;
 
     /**
      * Creates a new StdioTaskManager.
@@ -41,14 +42,16 @@ public class StdioTaskManager {
      * @param workingDirectorySupplier supplier for getting the current working directory
      */
     public StdioTaskManager(ProcessExecutor processExecutor,
-                         Consumer<String> statusUpdater,
-                         StatusProgressBar progressBar,
-                         JFrame parentFrame,
-                         Supplier<File> workingDirectorySupplier) {
+                            Consumer<String> statusUpdater,
+                            StatusProgressBar progressBar,
+                            JFrame parentFrame,
+                            Supplier<File> workingDirectorySupplier,
+                            Supplier<File> projectDirectorySupplier) {
         this.statusUpdater = statusUpdater;
         this.progressBar = progressBar;
         this.parentFrame = parentFrame;
         this.workingDirectorySupplier = workingDirectorySupplier;
+        this.projectDirectorySupplier = projectDirectorySupplier;
 
 
         // Initialize session manager
@@ -86,8 +89,11 @@ public class StdioTaskManager {
                 File workingDir = workingDirectorySupplier.get();
                 String currentFolder = workingDir != null ? workingDir.getAbsolutePath() : null;
 
+                File projectDir = projectDirectorySupplier != null ? projectDirectorySupplier.get() : null;
+                String projectFolder = projectDir != null ? projectDir.getAbsolutePath() : null;
+
                 // Locate kalix using preferences, checking current folder first
-                Optional<KalixCliLocator.CliLocation> cliLocation = KalixCliLocator.findKalixCliWithPreferences(currentFolder, null);
+                Optional<KalixCliLocator.CliLocation> cliLocation = KalixCliLocator.findKalixCliWithPreferences(currentFolder, projectFolder);
                 if (cliLocation.isEmpty()) {
                     handleCliNotFound();
                     throw new RuntimeException("kalix not found");

--- a/kalixide/src/main/java/com/kalix/ide/managers/optimisation/OptimisationSessionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/optimisation/OptimisationSessionManager.java
@@ -31,6 +31,7 @@ public class OptimisationSessionManager {
     // Core dependencies
     private final StdioTaskManager stdioTaskManager;
     private final Supplier<File> workingDirectorySupplier;
+    private final Supplier<File> projectDirectorySupplier;
     private final Supplier<String> modelTextSupplier;
 
     // Session tracking
@@ -60,15 +61,18 @@ public class OptimisationSessionManager {
     /**
      * Creates a new OptimisationSessionManager.
      *
-     * @param stdioTaskManager The STDIO task manager
+     * @param stdioTaskManager         The STDIO task manager
      * @param workingDirectorySupplier Supplier for the working directory
-     * @param modelTextSupplier Supplier for the model text
+     * @param projectDirectorySupplier Supplier for the project directory
+     * @param modelTextSupplier        Supplier for the model text
      */
     public OptimisationSessionManager(StdioTaskManager stdioTaskManager,
-                                     Supplier<File> workingDirectorySupplier,
-                                     Supplier<String> modelTextSupplier) {
+                                      Supplier<File> workingDirectorySupplier,
+                                      Supplier<File> projectDirectorySupplier,
+                                      Supplier<String> modelTextSupplier) {
         this.stdioTaskManager = stdioTaskManager;
         this.workingDirectorySupplier = workingDirectorySupplier;
+        this.projectDirectorySupplier = projectDirectorySupplier;
         this.modelTextSupplier = modelTextSupplier;
     }
 
@@ -96,8 +100,11 @@ public class OptimisationSessionManager {
         File workingDir = workingDirectorySupplier != null ? workingDirectorySupplier.get() : null;
         String currentFolder = workingDir != null ? workingDir.getAbsolutePath() : null;
 
+        File projectDir = projectDirectorySupplier != null ? projectDirectorySupplier.get() : null;
+        String projectFolder = projectDir != null ? projectDir.getAbsolutePath() : null;
+
         Optional<com.kalix.ide.cli.KalixCliLocator.CliLocation> cliLocationOpt =
-            com.kalix.ide.cli.KalixCliLocator.findKalixCliWithPreferences(currentFolder, null);
+            com.kalix.ide.cli.KalixCliLocator.findKalixCliWithPreferences(currentFolder, projectFolder);
 
         if (cliLocationOpt.isEmpty()) {
             handleError("kalix not found. Please configure the path in Preferences.");

--- a/kalixide/src/main/java/com/kalix/ide/managers/optimisation/OptimisationSessionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/optimisation/OptimisationSessionManager.java
@@ -97,7 +97,7 @@ public class OptimisationSessionManager {
         String currentFolder = workingDir != null ? workingDir.getAbsolutePath() : null;
 
         Optional<com.kalix.ide.cli.KalixCliLocator.CliLocation> cliLocationOpt =
-            com.kalix.ide.cli.KalixCliLocator.findKalixCliWithPreferences(currentFolder);
+            com.kalix.ide.cli.KalixCliLocator.findKalixCliWithPreferences(currentFolder, null);
 
         if (cliLocationOpt.isEmpty()) {
             handleError("kalix not found. Please configure the path in Preferences.");

--- a/kalixide/src/main/java/com/kalix/ide/windows/OptimisationWindow.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/OptimisationWindow.java
@@ -65,6 +65,7 @@ public class OptimisationWindow extends JFrame {
     private final Consumer<String> statusUpdater;
     private final StatusProgressBar progressBar;
     private final Supplier<File> workingDirectorySupplier;
+    private final Supplier<File> projectDirectorySupplier;
     private final Supplier<String> modelTextSupplier;
     private KalixIDE parentIDE;  // Reference to parent IDE window
 
@@ -120,11 +121,13 @@ public class OptimisationWindow extends JFrame {
                                Consumer<String> statusUpdater,
                                StatusProgressBar progressBar,
                                Supplier<File> workingDirectorySupplier,
+                               Supplier<File> projectDirectorySupplier,
                                Supplier<String> modelTextSupplier) {
         this.stdioTaskManager = stdioTaskManager;
         this.statusUpdater = statusUpdater;
         this.progressBar = progressBar;
         this.workingDirectorySupplier = workingDirectorySupplier;
+        this.projectDirectorySupplier = projectDirectorySupplier;
         this.modelTextSupplier = modelTextSupplier;
 
         // Store reference to parent IDE (cast JFrame to KalixIDE)
@@ -151,6 +154,7 @@ public class OptimisationWindow extends JFrame {
         this.sessionManager = new OptimisationSessionManager(
             stdioTaskManager,
             workingDirectorySupplier,
+            projectDirectorySupplier,
             modelTextSupplier
         );
 
@@ -291,10 +295,12 @@ public class OptimisationWindow extends JFrame {
                                               Consumer<String> statusUpdater,
                                               StatusProgressBar progressBar,
                                               Supplier<File> workingDirectorySupplier,
+                                              Supplier<File> projectDirectorySupplier,
                                               Supplier<String> modelTextSupplier) {
         if (instance == null) {
             instance = new OptimisationWindow(parentFrame, stdioTaskManager,
-                statusUpdater, progressBar, workingDirectorySupplier, modelTextSupplier);
+                    statusUpdater, progressBar, workingDirectorySupplier, projectDirectorySupplier,
+                    modelTextSupplier);
         }
 
         // Update simulated series options from current model


### PR DESCRIPTION
This pull request adds the currently open project folder to the list of locations to search for a kalix executable, i.e. the following locations will now work

```
<Path>
<User defined location>

Project folder
 | - kalix
 | - folder
      | - kalix
      | - model.ini
```