### PR TITLE
#278 Recent folders in file menu

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/KalixIDE.java
+++ b/kalixide/src/main/java/com/kalix/ide/KalixIDE.java
@@ -28,7 +28,6 @@ import com.kalix.ide.model.ModelChangeEvent;
 import com.kalix.ide.preferences.PreferenceManager;
 import com.kalix.ide.preferences.PreferenceKeys;
 import com.kalix.ide.themes.NodeTheme;
-import com.kalix.ide.utils.DialogUtils;
 import com.kalix.ide.utils.TerminalActions;
 import com.kalix.ide.utils.WindowsIntegration;
 import com.kalix.ide.workspace.ProjectTreePanel;
@@ -105,6 +104,7 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
     // Manager classes for specialized functionality
     private ThemeManager themeManager;
     private RecentFilesManager recentFilesManager;
+    private RecentFilesManager recentFoldersManager;
     private FileOperationsManager fileOperations;
     private FileDropHandler fileDropHandler;
     private VersionChecker versionChecker;
@@ -229,7 +229,14 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
         recentFilesManager = new RecentFilesManager(
             prefs,
             this::loadModelFile,
-            () -> updateStatus(AppConstants.STATUS_RECENT_FILES_CLEARED)
+            () -> updateStatus(AppConstants.STATUS_RECENT_FILES_CLEARED),
+            AppConstants.RECENT_FILE_PREF_PREFIX
+        );
+        recentFoldersManager = new RecentFilesManager(
+            prefs,
+            this::loadModelFolder,
+            () -> updateStatus(AppConstants.STATUS_RECENT_FOLDERS_CLEARED),
+            AppConstants.RECENT_FOLDER_PREF_PREFIX
         );
     }
 
@@ -708,7 +715,8 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
         setJMenuBar(menuBar);
 
         // Connect recent files manager to menu builder
-        recentFilesManager.setMenuBarBuilder(menuBuilder);
+        recentFilesManager.setMenuBarUpdateCallback(menuBuilder::rebuildRecentFiles);
+        recentFoldersManager.setMenuBarUpdateCallback(menuBuilder::rebuildRecentFolders);
     }
 
     /**
@@ -936,6 +944,24 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
         fileOperations.loadModelFile(filePath);
     }
 
+    /**
+     * Loads a model folder.
+     * Used by the recent folders manager callback.
+     *
+     * @param folderPath The absolute path to the folder to load
+     */
+    private void loadModelFolder(String folderPath) {
+        projectTreePanel.openFolder(folderPath);
+        PreferenceManager.setOsString(PreferenceKeys.UI_WORKSPACE_FOLDER, folderPath);
+        // Always auto-expand the tree region on opening a folder, and sync the toolbar toggle.
+        if (workspacePanel != null) {
+            workspacePanel.setTreeCollapsed(false);
+        }
+        syncToggleButtonStates();
+        revealActiveFileInTree();
+        File folder = new File(folderPath);
+        updateStatus("Opened folder: " + folder.getName());
+    }
 
 
     //
@@ -975,6 +1001,7 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
             File folder = chooser.getSelectedFile();
             projectTreePanel.openFolder(folder);
             PreferenceManager.setOsString(PreferenceKeys.UI_WORKSPACE_FOLDER, folder.getAbsolutePath());
+            recentFoldersManager.addRecentFile(folder.getAbsolutePath());
             // Always auto-expand the tree region on opening a folder, and sync the toolbar toggle.
             if (workspacePanel != null) {
                 workspacePanel.setTreeCollapsed(false);
@@ -1485,12 +1512,15 @@ public class KalixIDE extends JFrame implements MenuBarBuilder.MenuBarCallbacks 
             try {
                 // Clear all preferences
                 prefs.clear();
-                
-                // Clear recent files
+
+                // Clear recent files and folders
                 if (recentFilesManager != null) {
                     recentFilesManager.clearRecentFiles();
                 }
-                
+                if (recentFoldersManager != null) {
+                    recentFoldersManager.clearRecentFiles();
+                }
+
                 updateStatus("App data cleared. Application will restart...");
                 
                 // Schedule restart after a brief delay to show the status message

--- a/kalixide/src/main/java/com/kalix/ide/builders/MenuBarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/builders/MenuBarBuilder.java
@@ -27,7 +27,7 @@ public class MenuBarBuilder {
     
     private final MenuBarCallbacks callbacks;
     private JMenu fileMenu;
-    private int recentFilesSectionStart;  // Index where recent files section begins
+    @Deprecated private int recentFilesSectionStart;  // Index where recent files section begins
     
     /**
      * Interface defining all callback methods needed for menu and toolbar actions.
@@ -152,7 +152,8 @@ public class MenuBarBuilder {
      * @param recentFiles List of recent file paths to display
      * @param fileOpenCallback Callback when a recent file is clicked
      */
-    public void rebuildRecentFilesSection(List<String> recentFiles, java.util.function.Consumer<String> fileOpenCallback) {
+    @Deprecated
+    public void rebuildRecentFilesSection(List<String> recentFiles, Consumer<String> fileOpenCallback) {
         if (fileMenu == null) return;
 
         // Remove everything from recentFilesSectionStart to end
@@ -183,7 +184,7 @@ public class MenuBarBuilder {
         // Add Exit at the end
         fileMenu.add(createMenuItem("Exit", e -> callbacks.exitApplication()));
     }
-    
+
     /**
      * Creates the File menu.
      */

--- a/kalixide/src/main/java/com/kalix/ide/builders/MenuBarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/builders/MenuBarBuilder.java
@@ -1,14 +1,10 @@
 package com.kalix.ide.builders;
 
+import com.kalix.ide.constants.AppConstants;
 import com.kalix.ide.editor.EnhancedTextEditor;
 import com.kalix.ide.themes.NodeTheme;
 
-import javax.swing.Action;
-import javax.swing.JCheckBoxMenuItem;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.text.DefaultEditorKit;
@@ -18,6 +14,7 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Builder class for creating and configuring the application menu bar.
@@ -28,6 +25,8 @@ public class MenuBarBuilder {
     private final MenuBarCallbacks callbacks;
     private JMenu fileMenu;
     @Deprecated private int recentFilesSectionStart;  // Index where recent files section begins
+    private JMenu recentFilesSubmenu;
+    private JMenu recentFoldersSubMenu;
     
     /**
      * Interface defining all callback methods needed for menu and toolbar actions.
@@ -144,7 +143,63 @@ public class MenuBarBuilder {
 
         return menuBar;
     }
-    
+
+    /**
+     * Helper method for {@link #rebuildRecentFiles(List, Consumer)} and {@link #rebuildRecentFolders(List, Consumer)},
+     * referring to a folder and file both as a generic file on the operating system.
+     *
+     * @param recentFiles      List of recent file or folder paths
+     * @param fileOpenCallback Callback to open a file or folder
+     * @param submenu          The submenu to rebuild
+     */
+    private void rebuildRecentFilesHelper(List<String> recentFiles, Consumer<String> fileOpenCallback, JMenu submenu,
+                                          String emptyMessage){
+        if (fileMenu == null) return;
+
+        // Remove all existing menu items
+        submenu.removeAll();
+
+        // If empty, add disabled placeholder
+        if (recentFiles.isEmpty()) {
+            JMenuItem emptyItem = new JMenuItem(emptyMessage);
+            emptyItem.setEnabled(false);
+            submenu.add(emptyItem);
+        } else {
+            // Add recent file items
+            for (int i = 0; i < recentFiles.size(); i++) {
+                String fPath = recentFiles.get(i);
+                String fName = new File(fPath).getName();
+                String displayText = String.format("%d. %s", i + 1, fName);
+                JMenuItem item = new JMenuItem(displayText);
+                item.setToolTipText(fPath);
+                item.addActionListener(e -> fileOpenCallback.accept(fPath));
+                submenu.add(item);
+            }
+        }
+    }
+
+    /**
+     * Rebuild the recent files popup menu.
+     *
+     * @param recentFiles List of recent file paths
+     * @param fileOpenCallback Callback to open a file
+     */
+    public void rebuildRecentFiles(List<String> recentFiles,  Consumer<String> fileOpenCallback) {
+        rebuildRecentFilesHelper(recentFiles, fileOpenCallback, recentFilesSubmenu,
+                AppConstants.MENU_NO_RECENT_FILES);
+    }
+
+    /**
+     * Rebuild the recent folders popup menu.
+     *
+     * @param recentFolders List of recent folder paths
+     * @param folderOpenCallback Callback to open a folder
+     */
+    public void rebuildRecentFolders(List<String> recentFolders,  Consumer<String> folderOpenCallback) {
+        rebuildRecentFilesHelper(recentFolders, folderOpenCallback, recentFoldersSubMenu,
+                AppConstants.MENU_NO_RECENT_FOLDERS);
+    }
+
     /**
      * Rebuilds the recent files section of the File menu.
      * Clears existing recent files and Exit, then rebuilds cleanly.
@@ -195,6 +250,13 @@ public class MenuBarBuilder {
         fileMenu.add(createMenuItem("Open", KeyEvent.VK_O, e -> callbacks.openModel()));
         fileMenu.add(createMenuItem("Open Folder...", KeyEvent.VK_O, InputEvent.SHIFT_DOWN_MASK,
                 e -> callbacks.openFolder()));
+
+        fileMenu.addSeparator();
+        recentFilesSubmenu = new JMenu("Recent files");
+        fileMenu.add(recentFilesSubmenu);
+        recentFoldersSubMenu = new JMenu("Recent folders");
+        fileMenu.add(recentFoldersSubMenu);
+
         fileMenu.addSeparator();
         fileMenu.add(createMenuItem("Save", KeyEvent.VK_S, e -> callbacks.saveModel()));
         fileMenu.add(createMenuItem("Save As...", KeyEvent.VK_S, InputEvent.SHIFT_DOWN_MASK,

--- a/kalixide/src/main/java/com/kalix/ide/builders/MenuBarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/builders/MenuBarBuilder.java
@@ -24,7 +24,6 @@ public class MenuBarBuilder {
     
     private final MenuBarCallbacks callbacks;
     private JMenu fileMenu;
-    @Deprecated private int recentFilesSectionStart;  // Index where recent files section begins
     private JMenu recentFilesSubmenu;
     private JMenu recentFoldersSubMenu;
     
@@ -201,46 +200,6 @@ public class MenuBarBuilder {
     }
 
     /**
-     * Rebuilds the recent files section of the File menu.
-     * Clears existing recent files and Exit, then rebuilds cleanly.
-     *
-     * @param recentFiles List of recent file paths to display
-     * @param fileOpenCallback Callback when a recent file is clicked
-     */
-    @Deprecated
-    public void rebuildRecentFilesSection(List<String> recentFiles, Consumer<String> fileOpenCallback) {
-        if (fileMenu == null) return;
-
-        // Remove everything from recentFilesSectionStart to end
-        while (fileMenu.getMenuComponentCount() > recentFilesSectionStart) {
-            fileMenu.remove(recentFilesSectionStart);
-        }
-
-        // Add separator before recent files
-        fileMenu.addSeparator();
-
-        // Add recent file items
-        for (int i = 0; i < recentFiles.size(); i++) {
-            String filePath = recentFiles.get(i);
-            String fileName = new File(filePath).getName();
-            String displayText = String.format("%d. %s", i + 1, fileName);
-
-            JMenuItem item = new JMenuItem(displayText);
-            item.setToolTipText(filePath);
-            item.addActionListener(e -> fileOpenCallback.accept(filePath));
-            fileMenu.add(item);
-        }
-
-        // Add separator before Exit (only if we have recent files)
-        if (!recentFiles.isEmpty()) {
-            fileMenu.addSeparator();
-        }
-
-        // Add Exit at the end
-        fileMenu.add(createMenuItem("Exit", e -> callbacks.exitApplication()));
-    }
-
-    /**
      * Creates the File menu.
      */
     private JMenu createFileMenu() {
@@ -265,9 +224,6 @@ public class MenuBarBuilder {
         fileMenu.addSeparator();
         fileMenu.add(createMenuItem("Preferences", KeyEvent.VK_COMMA,
                 e -> callbacks.showPreferences()));
-
-        // Mark where the recent files section starts (after Preferences)
-        recentFilesSectionStart = fileMenu.getMenuComponentCount();
 
         // Add initial separator and Exit - will be rebuilt when recent files are loaded
         fileMenu.addSeparator();

--- a/kalixide/src/main/java/com/kalix/ide/constants/AppConstants.java
+++ b/kalixide/src/main/java/com/kalix/ide/constants/AppConstants.java
@@ -43,6 +43,7 @@ public final class AppConstants {
     // Recent files (Note: MAX_RECENT_FILES also defined in PreferenceKeys - should be unified)
     public static final int MAX_RECENT_FILES = 10; // Unified with PreferenceKeys value
     public static final String RECENT_FILE_PREF_PREFIX = "recentFile";
+    public static final String RECENT_FOLDER_PREF_PREFIX = "recentFolder";
     
     // File types
     public static final String INI_EXTENSION = ".ini";
@@ -80,6 +81,7 @@ public final class AppConstants {
     public static final String STATUS_ZOOMED_OUT = "Zoomed out";
     public static final String STATUS_ZOOM_RESET = "Zoom reset";
     public static final String STATUS_RECENT_FILES_CLEARED = "Recent files cleared";
+    public static final String STATUS_RECENT_FOLDERS_CLEARED = "Recent folders cleared";
 
     // Error messages
     public static final String ERROR_FILE_OPEN = "File Open Error";
@@ -92,6 +94,7 @@ public final class AppConstants {
 
     // Menu text
     public static final String MENU_NO_RECENT_FILES = "No recent files";
+    public static final String MENU_NO_RECENT_FOLDERS = "No recent folders";
 
     // Default text content
     public static final String DEFAULT_MODEL_TEXT = "# Welcome, friend ...\n";

--- a/kalixide/src/main/java/com/kalix/ide/managers/RecentFilesManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/RecentFilesManager.java
@@ -1,6 +1,5 @@
 package com.kalix.ide.managers;
 
-import com.kalix.ide.builders.MenuBarBuilder;
 import com.kalix.ide.constants.AppConstants;
 
 import javax.swing.JOptionPane;
@@ -8,6 +7,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.prefs.Preferences;
 import java.util.function.Consumer;
 
@@ -21,7 +21,8 @@ public class RecentFilesManager {
     private final List<String> recentFiles;
     private final Consumer<String> fileOpenCallback;
     private final Runnable statusUpdateCallback;
-    private MenuBarBuilder menuBarBuilder;
+    private final String prefPrefix;
+    private BiConsumer<List<String>, Consumer<String>> menuBarUpdateCallback;
 
     /**
      * Creates a new RecentFilesManager instance.
@@ -29,12 +30,15 @@ public class RecentFilesManager {
      * @param prefs The preferences object for storing recent files
      * @param fileOpenCallback Callback function to open a file
      * @param statusUpdateCallback Callback to update status when files are cleared
+     * @param prefPrefix The preference key prefix to use for storing items (e.g., "recentFile" or "recentFolder")
      */
-    public RecentFilesManager(Preferences prefs, Consumer<String> fileOpenCallback, Runnable statusUpdateCallback) {
+    public RecentFilesManager(Preferences prefs, Consumer<String> fileOpenCallback, Runnable statusUpdateCallback,
+                              String prefPrefix) {
         this.prefs = prefs;
         this.recentFiles = new ArrayList<>();
         this.fileOpenCallback = fileOpenCallback;
         this.statusUpdateCallback = statusUpdateCallback;
+        this.prefPrefix = prefPrefix;
         loadRecentFiles();
     }
     
@@ -44,7 +48,7 @@ public class RecentFilesManager {
     private void loadRecentFiles() {
         recentFiles.clear();
         for (int i = 0; i < AppConstants.MAX_RECENT_FILES; i++) {
-            String filePath = prefs.get(AppConstants.RECENT_FILE_PREF_PREFIX + i, null);
+            String filePath = prefs.get(prefPrefix + i, null);
             if (filePath != null && !filePath.isEmpty()) {
                 recentFiles.add(filePath);
             }
@@ -57,12 +61,12 @@ public class RecentFilesManager {
     private void saveRecentFiles() {
         // Clear all existing recent file preferences
         for (int i = 0; i < AppConstants.MAX_RECENT_FILES; i++) {
-            prefs.remove(AppConstants.RECENT_FILE_PREF_PREFIX + i);
+            prefs.remove(prefPrefix + i);
         }
-        
+
         // Save current recent files
         for (int i = 0; i < recentFiles.size(); i++) {
-            prefs.put(AppConstants.RECENT_FILE_PREF_PREFIX + i, recentFiles.get(i));
+            prefs.put(prefPrefix + i, recentFiles.get(i));
         }
     }
     
@@ -104,8 +108,8 @@ public class RecentFilesManager {
      *
      * @param menuBarBuilder The menu bar builder to use for updates
      */
-    public void setMenuBarBuilder(MenuBarBuilder menuBarBuilder) {
-        this.menuBarBuilder = menuBarBuilder;
+    public void setMenuBarUpdateCallback(BiConsumer<List<String>, Consumer<String>> menuBarBuilder) {
+        this.menuBarUpdateCallback = menuBarBuilder;
         rebuildMenu();
     }
 
@@ -113,10 +117,10 @@ public class RecentFilesManager {
      * Rebuilds the recent files section in the File menu.
      */
     private void rebuildMenu() {
-        if (menuBarBuilder == null) {
+        if (menuBarUpdateCallback == null) {
             return;
         }
-        menuBarBuilder.rebuildRecentFilesSection(
+        menuBarUpdateCallback.accept(
             Collections.unmodifiableList(recentFiles),
             this::openRecentFile
         );

--- a/kalixide/src/main/java/com/kalix/ide/workspace/ProjectTreePanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/ProjectTreePanel.java
@@ -45,6 +45,11 @@ public class ProjectTreePanel extends JPanel {
     }
 
     /** Opens the given folder: loads the tree and sets the header to the folder name. */
+    public void openFolder(String root) {
+        openFolder(new File(root));
+    }
+
+    /** Opens the given folder: loads the tree and sets the header to the folder name. */
     public void openFolder(File root) {
         tree.openFolder(root);
         String name = root.getName();


### PR DESCRIPTION
This pull request addresses #278. 

## Technical implementation
1. Recent files moved to a JMenu under the File JMenu (MenuBarBuilder). 
2. Recent folders tracked via a new instantiation of RecentFilesManager. 
3. RecentFilesManager is now passed an update callback from MenuBarBuilder instead of the entire class - facilitates reuse of the class. 

Let me know what you think - not sure this is the cleanest solution i.e. whether we should reuse RecentFilesManager (as done), subclass/extend it, or just add the recent folders functionality directly into it.