### PR TITLE
Feat/#280 run manager checkboxes

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -7,12 +7,14 @@ import javax.swing.event.TreeModelListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 // Reference - https://stackoverflow.com/a/21851201
@@ -20,13 +22,21 @@ import java.util.List;
 
 /// Note that rendering of individual entries is the purview of the chosen TreeCellRenderer implementation.
 ///
-///  Checked state is to be treated as the user's "chosen set", as opposed to {@link JTree}'s selection model.
+/// Checked state is to be treated as the user's "chosen set", as opposed to {@link JTree}'s
+/// selection model. The two are deliberately independent: only a left-click on the checkbox
+/// glyph itself (or Space on the focused row) toggles checked state. Clicks anywhere else on
+/// a row - including right-clicks that open context menus - select/focus the node without
+/// touching the chosen set.
 public class JCheckboxTree extends JTree {
-    // Used for defining inner classes
-    private final JCheckboxTree thisTree = this;
 
     public enum CheckState {
         UNCHECKED, CHECKED, PARTIAL
+    }
+
+    /// Implemented by cell renderers that draw a checkbox at the leading edge of each row,
+    /// so the tree can hit-test clicks against the checkbox glyph.
+    public interface CheckboxRowRenderer {
+        int getCheckboxWidth();
     }
 
     ///  {@link CheckedNodeMetadata} tracks metadata i.e. checked state, and whether the node has children
@@ -42,13 +52,20 @@ public class JCheckboxTree extends JTree {
 
     ///  Map from node path to metadata
     HashMap<TreePath, CheckedNodeMetadata> nodeCheckedStateMap;
-    ///  Set of all nodes currently ticked
-    HashSet<TreePath> checkedPaths;
+    /// All currently ticked paths, in the order they were ticked. Order matters: consumers
+    /// build the plotted-series list from this, and the first series acts as the reference
+    /// for difference-style plot types - so iteration must be deterministic and reflect the
+    /// order the user checked things, not hash order.
+    LinkedHashSet<TreePath> checkedPaths;
+
+    /// Fallback glyph width when the installed renderer is not a {@link CheckboxRowRenderer}.
+    private int fallbackCheckboxWidth = 0;
 
     /// Notified whenever the checked-path set changes, whether from a user click or a
     /// programmatic call to {@link #checkPath} / {@link #setCheckedPaths}.
-    /// This fires exactly once per logical change and is never fired incidentally
-    /// by selection changes.
+    /// Fires only when the checked set actually changed - a no-op call
+    /// (e.g. checking an already-checked path) is silent, and it is never fired
+    /// incidentally by selection changes.
     public interface CheckChangeListener {
         void checkStateChanged();
     }
@@ -96,7 +113,7 @@ public class JCheckboxTree extends JTree {
     /// Rebuilds node metadata map from root. Clears all checked state.
     /// All nodes start unchecked until explicitly ticked by user interaction.
     private void resetCheckedState() {
-        checkedPaths = new HashSet<>();
+        checkedPaths = new LinkedHashSet<>();
         nodeCheckedStateMap = new HashMap<>();
         var rootNode = getModel().getRoot();
         if (rootNode == null) {
@@ -121,36 +138,60 @@ public class JCheckboxTree extends JTree {
         return node;
     }
 
-    private void tickPath(TreePath nodePath) {
-        CheckedNodeMetadata node = getOrCreateMetadata(nodePath);
-        node.state = CheckState.CHECKED;
-        this.checkedPaths.add(nodePath);
-        if (node.hasChildren) {
-            Object lastComponent = nodePath.getLastPathComponent();
-            if (lastComponent instanceof DefaultMutableTreeNode treeNode) {
-                for (var child : Collections.list(treeNode.children())) {
-                    TreePath childPath = nodePath.pathByAddingChild(child);
-                    tickPath(childPath);
-                }
-            }
+    /// Ticks a path and all of its descendants, then recomputes the ancestor chain once.
+    /// Returns whether the checked set actually changed.
+    private boolean tickPath(TreePath nodePath) {
+        boolean changed = tickRecursive(nodePath);
+        if (changed) {
+            updateAncestorStates(nodePath);
         }
-        updateAncestorStates(nodePath);
+        return changed;
     }
 
-    private void untickPath(TreePath nodePath) {
+    /// Ticks the subtree only. Ancestor recomputation is done once by the caller
+    /// ({@link #tickPath}) rather than once per descendant, which would be quadratic in
+    /// wide subtrees. Does not short-circuit on an already-CHECKED node: children inserted
+    /// since the parent was ticked still need picking up.
+    private boolean tickRecursive(TreePath nodePath) {
         CheckedNodeMetadata node = getOrCreateMetadata(nodePath);
-        node.state = CheckState.UNCHECKED;
-        this.checkedPaths.remove(nodePath);
+        boolean changed = checkedPaths.add(nodePath);
+        node.state = CheckState.CHECKED;
         if (node.hasChildren) {
             Object lastComponent = nodePath.getLastPathComponent();
             if (lastComponent instanceof DefaultMutableTreeNode treeNode) {
                 for (var child : Collections.list(treeNode.children())) {
-                    TreePath childPath = nodePath.pathByAddingChild(child);
-                    untickPath(childPath);
+                    changed |= tickRecursive(nodePath.pathByAddingChild(child));
                 }
             }
         }
-        updateAncestorStates(nodePath);
+        return changed;
+    }
+
+    /// Unticks a path and all of its descendants, then recomputes the ancestor chain once.
+    /// Returns whether the checked set actually changed.
+    private boolean untickPath(TreePath nodePath) {
+        boolean changed = untickRecursive(nodePath);
+        if (changed) {
+            updateAncestorStates(nodePath);
+        }
+        return changed;
+    }
+
+    /// Unticks the subtree only - see {@link #tickRecursive} for why ancestors are handled
+    /// by the caller instead.
+    private boolean untickRecursive(TreePath nodePath) {
+        CheckedNodeMetadata node = getOrCreateMetadata(nodePath);
+        boolean changed = checkedPaths.remove(nodePath);
+        node.state = CheckState.UNCHECKED;
+        if (node.hasChildren) {
+            Object lastComponent = nodePath.getLastPathComponent();
+            if (lastComponent instanceof DefaultMutableTreeNode treeNode) {
+                for (var child : Collections.list(treeNode.children())) {
+                    changed |= untickRecursive(nodePath.pathByAddingChild(child));
+                }
+            }
+        }
+        return changed;
     }
 
     /// Recomputes checked state for every ancestor of {@code nodePath}, climbing from its
@@ -218,6 +259,7 @@ public class JCheckboxTree extends JTree {
             tickPath(nodePath); // If unchecked or partial, check it
         }
         fireCheckChangeEvent();
+        repaint(); // Repaint to show updated checkbox state
     }
 
     // Override adds resetCheckedState() call
@@ -252,6 +294,7 @@ public class JCheckboxTree extends JTree {
         });
     }
 
+    /// Returns the checked paths in the order they were ticked (see {@link #checkedPaths}).
     public TreePath[] getCheckedPaths() {
         return this.checkedPaths.toArray(new TreePath[0]);
     }
@@ -269,45 +312,83 @@ public class JCheckboxTree extends JTree {
         return node != null ? node.state : CheckState.UNCHECKED;
     }
 
-    /// Checks a single path, in addition to whatever is already checked. Fires a check
-    /// change event. Used for programmatic single-path updates (e.g. auto-checking a
-    /// newly-launched run) where wiping out the rest of the checked set is not wanted.
+    /// Checks a single path, in addition to whatever is already checked. Used for
+    /// programmatic single-path updates (e.g. auto-checking a newly-launched run) where
+    /// wiping out the rest of the checked set is not wanted. Fires a check change event
+    /// only if the path (or a descendant) wasn't already checked.
     public void checkPath(TreePath path) {
-        tickPath(path);
-        fireCheckChangeEvent();
-        repaint();
+        if (tickPath(path)) {
+            fireCheckChangeEvent();
+            repaint();
+        }
     }
 
-    /// Unchecks a path, and removes it from the checked set.
-    /// Removing the children is the responsibility of the caller.
+    /// Unchecks {@code path} and forgets it and all of its descendants entirely - metadata
+    /// included. For nodes being removed from the model, where the paths can never be
+    /// reached again and keeping their entries would leak for the life of the tree.
+    /// Fires a check change event only if the checked set actually changed (removing a
+    /// node that was never checked is silent).
     public void removePath(TreePath path) {
-       untickPath(path);
-       this.checkedPaths.remove(path);
-       this.nodeCheckedStateMap.remove(path);
-       fireCheckChangeEvent();
-       repaint();
+        boolean changed = untickPath(path);
+        nodeCheckedStateMap.keySet().removeIf(path::isDescendant);
+        if (changed) {
+            fireCheckChangeEvent();
+            repaint();
+        }
     }
 
-    /// Replaces the entire checked set with exactly the given paths. Fires a single check
-    /// change event. Used to restore checked state after a structural rebuild (which clears
-    /// checked state via {@link #attachStructureListener}) from a caller's own record of
-    /// what should be checked (e.g. by stable ref, not by the now-stale TreePath).
+    /// Replaces the entire checked set with exactly the given paths (in the given order).
+    /// Fires at most a single check change event. Used to restore checked state after a
+    /// structural rebuild (which clears checked state via {@link #attachStructureListener})
+    /// from a caller's own record of what should be checked (e.g. by stable ref, not by the
+    /// now-stale TreePath).
     public void setCheckedPaths(Collection<TreePath> paths) {
-        // Untick all current paths
+        boolean changed = false;
+        // Untick all current paths, then tick the new set. A call that re-supplies the
+        // current leaves still reports a change (untick + retick); callers run under the
+        // isUpdatingSelection guard, so the extra event is inert.
         for (TreePath path : new ArrayList<>(checkedPaths)) {
-            untickPath(path);
+            changed |= untickPath(path);
         }
-        addCheckedPaths(paths);
+        for (TreePath path : paths) {
+            changed |= tickPath(path);
+        }
+        if (changed) {
+            fireCheckChangeEvent();
+            repaint();
+        }
     }
 
-    ///  Convenience method to add the given paths to the checked set.
-    /// Fires a single check change event.
+    /// Convenience method to add the given paths to the checked set (in the given order).
+    /// Fires at most a single check change event, and none if all were already checked.
     public void addCheckedPaths(Collection<TreePath> paths) {
+        boolean changed = false;
         for (TreePath path : paths) {
-            tickPath(path);
+            changed |= tickPath(path);
         }
-        fireCheckChangeEvent();
-        repaint();
+        if (changed) {
+            fireCheckChangeEvent();
+            repaint();
+        }
+    }
+
+    /// True when {@code x} falls on the checkbox glyph at the leading edge of the row's
+    /// cell bounds. Clicks on the rest of the row (icon, label) must NOT toggle - the whole
+    /// point of the checkbox tree is that focusing, expanding, or right-clicking a node
+    /// never changes what's plotted.
+    private boolean isOverCheckbox(int x, TreePath path) {
+        Rectangle bounds = getPathBounds(path);
+        return bounds != null && x >= bounds.x && x < bounds.x + checkboxWidth();
+    }
+
+    private int checkboxWidth() {
+        if (getCellRenderer() instanceof CheckboxRowRenderer renderer) {
+            return renderer.getCheckboxWidth();
+        }
+        if (fallbackCheckboxWidth == 0) {
+            fallbackCheckboxWidth = new JTristateCheckBox().getPreferredSize().width;
+        }
+        return fallbackCheckboxWidth;
     }
 
     public JCheckboxTree(TreeModel treeModel) {
@@ -319,11 +400,24 @@ public class JCheckboxTree extends JTree {
         this.addMouseListener(new MouseInputAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                TreePath selPath = thisTree.getPathForLocation(e.getX(), e.getY());
-                if (selPath != null) {
-                    thisTree.togglePath(selPath);
-                    thisTree.repaint(); // Repaint to show updated checkbox state
+                // Every left click on the glyph toggles - no clickCount filter, or a quick
+                // check-then-uncheck would have its second click swallowed as a double-click.
+                if (!SwingUtilities.isLeftMouseButton(e)) {
+                    return;
                 }
+                TreePath path = getPathForLocation(e.getX(), e.getY());
+                if (path != null && isOverCheckbox(e.getX(), path)) {
+                    togglePath(path);
+                }
+            }
+        });
+
+        // Keyboard equivalent: Space toggles the focused row's checkbox.
+        getInputMap(WHEN_FOCUSED).put(KeyStroke.getKeyStroke("SPACE"), "toggleCheck");
+        getActionMap().put("toggleCheck", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                togglePath(getLeadSelectionPath());
             }
         });
     }

--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -40,7 +40,9 @@ public class JCheckboxTree extends JTree {
         }
     }
 
+    ///  Map from node path to metadata
     HashMap<TreePath, CheckedNodeMetadata> nodeCheckedStateMap;
+    ///  Set of all nodes currently ticked
     HashSet<TreePath> checkedPaths;
 
     /// Notified whenever the checked-path set changes, whether from a user click or a
@@ -276,13 +278,14 @@ public class JCheckboxTree extends JTree {
         repaint();
     }
 
-    /// Unchecks a single path, leaving the rest of the checked set alone. Fires a check
-    /// change event. Used to drop a stale entry (e.g. a node about to be removed from the
-    /// model) before it becomes unreachable via the tree structure.
-    public void uncheckPath(TreePath path) {
-        untickPath(path);
-        fireCheckChangeEvent();
-        repaint();
+    /// Unchecks a path, and removes it from the checked set.
+    /// Removing the children is the responsibility of the caller.
+    public void removePath(TreePath path) {
+       untickPath(path);
+       this.checkedPaths.remove(path);
+       this.nodeCheckedStateMap.remove(path);
+       fireCheckChangeEvent();
+       repaint();
     }
 
     /// Replaces the entire checked set with exactly the given paths. Fires a single check

--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -345,8 +345,8 @@ public class JCheckboxTree extends JTree {
     public void setCheckedPaths(Collection<TreePath> paths) {
         boolean changed = false;
         // Untick all current paths, then tick the new set. A call that re-supplies the
-        // current leaves still reports a change (untick + retick); callers run under the
-        // isUpdatingSelection guard, so the extra event is inert.
+        // current leaves still reports a change (untick + retick); callers run inside a
+        // programmatic-update section, so the extra event is inert.
         for (TreePath path : new ArrayList<>(checkedPaths)) {
             changed |= untickPath(path);
         }

--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -290,9 +290,16 @@ public class JCheckboxTree extends JTree {
     /// checked state via {@link #attachStructureListener}) from a caller's own record of
     /// what should be checked (e.g. by stable ref, not by the now-stale TreePath).
     public void setCheckedPaths(Collection<TreePath> paths) {
+        // Untick all current paths
         for (TreePath path : new ArrayList<>(checkedPaths)) {
             untickPath(path);
         }
+        addCheckedPaths(paths);
+    }
+
+    ///  Convenience method to add the given paths to the checked set.
+    /// Fires a single check change event.
+    public void addCheckedPaths(Collection<TreePath> paths) {
         for (TreePath path : paths) {
             tickPath(path);
         }

--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -1,0 +1,323 @@
+package com.kalix.ide.components;
+
+import javax.swing.*;
+import javax.swing.event.MouseInputAdapter;
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreePath;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+// Reference - https://stackoverflow.com/a/21851201
+//      Posted by SomethingSomething, modified by community. Retrieved 2026-07-03, License - CC BY-SA 4.0
+
+/// Note that rendering of individual entries is the purview of the chosen TreeCellRenderer implementation.
+///
+///  Checked state is to be treated as the user's "chosen set", as opposed to {@link JTree}'s selection model.
+public class JCheckboxTree extends JTree {
+    // Used for defining inner classes
+    private final JCheckboxTree thisTree = this;
+
+    public enum CheckState {
+        UNCHECKED, CHECKED, PARTIAL
+    }
+
+    ///  {@link CheckedNodeMetadata} tracks metadata i.e. checked state, and whether the node has children
+    static class CheckedNodeMetadata {
+        CheckState state;
+        boolean hasChildren;
+
+        public CheckedNodeMetadata(CheckState state, boolean hasChildren) {
+            this.state = state;
+            this.hasChildren = hasChildren;
+        }
+    }
+
+    public static class JTristateCheckBox extends JCheckBox {
+    }
+
+    HashMap<TreePath, CheckedNodeMetadata> nodeCheckedStateMap;
+    HashSet<TreePath> checkedPaths;
+
+    /// Notified whenever the checked-path set changes, whether from a user click or a
+    /// programmatic call to {@link #checkPath} / {@link #setCheckedPaths}.
+    /// This fires exactly once per logical change and is never fired incidentally
+    /// by selection changes.
+    public interface CheckChangeListener {
+        void checkStateChanged();
+    }
+    private final List<CheckChangeListener> checkChangeListeners = new ArrayList<>();
+
+    public void addCheckChangeListener(CheckChangeListener listener) {
+        checkChangeListeners.add(listener);
+    }
+
+    public void removeCheckChangeListener(CheckChangeListener listener) {
+        checkChangeListeners.remove(listener);
+    }
+
+    private void fireCheckChangeEvent() {
+        for (CheckChangeListener listener : checkChangeListeners) {
+            listener.checkStateChanged();
+        }
+    }
+
+    // Logic for tracking state of nodes
+    /// Builds node metadata map recursively. Initializes all nodes as unchecked.
+    /// Does not modify checkedPaths - nodes start unchecked until explicitly ticked.
+    private void buildNodeMetadata(DefaultMutableTreeNode node) {
+        var path = new TreePath(node.getPath());
+
+        // Determine if this node has children
+        boolean hasChildren = node.getChildCount() > 0;
+
+        // Create or update the node metadata
+        var checkedNode = nodeCheckedStateMap.get(path);
+        if (checkedNode == null) {
+            checkedNode = new CheckedNodeMetadata(CheckState.UNCHECKED, hasChildren);
+            nodeCheckedStateMap.put(path, checkedNode);
+        } else {
+            checkedNode.state = CheckState.UNCHECKED;
+            checkedNode.hasChildren = hasChildren;
+        }
+
+        // Recursively process children
+        for (var child : Collections.list(node.children())) {
+            buildNodeMetadata((DefaultMutableTreeNode) child);
+        }
+    }
+
+    /// Rebuilds node metadata map from root. Clears all checked state.
+    /// All nodes start unchecked until explicitly ticked by user interaction.
+    private void resetCheckedState() {
+        checkedPaths = new HashSet<>();
+        nodeCheckedStateMap = new HashMap<>();
+        var rootNode = getModel().getRoot();
+        if (rootNode == null) {
+            return;
+        }
+        buildNodeMetadata((DefaultMutableTreeNode) rootNode);
+    }
+
+    /// Returns existing metadata for a path, or creates it on demand. Needed because the
+    /// tree structure can grow between full rebuilds (e.g. a new run node inserted via
+    /// {@code nodesWereInserted}), so a path may not have been present the last time
+    /// {@link #resetCheckedState()} walked the model.
+    private CheckedNodeMetadata getOrCreateMetadata(TreePath nodePath) {
+        CheckedNodeMetadata node = nodeCheckedStateMap.get(nodePath);
+        if (node == null) {
+            Object lastComponent = nodePath.getLastPathComponent();
+            boolean hasChildren = lastComponent instanceof DefaultMutableTreeNode treeNode
+                    && treeNode.getChildCount() > 0;
+            node = new CheckedNodeMetadata(CheckState.UNCHECKED, hasChildren);
+            nodeCheckedStateMap.put(nodePath, node);
+        }
+        return node;
+    }
+
+    private void tickPath(TreePath nodePath) {
+        CheckedNodeMetadata node = getOrCreateMetadata(nodePath);
+        node.state = CheckState.CHECKED;
+        this.checkedPaths.add(nodePath);
+        if (node.hasChildren) {
+            Object lastComponent = nodePath.getLastPathComponent();
+            if (lastComponent instanceof DefaultMutableTreeNode treeNode) {
+                for (var child : Collections.list(treeNode.children())) {
+                    TreePath childPath = nodePath.pathByAddingChild(child);
+                    tickPath(childPath);
+                }
+            }
+        }
+        updateAncestorStates(nodePath);
+    }
+
+    private void untickPath(TreePath nodePath) {
+        CheckedNodeMetadata node = getOrCreateMetadata(nodePath);
+        node.state = CheckState.UNCHECKED;
+        this.checkedPaths.remove(nodePath);
+        if (node.hasChildren) {
+            Object lastComponent = nodePath.getLastPathComponent();
+            if (lastComponent instanceof DefaultMutableTreeNode treeNode) {
+                for (var child : Collections.list(treeNode.children())) {
+                    TreePath childPath = nodePath.pathByAddingChild(child);
+                    untickPath(childPath);
+                }
+            }
+        }
+        updateAncestorStates(nodePath);
+    }
+
+    /// Recomputes checked state for every ancestor of {@code nodePath}, climbing from its
+    /// immediate parent up to the root. Each ancestor's state is derived purely from its
+    /// own children: CHECKED if all are CHECKED, UNCHECKED if none are CHECKED or PARTIAL,
+    /// and PARTIAL otherwise. Stops climbing as soon as an ancestor's state is unchanged,
+    /// since further ancestors (which only depend on this one through that state) cannot
+    /// change either.
+    private void updateAncestorStates(TreePath nodePath) {
+        TreePath parentPath = nodePath.getParentPath();
+        while (parentPath != null) {
+            CheckedNodeMetadata parentNode = getOrCreateMetadata(parentPath);
+            if (!parentNode.hasChildren) {
+                parentNode.hasChildren = true;
+            }
+            Object parentComponent = parentPath.getLastPathComponent();
+            if (!(parentComponent instanceof DefaultMutableTreeNode parentTreeNode)) {
+                return;
+            }
+
+            boolean allChecked = true;
+            boolean anyCheckedOrPartial = false;
+            for (var child : Collections.list(parentTreeNode.children())) {
+                TreePath childPath = parentPath.pathByAddingChild(child);
+                CheckedNodeMetadata childNode = nodeCheckedStateMap.get(childPath);
+                CheckState childState = childNode != null ? childNode.state : CheckState.UNCHECKED;
+                if (childState != CheckState.CHECKED) {
+                    allChecked = false;
+                }
+                if (childState != CheckState.UNCHECKED) {
+                    anyCheckedOrPartial = true;
+                }
+            }
+            CheckState newState = allChecked ? CheckState.CHECKED
+                    : anyCheckedOrPartial ? CheckState.PARTIAL : CheckState.UNCHECKED;
+
+            if (newState == parentNode.state) {
+                return;
+            }
+            parentNode.state = newState;
+            if (newState == CheckState.CHECKED) {
+                checkedPaths.add(parentPath);
+            } else {
+                checkedPaths.remove(parentPath);
+            }
+
+            parentPath = parentPath.getParentPath();
+        }
+    }
+
+    /// Handles logic for toggling path, including updates of checkedPaths and
+    /// nodeCheckedHashMap, and setting of internal CheckedNode state.
+    /// Toggling a PARTIAL node resolves it to CHECKED (checking all of its descendants).
+    private void togglePath(TreePath nodePath) {
+        if (nodePath == null) {
+            return;
+        }
+
+        CheckedNodeMetadata node = getOrCreateMetadata(nodePath);
+
+        boolean currentlyChecked = node.state == CheckState.CHECKED;
+        if (currentlyChecked) {
+            untickPath(nodePath); // If checked, uncheck it
+        } else {
+            tickPath(nodePath); // If unchecked or partial, check it
+        }
+        fireCheckChangeEvent();
+    }
+
+    // Override adds resetCheckedState() call
+    @Override
+    public void setModel(TreeModel model) {
+        super.setModel(model);
+        resetCheckedState();
+        attachStructureListener(model);
+    }
+
+    /// Keeps checked-state metadata in sync with full tree rebuilds (e.g. {@code
+    /// DefaultTreeModel.reload()}, used when the outputs tree is filtered or repopulated
+    /// for a new set of checked sources). Incremental changes (node insert/remove) are left
+    /// alone so checked state on unaffected nodes survives - only a structural reload
+    /// invalidates the whole path set, since old TreePath instances reference node objects
+    /// that no longer exist in the model.
+    private void attachStructureListener(TreeModel model) {
+        if (model == null) {
+            return;
+        }
+        model.addTreeModelListener(new TreeModelListener() {
+            @Override
+            public void treeStructureChanged(TreeModelEvent e) {
+                resetCheckedState();
+            }
+            @Override
+            public void treeNodesChanged(TreeModelEvent e) {}
+            @Override
+            public void treeNodesInserted(TreeModelEvent e) {}
+            @Override
+            public void treeNodesRemoved(TreeModelEvent e) {}
+        });
+    }
+
+    public TreePath[] getCheckedPaths() {
+        return this.checkedPaths.toArray(new TreePath[0]);
+    }
+
+    public boolean isPathChecked(TreePath path) {
+        return this.checkedPaths.contains(path);
+    }
+
+    /// Returns the tri-state checked status of a path (UNCHECKED if the path isn't
+    /// currently tracked, e.g. it isn't part of the tree). Used by
+    /// {@link com.kalix.ide.renderers.CheckboxTreeCellRenderer} to render the partial
+    /// (some-but-not-all-descendants-checked) state.
+    public CheckState getCheckState(TreePath path) {
+        CheckedNodeMetadata node = nodeCheckedStateMap.get(path);
+        return node != null ? node.state : CheckState.UNCHECKED;
+    }
+
+    /// Checks a single path, in addition to whatever is already checked. Fires a check
+    /// change event. Used for programmatic single-path updates (e.g. auto-checking a
+    /// newly-launched run) where wiping out the rest of the checked set is not wanted.
+    public void checkPath(TreePath path) {
+        tickPath(path);
+        fireCheckChangeEvent();
+        repaint();
+    }
+
+    /// Unchecks a single path, leaving the rest of the checked set alone. Fires a check
+    /// change event. Used to drop a stale entry (e.g. a node about to be removed from the
+    /// model) before it becomes unreachable via the tree structure.
+    public void uncheckPath(TreePath path) {
+        untickPath(path);
+        fireCheckChangeEvent();
+        repaint();
+    }
+
+    /// Replaces the entire checked set with exactly the given paths. Fires a single check
+    /// change event. Used to restore checked state after a structural rebuild (which clears
+    /// checked state via {@link #attachStructureListener}) from a caller's own record of
+    /// what should be checked (e.g. by stable ref, not by the now-stale TreePath).
+    public void setCheckedPaths(Collection<TreePath> paths) {
+        for (TreePath path : new ArrayList<>(checkedPaths)) {
+            untickPath(path);
+        }
+        for (TreePath path : paths) {
+            tickPath(path);
+        }
+        fireCheckChangeEvent();
+        repaint();
+    }
+
+    public JCheckboxTree(TreeModel treeModel) {
+        super(treeModel);
+        // Not attaching the structure listener here: super(treeModel) already invoked our
+        // setModel() override above (JTree's constructor calls setModel(newModel)
+        // internally), which already attached one. Attaching a second time here would
+        // double-register it, so resetCheckedState() would run twice per reload().
+        this.addMouseListener(new MouseInputAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                TreePath selPath = thisTree.getPathForLocation(e.getX(), e.getY());
+                if (selPath != null) {
+                    thisTree.togglePath(selPath);
+                    thisTree.repaint(); // Repaint to show updated checkbox state
+                }
+            }
+        });
+    }
+}

--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -399,10 +399,18 @@ public class JCheckboxTree extends JTree {
         // double-register it, so resetCheckedState() would run twice per reload().
         this.addMouseListener(new MouseInputAdapter() {
             @Override
-            public void mouseClicked(MouseEvent e) {
-                // Every left click on the glyph toggles - no clickCount filter, or a quick
-                // check-then-uncheck would have its second click swallowed as a double-click.
-                if (!SwingUtilities.isLeftMouseButton(e)) {
+            public void mousePressed(MouseEvent e) {
+                // Toggle on press, not on mouseClicked: Swing only synthesizes a "clicked"
+                // event when the mouse doesn't move a single pixel between press and
+                // release, so click-based toggling silently drops the ~10-20% of clicks
+                // that drift slightly - the checkbox feels unreliable. Press-based
+                // toggling registers every time and shows the tick on finger-down, like a
+                // native checkbox. No clickCount filter for the same reason: a quick
+                // check-then-uncheck must not have its second press swallowed.
+                //
+                // isPopupTrigger is excluded explicitly because macOS Ctrl+left-click is a
+                // popup trigger that still passes the isLeftMouseButton test.
+                if (e.isPopupTrigger() || !SwingUtilities.isLeftMouseButton(e)) {
                     return;
                 }
                 TreePath path = getPathForLocation(e.getX(), e.getY());

--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -40,9 +40,6 @@ public class JCheckboxTree extends JTree {
         }
     }
 
-    public static class JTristateCheckBox extends JCheckBox {
-    }
-
     HashMap<TreePath, CheckedNodeMetadata> nodeCheckedStateMap;
     HashSet<TreePath> checkedPaths;
 

--- a/kalixide/src/main/java/com/kalix/ide/components/JTristateCheckBox.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JTristateCheckBox.java
@@ -1,0 +1,70 @@
+package com.kalix.ide.components;
+
+import javax.swing.Icon;
+import javax.swing.JCheckBox;
+import javax.swing.UIManager;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+
+/// A {@link JCheckBox} that can additionally render a third, PARTIAL state - some but not
+/// all of a group's members are checked - as a small filled dot over the centre of the box.
+///
+/// This deliberately does not use the classic "pressed+armed" {@code ButtonModel} trick for
+/// faking an indeterminate checkbox: that trick is Look-and-Feel-dependent (some L&Fs render
+/// pressed-but-unselected in a way that's indistinguishable from checked or unchecked), and
+/// is fragile to get right on a checkbox instance that's reused across many renders (see
+/// {@code CheckboxTreeCellRenderer} history - resetting {@code pressed} before {@code armed}
+/// silently toggled {@code selected} on the *next* rendered row via
+/// {@code DefaultButtonModel}'s click-simulation side effect). Painting our own indicator
+/// avoids both problems: it looks the same everywhere and never touches button-model state.
+public class JTristateCheckBox extends JCheckBox {
+
+    private boolean partial = false;
+
+    /// Sets whether this checkbox should render its PARTIAL (indeterminate) indicator.
+    /// PARTIAL and CHECKED are mutually exclusive display states - callers should pair this
+    /// with {@code setSelected(false)} when setting partial to {@code true}.
+    public void setPartial(boolean partial) {
+        if (this.partial != partial) {
+            this.partial = partial;
+            repaint();
+        }
+    }
+
+    public boolean isPartial() {
+        return partial;
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        if (!partial) {
+            return;
+        }
+
+        int boxSize = boxSize();
+        int dotSize = Math.max(2, boxSize / 3);
+        int x = (boxSize - dotSize) / 2 + getInsets().left;
+        int y = (getHeight() - dotSize) / 2;
+
+        Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2.setColor(isEnabled() ? getForeground() : UIManager.getColor("CheckBox.disabledText"));
+            g2.fillRoundRect(x, y, dotSize, dotSize, dotSize, dotSize);
+        } finally {
+            g2.dispose();
+        }
+    }
+
+    /// Approximates the width of the checkbox glyph itself (as opposed to the whole
+    /// component, which may include room for a label this checkbox never has in practice -
+    /// it's always used bare, alongside a separate label component). Falls back to the
+    /// component height, which is a reasonable proxy since the glyph is roughly square.
+    private int boxSize() {
+        Icon icon = UIManager.getIcon("CheckBox.icon");
+        int iconWidth = icon != null ? icon.getIconWidth() : -1;
+        return iconWidth > 0 ? iconWidth : getHeight();
+    }
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/data/DatasetSource.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/data/DatasetSource.java
@@ -1,0 +1,8 @@
+package com.kalix.ide.flowviz.data;
+
+/**
+ * {@link SourceRef} variant for a user-loaded dataset file, identified by its
+ * absolute path — the same {@code datasetId} convention as {@link DatasetSeries}.
+ */
+public record DatasetSource(String datasetId) implements SourceRef {
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/data/LastSource.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/data/LastSource.java
@@ -1,0 +1,11 @@
+package com.kalix.ide.flowviz.data;
+
+/**
+ * {@link SourceRef} variant for the "Last run" alias. Like {@link LastSeries}, it
+ * carries no run identity of its own: a tab that has Last checked tracks whichever
+ * run is currently the most recent, not the run that happened to be "last" when the
+ * tab recorded it. It deliberately survives the Last node being cleared — when a new
+ * run completes, tabs holding this ref pick the new Last up again on switch.
+ */
+public record LastSource() implements SourceRef {
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/data/RunSource.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/data/RunSource.java
@@ -1,0 +1,9 @@
+package com.kalix.ide.flowviz.data;
+
+/**
+ * {@link SourceRef} variant for a specific simulation run, identified by the same
+ * stable {@code runId} that {@link RunSeries} uses. Renaming the run does not change
+ * it; a removed run's id is never reused, so stale refs can simply be scrubbed.
+ */
+public record RunSource(long runId) implements SourceRef {
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/data/SourceRef.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/data/SourceRef.java
@@ -1,0 +1,18 @@
+package com.kalix.ide.flowviz.data;
+
+/**
+ * Stable internal identity for a <em>data source</em> in the Run Manager — a run, the
+ * "Last" alias, or a loaded dataset file. The source-level counterpart of
+ * {@link SeriesRef}: where a {@code SeriesRef} identifies one time-series, a
+ * {@code SourceRef} identifies the thing that produced a whole family of them.
+ *
+ * <p>Used to remember, per visualization tab, which sources are checked in the data
+ * source tree — so switching tabs can restore the tab's full context (sources <em>and</em>
+ * series). Stored as typed refs rather than {@code TreePath}s for the same reason
+ * {@code SeriesRef} exists: tree paths die on rebuilds and node replacement, while
+ * {@code runId} / dataset path survive renames and refreshes.</p>
+ *
+ * <p>Sealed so all variants are known and pattern-matchable.</p>
+ */
+public sealed interface SourceRef permits RunSource, LastSource, DatasetSource {
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/data/TimeSeriesData.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/data/TimeSeriesData.java
@@ -272,12 +272,26 @@ public class TimeSeriesData {
         }
         
         int startIndex, endIndex;
-        
+
         if (contiguous) {
+            // Honour the half-open contract at the extremes, exactly like the binary-search
+            // path below: a query window entirely after the last sample (or entirely before
+            // the first) is EMPTY. The old clamp to pointCount-1 instead shunted the last
+            // sample into any beyond-the-end query — the LOD column partition then dropped
+            // the last point into the final pixel column, and "draw across gaps" bridged it
+            // to the right plot edge as a phantom segment (auto-Y similarly picked up an
+            // out-of-view point).
+            if (startTimeMs > timestamps[pointCount - 1]) {
+                return new IndexRange(pointCount, pointCount);
+            }
+            if (endTimeMs < timestamps[0]) {
+                return new IndexRange(0, 0);
+            }
+
             // Fast calculation: on a gap-free grid the array index is exactly (t - first) / step
             startIndex = (int) Math.max(0, (startTimeMs - firstTimestamp) / nominalIntervalMillis);
             endIndex = (int) Math.min(pointCount, (endTimeMs - firstTimestamp) / nominalIntervalMillis + 1);
-            
+
             // Clamp to actual bounds
             startIndex = Math.max(0, Math.min(startIndex, pointCount - 1));
             endIndex = Math.max(startIndex, Math.min(endIndex, pointCount));

--- a/kalixide/src/main/java/com/kalix/ide/managers/OutputsTreeBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/OutputsTreeBuilder.java
@@ -38,7 +38,8 @@ import java.util.stream.Collectors;
  * <h2>Rebuild Behavior</h2>
  * {@link #updateTree} does a full rebuild via {@code timeseriesTreeModel.reload()}.
  * Expansion state is preserved by recording expanded paths before rebuild and restoring after.
- * Tree selection is handled separately by RunManager via {@code restoreTreeSelectionForSeries()}.
+ * Checked state (what's plotted) is handled separately by RunManager via
+ * {@code restoreTreeSelectionForSeries()}, since a reload invalidates the old TreePaths.
  *
  * <h2>Data Source</h2>
  * Series names come from {@code getSeriesNamesCallback} which calls:
@@ -47,7 +48,7 @@ import java.util.stream.Collectors;
  *   <li>For datasets: The loaded CSV/Pixie column names</li>
  * </ul>
  *
- * @see com.kalix.ide.windows.RunManager#onRunTreeSelectionChanged
+ * @see com.kalix.ide.windows.RunManager#onSourceTreeCheckedChanged
  * @see com.kalix.ide.windows.RunManager#restoreTreeSelectionForSeries
  */
 public class OutputsTreeBuilder {

--- a/kalixide/src/main/java/com/kalix/ide/managers/OutputsTreeBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/managers/OutputsTreeBuilder.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  * {@link #updateTree} does a full rebuild via {@code timeseriesTreeModel.reload()}.
  * Expansion state is preserved by recording expanded paths before rebuild and restoring after.
  * Checked state (what's plotted) is handled separately by RunManager via
- * {@code restoreTreeSelectionForSeries()}, since a reload invalidates the old TreePaths.
+ * {@code restoreTreeChecksForSeries()}, since a reload invalidates the old TreePaths.
  *
  * <h2>Data Source</h2>
  * Series names come from {@code getSeriesNamesCallback} which calls:
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
  * </ul>
  *
  * @see com.kalix.ide.windows.RunManager#onSourceTreeCheckedChanged
- * @see com.kalix.ide.windows.RunManager#restoreTreeSelectionForSeries
+ * @see com.kalix.ide.windows.RunManager#restoreTreeChecksForSeries(Set)
  */
 public class OutputsTreeBuilder {
 

--- a/kalixide/src/main/java/com/kalix/ide/renderers/CheckboxTreeCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/renderers/CheckboxTreeCellRenderer.java
@@ -1,0 +1,113 @@
+package com.kalix.ide.renderers;
+
+import com.kalix.ide.components.JCheckboxTree;
+
+import javax.swing.Icon;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeCellRenderer;
+import javax.swing.tree.TreePath;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+
+public class CheckboxTreeCellRenderer extends JPanel implements TreeCellRenderer {
+    private final JCheckBox checkbox;
+    private final DefaultTreeCellRenderer label;
+
+    public CheckboxTreeCellRenderer() {
+        setLayout(new BorderLayout());
+        checkbox = new JCheckBox();
+        // Make checkbox display-only (tree handles interaction logic)
+        checkbox.setFocusable(false);
+        checkbox.setRequestFocusEnabled(false);
+
+        label = new DefaultTreeCellRenderer();
+        add(checkbox, BorderLayout.WEST);
+        add(label, BorderLayout.CENTER);
+        setOpaque(false);
+    }
+
+    @Override
+    public Component getTreeCellRendererComponent(JTree tree, Object value,
+                                                  boolean selected, boolean expanded,
+                                                  boolean leaf, int row, boolean hasFocus) {
+        // Update the label component with default rendering
+        label.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
+        if (tree instanceof JCheckboxTree checkboxTree) {
+            TreePath path = tree.getPathForRow(row);
+            JCheckboxTree.CheckState state = path != null
+                    ? checkboxTree.getCheckState(path)
+                    : JCheckboxTree.CheckState.UNCHECKED;
+            applyCheckState(state);
+        } else {
+            applyCheckState(JCheckboxTree.CheckState.UNCHECKED);
+        }
+        return this;
+    }
+
+    /**
+     * Renders the checkbox for a tri-state {@link JCheckboxTree.CheckState}. PARTIAL uses
+     * the button-model pressed+armed trick (no native tri-state JCheckBox exists in Swing):
+     * https://stackoverflow.com/a/11067422 - Posted by Daniel, modified by community,
+     * retrieved 2026-07-07, license CC BY-SA 3.0.
+     *
+     * <p>{@code checkbox} is a single instance reused for every row, so a PARTIAL render
+     * leaves its model armed+pressed behind for whichever row renders next.
+     * {@code DefaultButtonModel.setPressed(false)} treats a pressed-to-unpressed transition
+     * while still armed as a mouse-release and toggles {@code selected} - exactly like a
+     * real click - which would silently flip the *next* rendered row's checkbox back on
+     * after we just set it unselected. Dropping {@code armed} before {@code pressed} on
+     * every reset means that toggle's guard ({@code !pressed && armed}) can never be true
+     * during cleanup.</p>
+     */
+    private void applyCheckState(JCheckboxTree.CheckState state) {
+        var model = checkbox.getModel();
+        model.setArmed(false);
+        model.setPressed(false);
+        switch (state) {
+            case CHECKED -> checkbox.setSelected(true);
+            case PARTIAL -> {
+                checkbox.setSelected(false);
+                model.setArmed(true);
+                model.setPressed(true);
+            }
+            case UNCHECKED -> checkbox.setSelected(false);
+            default -> throw new IllegalStateException("Unexpected value: " + state);
+        }
+    }
+
+    // Delegation methods for subclasses to customize the label appearance
+    // These mirror DefaultTreeCellRenderer methods for API compatibility
+
+    /**
+     * Sets the text of the label component.
+     * Delegates to the internal label renderer.
+     */
+    public void setText(String text) {
+        label.setText(text);
+    }
+
+    /**
+     * Sets the icon of the label component.
+     * Delegates to the internal label renderer.
+     */
+    public void setIcon(Icon icon) {
+        label.setIcon(icon);
+    }
+
+    /**
+     * Sets the foreground color of the label component.
+     * Delegates to the internal label renderer.
+     */
+    @Override
+    public void setForeground(Color color) {
+        // Must check for null because this can be called during construction
+        // before the label field is initialized
+        if (label != null) {
+            label.setForeground(color);
+        }
+    }
+}

--- a/kalixide/src/main/java/com/kalix/ide/renderers/CheckboxTreeCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/renderers/CheckboxTreeCellRenderer.java
@@ -1,9 +1,9 @@
 package com.kalix.ide.renderers;
 
 import com.kalix.ide.components.JCheckboxTree;
+import com.kalix.ide.components.JTristateCheckBox;
 
 import javax.swing.Icon;
-import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -14,12 +14,12 @@ import java.awt.Color;
 import java.awt.Component;
 
 public class CheckboxTreeCellRenderer extends JPanel implements TreeCellRenderer {
-    private final JCheckBox checkbox;
+    private final JTristateCheckBox checkbox;
     private final DefaultTreeCellRenderer label;
 
     public CheckboxTreeCellRenderer() {
         setLayout(new BorderLayout());
-        checkbox = new JCheckBox();
+        checkbox = new JTristateCheckBox();
         // Make checkbox display-only (tree handles interaction logic)
         checkbox.setFocusable(false);
         checkbox.setRequestFocusEnabled(false);
@@ -49,33 +49,29 @@ public class CheckboxTreeCellRenderer extends JPanel implements TreeCellRenderer
     }
 
     /**
-     * Renders the checkbox for a tri-state {@link JCheckboxTree.CheckState}. PARTIAL uses
-     * the button-model pressed+armed trick (no native tri-state JCheckBox exists in Swing):
-     * https://stackoverflow.com/a/11067422 - Posted by Daniel, modified by community,
-     * retrieved 2026-07-07, license CC BY-SA 3.0.
-     *
-     * <p>{@code checkbox} is a single instance reused for every row, so a PARTIAL render
-     * leaves its model armed+pressed behind for whichever row renders next.
-     * {@code DefaultButtonModel.setPressed(false)} treats a pressed-to-unpressed transition
-     * while still armed as a mouse-release and toggles {@code selected} - exactly like a
-     * real click - which would silently flip the *next* rendered row's checkbox back on
-     * after we just set it unselected. Dropping {@code armed} before {@code pressed} on
-     * every reset means that toggle's guard ({@code !pressed && armed}) can never be true
-     * during cleanup.</p>
+     * Renders the checkbox for a tri-state {@link JCheckboxTree.CheckState}, delegating the
+     * PARTIAL indicator to {@link JTristateCheckBox#setPartial}. An earlier version of this
+     * faked PARTIAL via the classic checkbox {@code ButtonModel} pressed+armed trick, but
+     * that turned out to be fragile on a checkbox instance reused across every row: resetting
+     * {@code pressed} before {@code armed} silently toggled {@code selected} back on for
+     * whichever row rendered next, via {@code DefaultButtonModel}'s click-simulation side
+     * effect. Painting the indicator directly (see {@link JTristateCheckBox}) sidesteps that
+     * whole class of bug by never touching button-model state.
      */
     private void applyCheckState(JCheckboxTree.CheckState state) {
-        var model = checkbox.getModel();
-        model.setArmed(false);
-        model.setPressed(false);
         switch (state) {
-            case CHECKED -> checkbox.setSelected(true);
+            case CHECKED -> {
+                checkbox.setSelected(true);
+                checkbox.setPartial(false);
+            }
             case PARTIAL -> {
                 checkbox.setSelected(false);
-                model.setArmed(true);
-                model.setPressed(true);
+                checkbox.setPartial(true);
             }
-            case UNCHECKED -> checkbox.setSelected(false);
-            default -> throw new IllegalStateException("Unexpected value: " + state);
+            case UNCHECKED -> {
+                checkbox.setSelected(false);
+                checkbox.setPartial(false);
+            }
         }
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/renderers/CheckboxTreeCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/renderers/CheckboxTreeCellRenderer.java
@@ -13,9 +13,19 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 
-public class CheckboxTreeCellRenderer extends JPanel implements TreeCellRenderer {
+public class CheckboxTreeCellRenderer extends JPanel
+        implements TreeCellRenderer, JCheckboxTree.CheckboxRowRenderer {
     private final JTristateCheckBox checkbox;
     private final DefaultTreeCellRenderer label;
+
+    /**
+     * Width of the checkbox glyph region at the leading edge of the row. The tree uses
+     * this to hit-test clicks: only clicks inside this strip toggle the checkbox.
+     */
+    @Override
+    public int getCheckboxWidth() {
+        return checkbox.getPreferredSize().width;
+    }
 
     public CheckboxTreeCellRenderer() {
         setLayout(new BorderLayout());

--- a/kalixide/src/main/java/com/kalix/ide/renderers/OutputsTreeCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/renderers/OutputsTreeCellRenderer.java
@@ -13,7 +13,7 @@ import java.awt.Component;
  * Custom tree cell renderer for the timeseries/outputs tree.
  * Provides themed icons based on variable names for better visual identification.
  */
-public class OutputsTreeCellRenderer extends DefaultTreeCellRenderer {
+public class OutputsTreeCellRenderer extends CheckboxTreeCellRenderer {
 
     private static final int TREE_ICON_SIZE = 12; // 75% of standard toolbar icon size
 

--- a/kalixide/src/main/java/com/kalix/ide/renderers/RunTreeCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/renderers/RunTreeCellRenderer.java
@@ -15,7 +15,7 @@ import java.awt.Component;
  * Custom tree cell renderer for the run tree.
  * Provides colored text and icons based on run status and node type.
  */
-public class RunTreeCellRenderer extends DefaultTreeCellRenderer {
+public class RunTreeCellRenderer extends CheckboxTreeCellRenderer {
 
     private static final int TREE_ICON_SIZE = 12; // 75% of standard toolbar icon size
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
@@ -170,54 +170,57 @@ class LastRunTracker {
 
         // If Last was checked, block all checked-state events during the entire update
         if (wasLastChecked) {
-            fetchCoordinator.setUpdatingSelection(true);
+            fetchCoordinator.beginProgrammaticUpdate();
         }
+        try {
+            // Create new child node. The Last subtree's wrapper carries the structural
+            // "is last alias" marker via RunInfoImpl.lastAlias — seriesRefForLeaf consults
+            // that marker (not the runName string) to mint LastSeries refs.
+            lastRunChildNode = new DefaultMutableTreeNode(
+                RunInfoImpl.lastAlias(newLastRun.getSession())
+            );
 
-        // Create new child node. The Last subtree's wrapper carries the structural
-        // "is last alias" marker via RunInfoImpl.lastAlias — seriesRefForLeaf consults
-        // that marker (not the runName string) to mint LastSeries refs.
-        lastRunChildNode = new DefaultMutableTreeNode(
-            RunInfoImpl.lastAlias(newLastRun.getSession())
-        );
+            if (oldChildNode != null) {
+                // Old node is leaving the tree - forget its checked-state entry entirely (not
+                // just uncheck it) so it doesn't dangle in nodeCheckedStateMap, unreachable via
+                // the tree, for the life of the app. Matches RunTreeController's run-removal and
+                // RunManager's dataset-removal handling.
+                timeseriesSourceTree.removePath(oldLastPath);
 
-        if (oldChildNode != null) {
-            // Old node is leaving the tree - forget its checked-state entry entirely (not
-            // just uncheck it) so it doesn't dangle in nodeCheckedStateMap, unreachable via
-            // the tree, for the life of the app. Matches RunTreeController's run-removal and
-            // RunManager's dataset-removal handling.
-            timeseriesSourceTree.removePath(oldLastPath);
+                // Replacing existing child - remove old, add new
+                lastRunNode.remove(oldChildNode);
+                treeModel.nodesWereRemoved(lastRunNode, new int[]{oldChildIndex}, new Object[]{oldChildNode});
 
-            // Replacing existing child - remove old, add new
-            lastRunNode.remove(oldChildNode);
-            treeModel.nodesWereRemoved(lastRunNode, new int[]{oldChildIndex}, new Object[]{oldChildNode});
+                lastRunNode.add(lastRunChildNode);
+                treeModel.nodesWereInserted(lastRunNode, new int[]{0});
+            } else {
+                // First time - just add
+                lastRunNode.add(lastRunChildNode);
+                treeModel.nodesWereInserted(lastRunNode, new int[]{0});
+            }
 
-            lastRunNode.add(lastRunChildNode);
-            treeModel.nodesWereInserted(lastRunNode, new int[]{0});
-        } else {
-            // First time - just add
-            lastRunNode.add(lastRunChildNode);
-            treeModel.nodesWereInserted(lastRunNode, new int[]{0});
-        }
+            // If Last was previously checked, rebuild the timeseries tree to show new outputs
+            if (wasLastChecked) {
+                TreePath newLastPath = new TreePath(lastRunChildNode.getPath());
 
-        // If Last was previously checked, rebuild the timeseries tree to show new outputs
-        if (wasLastChecked) {
-            TreePath newLastPath = new TreePath(lastRunChildNode.getPath());
+                // Check the new Last node so its outputs are picked up below
+                timeseriesSourceTree.checkPath(newLastPath);
 
-            // Check the new Last node so its outputs are picked up below
-            timeseriesSourceTree.checkPath(newLastPath);
+                // Rebuild the timeseries tree to include any new outputs from the new run
+                // This is necessary because the new run may have different outputs than the old one
+                window.updateOutputsTree();
 
-            // Rebuild the timeseries tree to include any new outputs from the new run
-            // This is necessary because the new run may have different outputs than the old one
-            window.updateOutputsTree();
+                // Restore checked state for series that still exist in the new tree
+                Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
+                Set<SeriesRef> restoredSeries = window.restoreTreeChecksForSeries(tabSeries);
 
-            // Restore checked state for series that still exist in the new tree
-            Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-            Set<SeriesRef> restoredSeries = window.restoreTreeChecksForSeries(tabSeries);
-
-            // Remove from tab any series that no longer exist (e.g., outputs that were removed)
-            window.reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
-
-            fetchCoordinator.setUpdatingSelection(false);
+                // Remove from tab any series that no longer exist (e.g., outputs that were removed)
+                window.reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
+            }
+        } finally {
+            if (wasLastChecked) {
+                fetchCoordinator.endProgrammaticUpdate();
+            }
         }
 
         // Expand the Last run node to show the new child

--- a/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
@@ -123,6 +123,7 @@ class LastRunTracker {
             if (lastRunChildNode != null) {
                 int childIndex = lastRunNode.getIndex(lastRunChildNode);
                 Object[] removedChild = new Object[]{lastRunChildNode};
+                timeseriesSourceTree.removePath(new TreePath(lastRunChildNode.getPath()));
                 lastRunNode.removeAllChildren();
                 treeModel.nodesWereRemoved(lastRunNode, new int[]{childIndex}, removedChild);
                 lastRunChildNode = null;

--- a/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
@@ -180,11 +180,11 @@ class LastRunTracker {
         );
 
         if (oldChildNode != null) {
-            // Old node is leaving the tree - drop its checked entry so it doesn't linger as
-            // a dangling, unreachable "checked" path.
-            if (wasLastChecked) {
-                timeseriesSourceTree.uncheckPath(oldLastPath);
-            }
+            // Old node is leaving the tree - forget its checked-state entry entirely (not
+            // just uncheck it) so it doesn't dangle in nodeCheckedStateMap, unreachable via
+            // the tree, for the life of the app. Matches RunTreeController's run-removal and
+            // RunManager's dataset-removal handling.
+            timeseriesSourceTree.removePath(oldLastPath);
 
             // Replacing existing child - remove old, add new
             lastRunNode.remove(oldChildNode);

--- a/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
@@ -141,7 +141,7 @@ class LastRunTracker {
      *     <ul>
      *       <li>Rebuilds timeseries tree to show outputs from new run (may have new/removed outputs)</li>
      *       <li>Restores selection for series that still exist</li>
-     *       <li>Removes stale series from plot via {@link RunManager#reconcileSelectedSeriesWithTree}</li>
+     *       <li>Removes stale series from plot via {@link RunManager#reconcileCheckedSeriesWithTree}</li>
      *     </ul>
      *   </li>
      *   <li>Calls {@link #refreshLastSeries} to update plotted "[Last]" data with new values</li>
@@ -211,10 +211,10 @@ class LastRunTracker {
 
             // Restore checked state for series that still exist in the new tree
             Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-            Set<SeriesRef> restoredSeries = window.restoreTreeSelectionForSeries(tabSeries);
+            Set<SeriesRef> restoredSeries = window.restoreTreeChecksForSeries(tabSeries);
 
             // Remove from tab any series that no longer exist (e.g., outputs that were removed)
-            window.reconcileSelectedSeriesWithTree(restoredSeries, tabSeries);
+            window.reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
 
             fetchCoordinator.setUpdatingSelection(false);
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
@@ -1,5 +1,6 @@
 package com.kalix.ide.windows;
 
+import com.kalix.ide.components.JCheckboxTree;
 import com.kalix.ide.flowviz.data.LastSeries;
 import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.flowviz.data.TimeSeriesData;
@@ -8,7 +9,6 @@ import com.kalix.ide.managers.TimeSeriesRequestManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
@@ -25,7 +25,7 @@ import java.util.Set;
  * When a run completes ({@link #onRunCompleted}):
  * <ol>
  *   <li>Cache is cleared for the session ({@link TimeSeriesRequestManager#clearCacheForSession})</li>
- *   <li>If "Last" was selected, timeseries tree is rebuilt to show new outputs</li>
+ *   <li>If "Last" was checked, timeseries tree is rebuilt to show new outputs</li>
  *   <li>Plotted "[Last]" series are refreshed with new data ({@link #refreshLastSeries})</li>
  * </ol>
  *
@@ -38,7 +38,7 @@ class LastRunTracker {
     private static final Logger logger = LoggerFactory.getLogger(LastRunTracker.class);
 
     private final RunManager window;
-    private final JTree timeseriesSourceTree;
+    private final JCheckboxTree timeseriesSourceTree;
     private final DefaultTreeModel treeModel;
     private final DefaultMutableTreeNode lastRunNode;
     private final VisualizationTabManager tabManager;
@@ -63,7 +63,7 @@ class LastRunTracker {
     private long lastRunCompletionTime = 0L;
 
     LastRunTracker(RunManager window,
-                   JTree timeseriesSourceTree,
+                   JCheckboxTree timeseriesSourceTree,
                    DefaultTreeModel treeModel,
                    DefaultMutableTreeNode lastRunNode,
                    VisualizationTabManager tabManager,
@@ -157,27 +157,18 @@ class LastRunTracker {
         // Check if we're replacing an existing Last child or creating the first one
         DefaultMutableTreeNode oldChildNode = null;
         int oldChildIndex = -1;
-        boolean wasLastSelected = false;
+        TreePath oldLastPath = null;
+        boolean wasLastChecked = false;
 
         if (lastRunChildNode != null) {
             oldChildIndex = lastRunNode.getIndex(lastRunChildNode);
             oldChildNode = lastRunChildNode;
-
-            // Check if the old Last child was selected
-            TreePath[] selectedPaths = timeseriesSourceTree.getSelectionPaths();
-            if (selectedPaths != null) {
-                TreePath oldLastPath = new TreePath(lastRunChildNode.getPath());
-                for (TreePath path : selectedPaths) {
-                    if (path.equals(oldLastPath)) {
-                        wasLastSelected = true;
-                        break;
-                    }
-                }
-            }
+            oldLastPath = new TreePath(lastRunChildNode.getPath());
+            wasLastChecked = timeseriesSourceTree.isPathChecked(oldLastPath);
         }
 
-        // If Last was selected, block all selection events during the entire update
-        if (wasLastSelected) {
+        // If Last was checked, block all checked-state events during the entire update
+        if (wasLastChecked) {
             fetchCoordinator.setUpdatingSelection(true);
         }
 
@@ -189,6 +180,12 @@ class LastRunTracker {
         );
 
         if (oldChildNode != null) {
+            // Old node is leaving the tree - drop its checked entry so it doesn't linger as
+            // a dangling, unreachable "checked" path.
+            if (wasLastChecked) {
+                timeseriesSourceTree.uncheckPath(oldLastPath);
+            }
+
             // Replacing existing child - remove old, add new
             lastRunNode.remove(oldChildNode);
             treeModel.nodesWereRemoved(lastRunNode, new int[]{oldChildIndex}, new Object[]{oldChildNode});
@@ -201,18 +198,18 @@ class LastRunTracker {
             treeModel.nodesWereInserted(lastRunNode, new int[]{0});
         }
 
-        // If Last was previously selected, rebuild the timeseries tree to show new outputs
-        if (wasLastSelected) {
+        // If Last was previously checked, rebuild the timeseries tree to show new outputs
+        if (wasLastChecked) {
             TreePath newLastPath = new TreePath(lastRunChildNode.getPath());
 
-            // Restore run tree selection to the new Last node
-            timeseriesSourceTree.addSelectionPath(newLastPath);
+            // Check the new Last node so its outputs are picked up below
+            timeseriesSourceTree.checkPath(newLastPath);
 
             // Rebuild the timeseries tree to include any new outputs from the new run
             // This is necessary because the new run may have different outputs than the old one
             window.updateOutputsTree();
 
-            // Restore selection for series that still exist in the new tree
+            // Restore checked state for series that still exist in the new tree
             Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
             Set<SeriesRef> restoredSeries = window.restoreTreeSelectionForSeries(tabSeries);
 
@@ -251,7 +248,7 @@ class LastRunTracker {
      * So the pool never holds a {@code LastSeries} key that could go stale: when Last
      * changes, a {@code LastSeries} ref simply resolves to a different {@code RunSeries}.
      * This method just ensures that target is populated. The
-     * {@code onOutputsTreeSelectionChanged} "already in pool" short-circuit is therefore
+     * {@code onOutputsTreeCheckedChanged} "already in pool" short-circuit is therefore
      * correct by construction — a {@code getSeries(LastSeries)} probe resolves to the
      * current run's data or to {@code null} (triggering a fetch).
      *

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -912,7 +912,7 @@ public class RunManager extends JFrame {
      */
     void updateOutputsTree() {
         TreePath[] checkedPaths = timeseriesSourceTree.getCheckedPaths();
-        if (checkedPaths == null || checkedPaths.length == 0) {
+        if (checkedPaths.length == 0) {
             outputsTreeBuilder.showEmptyTree(OutputsTreeBuilder.SELECT_SOURCES_MESSAGE);
             return;
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -2,10 +2,14 @@ package com.kalix.ide.windows;
 
 import com.kalix.ide.components.JCheckboxTree;
 import com.kalix.ide.flowviz.data.DatasetSeries;
+import com.kalix.ide.flowviz.data.DatasetSource;
 import com.kalix.ide.flowviz.data.LabelResolver;
 import com.kalix.ide.flowviz.data.LastSeries;
+import com.kalix.ide.flowviz.data.LastSource;
 import com.kalix.ide.flowviz.data.RunSeries;
+import com.kalix.ide.flowviz.data.RunSource;
 import com.kalix.ide.flowviz.data.SeriesRef;
+import com.kalix.ide.flowviz.data.SourceRef;
 import com.kalix.ide.managers.StdioTaskManager;
 import com.kalix.ide.managers.TimeSeriesRequestManager;
 import com.kalix.ide.managers.OutputsTreeBuilder;
@@ -85,7 +89,9 @@ import java.util.function.Consumer;
  *
  * <h2>Selection Tracking</h2>
  * <ul>
- *   <li>Per-tab selected series stored in {@link VisualizationTabManager} TabInfo</li>
+ *   <li>Per-tab selected series AND per-tab checked sources stored in
+ *       {@link VisualizationTabManager} TabInfo — a tab is a complete view (sources +
+ *       series + plot settings), restored as a whole by {@link #onTabChanged}</li>
  *   <li>{@link SeriesFetchCoordinator#isUpdatingSelection()} - Guard to prevent listener
  *       feedback loops during programmatic updates</li>
  *   <li>Checked state (what's plotted) is separate from plain tree selection (row highlight);
@@ -880,6 +886,10 @@ public class RunManager extends JFrame {
             return;
         }
 
+        // Record the new source context on the target tab, so switching back to this
+        // tab later restores it (sources and series are both per-tab state).
+        snapshotSourceChecksToTargetTab();
+
         // Block timeseries tree checked-state events during rebuild and restoration
         fetchCoordinator.setUpdatingSelection(true);
         updateOutputsTree();
@@ -983,8 +993,10 @@ public class RunManager extends JFrame {
         }
         datasetSeriesCache.keySet().removeIf(dsRef -> dsRef.datasetId().equals(absPath));
 
-        // Strip them from every tab's selection, legend, visible-series, and stats.
+        // Strip them from every tab's selection, legend, visible-series, and stats,
+        // and forget the dataset from every tab's recorded source context.
         tabManager.removeSeriesFromAllTabs(refs);
+        tabManager.removeSourceFromAllTabs(new DatasetSource(absPath));
 
         // Remove the tree node — selection changes (if any) refresh the outputs tree.
         for (int i = 0; i < loadedDatasetsNode.getChildCount(); i++) {
@@ -1004,8 +1016,82 @@ public class RunManager extends JFrame {
     }
 
     /**
-     * Called when the user switches tabs. Syncs the timeseries tree selection
-     * to reflect the new active tab's selected series.
+     * Projects a source-tree node's user object to its stable {@link SourceRef}
+     * identity, or {@code null} for anything that isn't a data source (category
+     * headers, the root).
+     */
+    private SourceRef sourceRefForNode(Object userObject) {
+        if (userObject instanceof RunInfoImpl runInfo) {
+            return runInfo.isLastAlias() ? new LastSource() : new RunSource(runInfo.getRunId());
+        }
+        if (userObject instanceof DatasetLoaderManager.LoadedDatasetInfo info) {
+            return new DatasetSource(info.file.getAbsolutePath());
+        }
+        return null;
+    }
+
+    /**
+     * Returns the {@link SourceRef}s of the sources currently checked in the data
+     * source tree, in check order. Category paths (auto-checked parents) project to
+     * {@code null} and are skipped.
+     */
+    private Set<SourceRef> currentCheckedSourceRefs() {
+        Set<SourceRef> refs = new LinkedHashSet<>();
+        for (TreePath path : timeseriesSourceTree.getCheckedPaths()) {
+            DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
+            SourceRef ref = sourceRefForNode(node.getUserObject());
+            if (ref != null) {
+                refs.add(ref);
+            }
+        }
+        return refs;
+    }
+
+    /**
+     * Records the currently checked sources on the target tab. Called whenever the
+     * user changes the source checks, and from programmatic check changes that run
+     * under the isUpdatingSelection guard (e.g. {@link RunTreeController#selectRun})
+     * where {@link #onSourceTreeCheckedChanged} won't fire.
+     */
+    void snapshotSourceChecksToTargetTab() {
+        tabManager.setTargetTabCheckedSources(currentCheckedSourceRefs());
+    }
+
+    /**
+     * Resolves a {@link SourceRef} back to its current tree path, or {@code null} if
+     * the source no longer exists (run removed, dataset unloaded, no Last yet).
+     */
+    private TreePath pathForSourceRef(SourceRef ref) {
+        DefaultMutableTreeNode parent = switch (ref) {
+            case LastSource ignored -> lastRunNode;
+            case RunSource ignored -> currentRunsNode;
+            case DatasetSource ignored -> loadedDatasetsNode;
+        };
+        for (int i = 0; i < parent.getChildCount(); i++) {
+            DefaultMutableTreeNode child = (DefaultMutableTreeNode) parent.getChildAt(i);
+            if (ref.equals(sourceRefForNode(child.getUserObject()))) {
+                return new TreePath(child.getPath());
+            }
+        }
+        return null;
+    }
+
+    private List<TreePath> pathsForSourceRefs(Set<SourceRef> refs) {
+        List<TreePath> paths = new ArrayList<>();
+        for (SourceRef ref : refs) {
+            TreePath path = pathForSourceRef(ref);
+            if (path != null) {
+                paths.add(path);
+            }
+        }
+        return paths;
+    }
+
+    /**
+     * Called when the user switches tabs. Restores the new active tab's full context:
+     * first the data-source checks (rebuilding the outputs tree for that context),
+     * then the series checks. A tab is a complete view — sources + series + plot
+     * settings — so switching tabs swaps the whole left panel to match.
      */
     private void onTabChanged() {
         // Adding the default tabs in createDetailsComponents() auto-selects the first tab,
@@ -1014,10 +1100,21 @@ public class RunManager extends JFrame {
         if (fetchCoordinator == null) return;
 
         Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-        if (tabSeries == null) return;
+        Set<SourceRef> tabSources = tabManager.getTargetTabCheckedSources();
 
         fetchCoordinator.setUpdatingSelection(true);
         try {
+            if (tabSources.isEmpty() && tabSeries.isEmpty()) {
+                // Unconfigured tab (e.g. a startup default tab the user hasn't touched):
+                // adopt the current source context rather than clearing it, so a fresh
+                // tab starts where the user is.
+                snapshotSourceChecksToTargetTab();
+            } else if (!tabSources.equals(currentCheckedSourceRefs())) {
+                // Same context → skip the rebuild: no outputs-tree churn when flicking
+                // between tabs that look at the same sources.
+                timeseriesSourceTree.setCheckedPaths(pathsForSourceRefs(tabSources));
+                updateOutputsTree();
+            }
             restoreTreeChecksForSeries(tabSeries);
         } finally {
             fetchCoordinator.setUpdatingSelection(false);

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -988,7 +988,9 @@ public class RunManager extends JFrame {
         // Remove the tree node — selection changes (if any) refresh the outputs tree.
         for (int i = 0; i < loadedDatasetsNode.getChildCount(); i++) {
             DefaultMutableTreeNode child = (DefaultMutableTreeNode) loadedDatasetsNode.getChildAt(i);
+            var path = child.getPath();
             if (child.getUserObject() == info) {
+                timeseriesSourceTree.removePath(new TreePath(path));
                 loadedDatasetsNode.remove(i);
                 treeModel.nodesWereRemoved(loadedDatasetsNode, new int[]{i}, new Object[]{child});
                 break;

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -85,7 +85,7 @@ import java.util.function.Consumer;
  *   <li>{@link SeriesFetchCoordinator#isUpdatingSelection()} - Guard to prevent listener
  *       feedback loops during programmatic updates</li>
  *   <li>Checked state (what's plotted) is separate from plain tree selection (row highlight);
- *       checked state is restored after rebuilds via {@link #restoreTreeSelectionForSeries}</li>
+ *       checked state is restored after rebuilds via {@link #restoreTreeChecksForSeries}</li>
  * </ul>
  *
  * <h2>Window collaborators</h2>
@@ -795,7 +795,7 @@ public class RunManager extends JFrame {
      *
      * @param seriesToRestore The set of series keys to check in the tree
      */
-    Set<SeriesRef> restoreTreeSelectionForSeries(
+    Set<SeriesRef> restoreTreeChecksForSeries(
             Set<SeriesRef> seriesToRestore) {
         if (seriesToRestore.isEmpty()) {
             timeseriesTree.setCheckedPaths(Collections.emptyList());
@@ -826,8 +826,8 @@ public class RunManager extends JFrame {
      * Reconciles the target tab's selected series with what's actually available in the tree.
      * Removes series from the tab that couldn't be restored (e.g., when a run is deselected).
      */
-    void reconcileSelectedSeriesWithTree(Set<SeriesRef> restoredSeries,
-                                                  Set<SeriesRef> tabSeries) {
+    void reconcileCheckedSeriesWithTree(Set<SeriesRef> restoredSeries,
+                                        Set<SeriesRef> tabSeries) {
         // Find series that need to be removed from the tab
         Set<SeriesRef> seriesToRemove = new HashSet<>(tabSeries);
         seriesToRemove.removeAll(restoredSeries);
@@ -885,8 +885,8 @@ public class RunManager extends JFrame {
 
         // Restore checked state to match what's currently plotted on active tab
         Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-        Set<SeriesRef> restoredSeries = restoreTreeSelectionForSeries(tabSeries);
-        reconcileSelectedSeriesWithTree(restoredSeries, tabSeries);
+        Set<SeriesRef> restoredSeries = restoreTreeChecksForSeries(tabSeries);
+        reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
 
         fetchCoordinator.setUpdatingSelection(false);
     }
@@ -900,7 +900,7 @@ public class RunManager extends JFrame {
         try {
             outputsTreeBuilder.setFilterText(treeFilterManager.getFilterText());
             updateOutputsTree();
-            restoreTreeSelectionForSeries(tabManager.getTargetTabSelectedSeries());
+            restoreTreeChecksForSeries(tabManager.getTargetTabSelectedSeries());
         } finally {
             fetchCoordinator.setUpdatingSelection(false);
         }
@@ -1015,7 +1015,7 @@ public class RunManager extends JFrame {
 
         fetchCoordinator.setUpdatingSelection(true);
         try {
-            restoreTreeSelectionForSeries(tabSeries);
+            restoreTreeChecksForSeries(tabSeries);
         } finally {
             fetchCoordinator.setUpdatingSelection(false);
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -1,6 +1,10 @@
 package com.kalix.ide.windows;
 
 import com.kalix.ide.components.JCheckboxTree;
+import com.kalix.ide.flowviz.data.DatasetSeries;
+import com.kalix.ide.flowviz.data.LabelResolver;
+import com.kalix.ide.flowviz.data.LastSeries;
+import com.kalix.ide.flowviz.data.RunSeries;
 import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.managers.StdioTaskManager;
 import com.kalix.ide.managers.TimeSeriesRequestManager;
@@ -146,7 +150,7 @@ public class RunManager extends JFrame {
     // named series from different files distinct. Keying by ref preserves that separation.
     // Value: TimeSeriesData
     // Mirrors how runs store data in TimeSeriesRequestManager's cache.
-    private final Map<com.kalix.ide.flowviz.data.DatasetSeries, TimeSeriesData> datasetSeriesCache = new HashMap<>();
+    private final Map<DatasetSeries, TimeSeriesData> datasetSeriesCache = new HashMap<>();
 
     // Manager instances
     private OutputsTreeBuilder outputsTreeBuilder;
@@ -170,7 +174,7 @@ public class RunManager extends JFrame {
     // Single point of authority for projecting SeriesRef → display label.
     // Consumed by stats tables, legends, and the outputs tree so that the user-visible
     // string for a run-derived series tracks the current run name automatically.
-    private final com.kalix.ide.flowviz.data.LabelResolver labelResolver =
+    private final LabelResolver labelResolver =
         new com.kalix.ide.flowviz.data.DefaultLabelResolver(this::runNameForId);
 
     /**
@@ -378,7 +382,7 @@ public class RunManager extends JFrame {
         plotDataSet.setLastSeriesResolver(last -> {
             RunInfoImpl lastRunInfo = lastRunTracker != null ? lastRunTracker.getLastRunInfo() : null;
             return lastRunInfo != null
-                ? new com.kalix.ide.flowviz.data.RunSeries(lastRunInfo.getRunId(), last.baseName())
+                ? new RunSeries(lastRunInfo.getRunId(), last.baseName())
                 : null;
         });
 
@@ -564,7 +568,7 @@ public class RunManager extends JFrame {
         // Get series from cache (NOT plotDataSet) - mirrors how runs work
         return datasetSeriesCache.keySet().stream()
             .filter(ref -> ref.datasetId().equals(datasetId))
-            .map(com.kalix.ide.flowviz.data.DatasetSeries::baseName)
+            .map(DatasetSeries::baseName)
             .sorted(NaturalSortUtils::naturalCompare)
             .collect(java.util.stream.Collectors.toList());
     }
@@ -777,12 +781,12 @@ public class RunManager extends JFrame {
     private SeriesRef refForSource(String seriesName, Object source) {
         if (source instanceof RunInfoImpl runInfo) {
             if (runInfo.isLastAlias()) {
-                return new com.kalix.ide.flowviz.data.LastSeries(seriesName);
+                return new LastSeries(seriesName);
             }
-            return new com.kalix.ide.flowviz.data.RunSeries(runInfo.getRunId(), seriesName);
+            return new RunSeries(runInfo.getRunId(), seriesName);
         }
         if (source instanceof DatasetLoaderManager.LoadedDatasetInfo info) {
-            return new com.kalix.ide.flowviz.data.DatasetSeries(info.file.getAbsolutePath(), seriesName);
+            return new DatasetSeries(info.file.getAbsolutePath(), seriesName);
         }
         return null;
     }
@@ -858,17 +862,14 @@ public class RunManager extends JFrame {
     }
 
     /**
-     * Returns the {@link com.kalix.ide.flowviz.data.LabelResolver} bound to this
+     * Returns the {@link LabelResolver} bound to this
      * RunManager's state. Components that need to render series labels — stats tables,
      * plot legends, the outputs tree — should obtain the resolver here rather than
      * constructing label strings themselves.
      */
-    public com.kalix.ide.flowviz.data.LabelResolver getLabelResolver() {
+    public LabelResolver getLabelResolver() {
         return labelResolver;
     }
-
-    // extractSeriesName removed — there are no series-key strings to parse anymore.
-    // Identity is the typed SeriesRef; baseName comes from ref.baseName().
 
     /**
      * Handles data-source-tree checked-state changes to update the timeseries tree.
@@ -969,7 +970,7 @@ public class RunManager extends JFrame {
 
         // Collect all DatasetSeries refs that belong to this dataset.
         List<SeriesRef> refs = new ArrayList<>();
-        for (com.kalix.ide.flowviz.data.DatasetSeries dsRef : datasetSeriesCache.keySet()) {
+        for (DatasetSeries dsRef : datasetSeriesCache.keySet()) {
             if (dsRef.datasetId().equals(absPath)) {
                 refs.add(dsRef);
             }
@@ -1022,5 +1023,4 @@ public class RunManager extends JFrame {
             fetchCoordinator.setUpdatingSelection(false);
         }
     }
-
 }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -1,5 +1,7 @@
 package com.kalix.ide.windows;
 
+import com.kalix.ide.components.JCheckboxTree;
+import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.managers.StdioTaskManager;
 import com.kalix.ide.managers.TimeSeriesRequestManager;
 import com.kalix.ide.managers.OutputsTreeBuilder;
@@ -14,7 +16,6 @@ import com.kalix.ide.cli.RunModelProgram;
 import com.kalix.ide.utils.NaturalSortUtils;
 import com.kalix.ide.flowviz.data.TimeSeriesData;
 import com.kalix.ide.flowviz.data.DataSet;
-import com.kalix.ide.flowviz.models.StatsTableModel;
 import com.kalix.ide.renderers.OutputsTreeCellRenderer;
 import com.kalix.ide.renderers.RunTreeCellRenderer;
 
@@ -26,10 +27,8 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
-import javax.swing.event.TreeSelectionEvent;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
@@ -72,9 +71,9 @@ import java.util.function.Consumer;
  *
  * <h2>Data Flow</h2>
  * <ol>
- *   <li>User selects source(s) in data source tree → {@link #onRunTreeSelectionChanged}</li>
+ *   <li>User checks source(s) in data source tree → {@link #onSourceTreeCheckedChanged}</li>
  *   <li>Timeseries tree is rebuilt with available outputs → {@link OutputsTreeBuilder#updateTree}</li>
- *   <li>User selects series in timeseries tree → {@link SeriesFetchCoordinator#onOutputsTreeSelectionChanged}</li>
+ *   <li>User checks series in timeseries tree → {@link SeriesFetchCoordinator#onOutputsTreeCheckedChanged}</li>
  *   <li>Data is fetched via {@link TimeSeriesRequestManager} (cached by kalixcliUid:seriesName)</li>
  *   <li>Data is added to shared {@link DataSet} pool → {@link #addSeriesToPool}</li>
  *   <li>All plot tabs are updated → {@link VisualizationTabManager#updateAllTabs}</li>
@@ -85,7 +84,8 @@ import java.util.function.Consumer;
  *   <li>Per-tab selected series stored in {@link VisualizationTabManager} TabInfo</li>
  *   <li>{@link SeriesFetchCoordinator#isUpdatingSelection()} - Guard to prevent listener
  *       feedback loops during programmatic updates</li>
- *   <li>Tree selection is restored after rebuilds via {@link #restoreTreeSelectionForSeries}</li>
+ *   <li>Checked state (what's plotted) is separate from plain tree selection (row highlight);
+ *       checked state is restored after rebuilds via {@link #restoreTreeSelectionForSeries}</li>
  * </ul>
  *
  * <h2>Window collaborators</h2>
@@ -118,7 +118,7 @@ public class RunManager extends JFrame {
     // === DATA SOURCE TREE (left-top) ===
     // Shows: Last run, Current runs, Run library, Loaded datasets
     // Selection triggers rebuild of timeseries tree
-    private JTree timeseriesSourceTree;
+    private JCheckboxTree timeseriesSourceTree;
     private DefaultTreeModel treeModel;
     private DefaultMutableTreeNode rootNode;
     private DefaultMutableTreeNode lastRunNode;
@@ -129,7 +129,7 @@ public class RunManager extends JFrame {
     // === TIMESERIES TREE (left-bottom) ===
     // Shows hierarchical output series from selected sources
     // Selection triggers data fetching and plotting
-    private JTree timeseriesTree;
+    private JCheckboxTree timeseriesTree;
     private DefaultTreeModel timeseriesTreeModel;
     private JScrollPane timeseriesScrollPane;
 
@@ -304,7 +304,7 @@ public class RunManager extends JFrame {
         rootNode.add(loadedDatasetsNode);
 
         treeModel = new DefaultTreeModel(rootNode);
-        timeseriesSourceTree = new JTree(treeModel) {
+        timeseriesSourceTree = new JCheckboxTree(treeModel) {
             @Override
             public String getToolTipText(MouseEvent evt) {
                 if (getRowForLocation(evt.getX(), evt.getY()) == -1) {
@@ -343,8 +343,9 @@ public class RunManager extends JFrame {
         timeseriesSourceTree.expandPath(new TreePath(libraryNode.getPath()));
         timeseriesSourceTree.expandPath(new TreePath(loadedDatasetsNode.getPath()));
 
-        // Add tree selection listener to update details panel with outputs
-        timeseriesSourceTree.addTreeSelectionListener(this::onRunTreeSelectionChanged);
+        // Add checked-state listener to update details panel with outputs. Plain tree
+        // selection (mouse focus / right-click target) is deliberately left alone here.
+        timeseriesSourceTree.addCheckChangeListener(this::onSourceTreeCheckedChanged);
 
         // Initialize visualization components
         createDetailsComponents();
@@ -354,7 +355,7 @@ public class RunManager extends JFrame {
         // Create timeseries tree
         DefaultMutableTreeNode outputsRootNode = new DefaultMutableTreeNode("Outputs");
         timeseriesTreeModel = new DefaultTreeModel(outputsRootNode);
-        timeseriesTree = new JTree(timeseriesTreeModel);
+        timeseriesTree = new JCheckboxTree(timeseriesTreeModel);
         timeseriesTree.setRootVisible(false);
         timeseriesTree.setShowsRootHandles(true);
         timeseriesTree.setCellRenderer(new OutputsTreeCellRenderer());
@@ -362,8 +363,8 @@ public class RunManager extends JFrame {
         // Enable multiple selection for the timeseries tree to allow plotting multiple series
         timeseriesTree.getSelectionModel().setSelectionMode(TreeSelectionModel.DISCONTIGUOUS_TREE_SELECTION);
 
-        // Add selection listener to fetch timeseries data for leaf nodes and update plot
-        timeseriesTree.addTreeSelectionListener(this::onOutputsTreeSelectionChanged);
+        // Add checked-state listener to fetch timeseries data for leaf nodes and update plot
+        timeseriesTree.addCheckChangeListener(this::onOutputsTreeCheckedChanged);
 
         timeseriesScrollPane = new JScrollPane(timeseriesTree);
 
@@ -735,7 +736,7 @@ public class RunManager extends JFrame {
      * Recursively searches tree nodes for matching series keys and collects their paths.
      */
     private void searchAndCollectPaths(DefaultMutableTreeNode node,
-                                        Set<com.kalix.ide.flowviz.data.SeriesRef> targetRefs,
+                                        Set<SeriesRef> targetRefs,
                                         List<TreePath> results) {
         if (node == null) return;
 
@@ -743,7 +744,7 @@ public class RunManager extends JFrame {
 
         // Check if this is a SeriesLeafNode that maps to one of our target refs
         if (userObject instanceof OutputsTreeBuilder.SeriesLeafNode leaf) {
-            com.kalix.ide.flowviz.data.SeriesRef ref = seriesRefForLeaf(leaf);
+            SeriesRef ref = seriesRefForLeaf(leaf);
             if (ref != null && targetRefs.contains(ref)) {
                 TreePath path = new TreePath(node.getPath());
                 results.add(path);
@@ -758,22 +759,22 @@ public class RunManager extends JFrame {
     }
 
     /**
-     * Constructs the {@link com.kalix.ide.flowviz.data.SeriesRef} that identifies the
+     * Constructs the {@link SeriesRef} that identifies the
      * data behind a {@link OutputsTreeBuilder.SeriesLeafNode}. The leaf still carries
      * the legacy {@code source} object (RunInfoImpl or LoadedDatasetInfo) plus
      * {@code seriesName} — this helper produces the typed ref from that pair.
      * Will move onto the leaf itself when OutputsTreeBuilder is migrated.
      */
-    private com.kalix.ide.flowviz.data.SeriesRef seriesRefForLeaf(OutputsTreeBuilder.SeriesLeafNode leaf) {
+    private SeriesRef seriesRefForLeaf(OutputsTreeBuilder.SeriesLeafNode leaf) {
         return leaf.ref;
     }
 
     /**
-     * Constructs the {@link com.kalix.ide.flowviz.data.SeriesRef} for a (seriesName, source)
+     * Constructs the {@link SeriesRef} for a (seriesName, source)
      * pair. Used by {@link OutputsTreeBuilder} when building leaves and parents — the
      * resulting ref is cached on the leaf so subsequent lookups don't re-project.
      */
-    private com.kalix.ide.flowviz.data.SeriesRef refForSource(String seriesName, Object source) {
+    private SeriesRef refForSource(String seriesName, Object source) {
         if (source instanceof RunInfoImpl runInfo) {
             if (runInfo.isLastAlias()) {
                 return new com.kalix.ide.flowviz.data.LastSeries(seriesName);
@@ -787,40 +788,36 @@ public class RunManager extends JFrame {
     }
 
     /**
-     * Restores tree selection to match the given series set.
-     * This ensures the tree visually reflects what's plotted, even after tree rebuilds.
+     * Restores checked state to match the given series set.
+     * This ensures the tree visually reflects what's plotted, even after tree rebuilds
+     * (rebuilds reset checked state, since old TreePaths reference discarded nodes).
      * Returns the set of series that were successfully restored (found in the tree).
      *
-     * @param seriesToRestore The set of series keys to select in the tree
+     * @param seriesToRestore The set of series keys to check in the tree
      */
-    Set<com.kalix.ide.flowviz.data.SeriesRef> restoreTreeSelectionForSeries(
-            Set<com.kalix.ide.flowviz.data.SeriesRef> seriesToRestore) {
+    Set<SeriesRef> restoreTreeSelectionForSeries(
+            Set<SeriesRef> seriesToRestore) {
         if (seriesToRestore.isEmpty()) {
-            timeseriesTree.clearSelection();
+            timeseriesTree.setCheckedPaths(Collections.emptyList());
             return Collections.emptySet();
         }
 
-        List<TreePath> pathsToSelect = new ArrayList<>();
-        Set<com.kalix.ide.flowviz.data.SeriesRef> restoredRefs = new HashSet<>();
+        List<TreePath> pathsToCheck = new ArrayList<>();
+        Set<SeriesRef> restoredRefs = new HashSet<>();
         DefaultMutableTreeNode root = (DefaultMutableTreeNode) timeseriesTreeModel.getRoot();
 
         // Search tree for nodes matching the ref set, collect which ones we found
-        for (com.kalix.ide.flowviz.data.SeriesRef ref : seriesToRestore) {
+        for (SeriesRef ref : seriesToRestore) {
             List<TreePath> foundPaths = new ArrayList<>();
             searchAndCollectPaths(root, Collections.singleton(ref), foundPaths);
             if (!foundPaths.isEmpty()) {
-                pathsToSelect.addAll(foundPaths);
+                pathsToCheck.addAll(foundPaths);
                 restoredRefs.add(ref);
             }
         }
 
-        if (!pathsToSelect.isEmpty()) {
-            // Note: Caller should have isUpdatingSelection set to block events
-            TreePath[] pathsArray = pathsToSelect.toArray(new TreePath[0]);
-            timeseriesTree.setSelectionPaths(pathsArray);
-        } else {
-            timeseriesTree.clearSelection();
-        }
+        // Note: Caller should have isUpdatingSelection set to block events
+        timeseriesTree.setCheckedPaths(pathsToCheck);
 
         return restoredRefs;
     }
@@ -829,10 +826,10 @@ public class RunManager extends JFrame {
      * Reconciles the target tab's selected series with what's actually available in the tree.
      * Removes series from the tab that couldn't be restored (e.g., when a run is deselected).
      */
-    void reconcileSelectedSeriesWithTree(Set<com.kalix.ide.flowviz.data.SeriesRef> restoredSeries,
-                                                  Set<com.kalix.ide.flowviz.data.SeriesRef> tabSeries) {
+    void reconcileSelectedSeriesWithTree(Set<SeriesRef> restoredSeries,
+                                                  Set<SeriesRef> tabSeries) {
         // Find series that need to be removed from the tab
-        Set<com.kalix.ide.flowviz.data.SeriesRef> seriesToRemove = new HashSet<>(tabSeries);
+        Set<SeriesRef> seriesToRemove = new HashSet<>(tabSeries);
         seriesToRemove.removeAll(restoredSeries);
 
         if (seriesToRemove.isEmpty()) {
@@ -840,12 +837,12 @@ public class RunManager extends JFrame {
         }
 
         // Update the target tab's series (remove unrestorable ones)
-        Set<com.kalix.ide.flowviz.data.SeriesRef> updatedSeries = new LinkedHashSet<>(tabSeries);
+        Set<SeriesRef> updatedSeries = new LinkedHashSet<>(tabSeries);
         updatedSeries.removeAll(seriesToRemove);
         tabManager.setTargetTabSelectedSeries(updatedSeries);
 
         // Remove from stats tables
-        for (com.kalix.ide.flowviz.data.SeriesRef ref : seriesToRemove) {
+        for (SeriesRef ref : seriesToRemove) {
             tabManager.removeSeriesFromStatsTabs(ref);
         }
     }
@@ -874,21 +871,21 @@ public class RunManager extends JFrame {
     // Identity is the typed SeriesRef; baseName comes from ref.baseName().
 
     /**
-     * Handles tree selection changes to update the timeseries tree.
+     * Handles data-source-tree checked-state changes to update the timeseries tree.
      */
-    private void onRunTreeSelectionChanged(TreeSelectionEvent e) {
-        // Ignore selection changes during programmatic updates
+    private void onSourceTreeCheckedChanged() {
+        // Ignore checked-state changes during programmatic updates
         if (fetchCoordinator.isUpdatingSelection()) {
             return;
         }
 
-        // Block timeseries tree selection events during rebuild and restoration
+        // Block timeseries tree checked-state events during rebuild and restoration
         fetchCoordinator.setUpdatingSelection(true);
         updateOutputsTree();
 
-        // Restore visual selection to match what's currently plotted on active tab
-        Set<com.kalix.ide.flowviz.data.SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-        Set<com.kalix.ide.flowviz.data.SeriesRef> restoredSeries = restoreTreeSelectionForSeries(tabSeries);
+        // Restore checked state to match what's currently plotted on active tab
+        Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
+        Set<SeriesRef> restoredSeries = restoreTreeSelectionForSeries(tabSeries);
         reconcileSelectedSeriesWithTree(restoredSeries, tabSeries);
 
         fetchCoordinator.setUpdatingSelection(false);
@@ -913,53 +910,48 @@ public class RunManager extends JFrame {
      * Updates the timeseries tree based on current run tree selection.
      */
     void updateOutputsTree() {
-        TreePath[] selectedPaths = timeseriesSourceTree.getSelectionPaths();
-        if (selectedPaths == null || selectedPaths.length == 0) {
+        TreePath[] checkedPaths = timeseriesSourceTree.getCheckedPaths();
+        if (checkedPaths == null || checkedPaths.length == 0) {
             outputsTreeBuilder.showEmptyTree(OutputsTreeBuilder.SELECT_SOURCES_MESSAGE);
             return;
         }
 
         // Collect all selected RunInfo and LoadedDatasetInfo objects
-        List<Object> selectedRuns = new ArrayList<>();
-        List<Object> selectedDatasets = new ArrayList<>();
+        List<Object> checkedRuns = new ArrayList<>();
+        List<Object> checkedDatasets = new ArrayList<>();
 
-        for (TreePath path : selectedPaths) {
+        for (TreePath path : checkedPaths) {
             DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
             Object userObject = node.getUserObject();
 
             if (userObject instanceof RunContextMenuManager.RunInfo) {
-                selectedRuns.add(userObject);
+                checkedRuns.add(userObject);
             } else if (userObject instanceof DatasetLoaderManager.LoadedDatasetInfo) {
-                selectedDatasets.add(userObject);
+                checkedDatasets.add(userObject);
             }
         }
 
-        if (selectedRuns.isEmpty() && selectedDatasets.isEmpty()) {
+        if (checkedRuns.isEmpty() && checkedDatasets.isEmpty()) {
             outputsTreeBuilder.showEmptyTree(OutputsTreeBuilder.SELECT_SOURCES_MESSAGE);
         } else {
-            outputsTreeBuilder.updateTree(selectedRuns, selectedDatasets);
+            outputsTreeBuilder.updateTree(checkedRuns, checkedDatasets);
         }
     }
 
-
-    // renameTimeSeriesData removed — TimeSeriesData no longer carries identity, so
-    // there's no rename operation. The pool stores (ref, data) pairs and the same
-    // TimeSeriesData instance can sit under any ref.
-
     /**
-     * Handles selection changes in the timeseries tree. Delegates to
-     * {@link SeriesFetchCoordinator#onOutputsTreeSelectionChanged}.
+     * Handles checked-state changes in the timeseries tree. Delegates to
+     * {@link SeriesFetchCoordinator#onOutputsTreeCheckedChanged}.
      */
-    private void onOutputsTreeSelectionChanged(TreeSelectionEvent e) {
-        fetchCoordinator.onOutputsTreeSelectionChanged(e);
+    private void onOutputsTreeCheckedChanged() {
+        fetchCoordinator.onOutputsTreeCheckedChanged();
     }
 
     /**
-     * Adds a series to the shared data pool under the given {@link com.kalix.ide.flowviz.data.SeriesRef}.
+     * Adds a series to the shared data pool under the given {@link SeriesRef}.
      * The data's legacy name field is ignored — identity comes from the ref.
      * Legend and visibility are managed per-tab via VisualizationTabManager.
      */
-    void addSeriesToPool(com.kalix.ide.flowviz.data.SeriesRef ref, TimeSeriesData timeSeriesData) {
+    void addSeriesToPool(SeriesRef ref, TimeSeriesData timeSeriesData) {
         plotDataSet.addSeries(ref, timeSeriesData);
     }
 
@@ -976,7 +968,7 @@ public class RunManager extends JFrame {
         String absPath = info.file.getAbsolutePath();
 
         // Collect all DatasetSeries refs that belong to this dataset.
-        List<com.kalix.ide.flowviz.data.SeriesRef> refs = new ArrayList<>();
+        List<SeriesRef> refs = new ArrayList<>();
         for (com.kalix.ide.flowviz.data.DatasetSeries dsRef : datasetSeriesCache.keySet()) {
             if (dsRef.datasetId().equals(absPath)) {
                 refs.add(dsRef);
@@ -984,7 +976,7 @@ public class RunManager extends JFrame {
         }
 
         // Drop them from the shared pool, the per-context cache, and slot assignment.
-        for (com.kalix.ide.flowviz.data.SeriesRef ref : refs) {
+        for (SeriesRef ref : refs) {
             plotDataSet.removeSeries(ref);
             seriesSlotManager.removeSlot(ref);
         }
@@ -1018,7 +1010,7 @@ public class RunManager extends JFrame {
         // Nothing to sync during construction (the tree is empty), so bail out early.
         if (fetchCoordinator == null) return;
 
-        Set<com.kalix.ide.flowviz.data.SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
+        Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
         if (tabSeries == null) return;
 
         fetchCoordinator.setUpdatingSelection(true);

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -92,7 +92,7 @@ import java.util.function.Consumer;
  *   <li>Per-tab selected series AND per-tab checked sources stored in
  *       {@link VisualizationTabManager} TabInfo — a tab is a complete view (sources +
  *       series + plot settings), restored as a whole by {@link #onTabChanged}</li>
- *   <li>{@link SeriesFetchCoordinator#isUpdatingSelection()} - Guard to prevent listener
+ *   <li>{@link SeriesFetchCoordinator#isProgrammaticUpdate()} - Guard to prevent listener
  *       feedback loops during programmatic updates</li>
  *   <li>Checked state (what's plotted) is separate from plain tree selection (row highlight);
  *       checked state is restored after rebuilds via {@link #restoreTreeChecksForSeries}</li>
@@ -826,7 +826,7 @@ public class RunManager extends JFrame {
             }
         }
 
-        // Note: Caller should have isUpdatingSelection set to block events
+        // Note: Callers run inside a programmatic-update section to block events
         timeseriesTree.setCheckedPaths(pathsToCheck);
 
         return restoredRefs;
@@ -882,7 +882,7 @@ public class RunManager extends JFrame {
      */
     private void onSourceTreeCheckedChanged() {
         // Ignore checked-state changes during programmatic updates
-        if (fetchCoordinator.isUpdatingSelection()) {
+        if (fetchCoordinator.isProgrammaticUpdate()) {
             return;
         }
 
@@ -891,15 +891,17 @@ public class RunManager extends JFrame {
         snapshotSourceChecksToTargetTab();
 
         // Block timeseries tree checked-state events during rebuild and restoration
-        fetchCoordinator.setUpdatingSelection(true);
-        updateOutputsTree();
+        fetchCoordinator.beginProgrammaticUpdate();
+        try {
+            updateOutputsTree();
 
-        // Restore checked state to match what's currently plotted on active tab
-        Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-        Set<SeriesRef> restoredSeries = restoreTreeChecksForSeries(tabSeries);
-        reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
-
-        fetchCoordinator.setUpdatingSelection(false);
+            // Restore checked state to match what's currently plotted on active tab
+            Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
+            Set<SeriesRef> restoredSeries = restoreTreeChecksForSeries(tabSeries);
+            reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
+        } finally {
+            fetchCoordinator.endProgrammaticUpdate();
+        }
     }
 
     /**
@@ -907,13 +909,13 @@ public class RunManager extends JFrame {
      * applied. Purely visual - does NOT change selection or affect plots.
      */
     private void onFilterTextChanged() {
-        fetchCoordinator.setUpdatingSelection(true);
+        fetchCoordinator.beginProgrammaticUpdate();
         try {
             outputsTreeBuilder.setFilterText(treeFilterManager.getFilterText());
             updateOutputsTree();
             restoreTreeChecksForSeries(tabManager.getTargetTabSelectedSeries());
         } finally {
-            fetchCoordinator.setUpdatingSelection(false);
+            fetchCoordinator.endProgrammaticUpdate();
         }
     }
 
@@ -1048,12 +1050,12 @@ public class RunManager extends JFrame {
     }
 
     /**
-     * Records the currently checked sources on the target tab. Called whenever the
-     * user changes the source checks, and from programmatic check changes that run
-     * under the isUpdatingSelection guard (e.g. {@link RunTreeController#selectRun})
-     * where {@link #onSourceTreeCheckedChanged} won't fire.
+     * Records the currently checked sources on the target tab. Called from
+     * {@link #onSourceTreeCheckedChanged} — i.e. whenever the checked set genuinely
+     * changes — and nowhere else: recording must stay tied to check <em>changes</em>,
+     * never to restore paths like {@link #onTabChanged}.
      */
-    void snapshotSourceChecksToTargetTab() {
+    private void snapshotSourceChecksToTargetTab() {
         tabManager.setTargetTabCheckedSources(currentCheckedSourceRefs());
     }
 
@@ -1088,10 +1090,17 @@ public class RunManager extends JFrame {
     }
 
     /**
-     * Called when the user switches tabs. Restores the new active tab's full context:
-     * first the data-source checks (rebuilding the outputs tree for that context),
-     * then the series checks. A tab is a complete view — sources + series + plot
-     * settings — so switching tabs swaps the whole left panel to match.
+     * Called when the user switches tabs. Restores the new active tab's recorded context
+     * verbatim: first the data-source checks (rebuilding the outputs tree for that
+     * context), then the series checks. A tab is a complete view — sources + series +
+     * plot settings — so switching tabs swaps the whole left panel to match; an empty
+     * tab restores an empty panel.
+     *
+     * <p>This is strictly a <em>read</em> of tab state — it must never write any tab's
+     * recorded context. (An earlier "unconfigured tabs adopt the current context"
+     * heuristic wrote to the incoming tab here, which silently copied one tab's sources
+     * onto another on every switch. Restore paths that also record state are how tabs
+     * cross-contaminate; don't reintroduce one.)</p>
      */
     private void onTabChanged() {
         // Adding the default tabs in createDetailsComponents() auto-selects the first tab,
@@ -1102,22 +1111,17 @@ public class RunManager extends JFrame {
         Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
         Set<SourceRef> tabSources = tabManager.getTargetTabCheckedSources();
 
-        fetchCoordinator.setUpdatingSelection(true);
+        fetchCoordinator.beginProgrammaticUpdate();
         try {
-            if (tabSources.isEmpty() && tabSeries.isEmpty()) {
-                // Unconfigured tab (e.g. a startup default tab the user hasn't touched):
-                // adopt the current source context rather than clearing it, so a fresh
-                // tab starts where the user is.
-                snapshotSourceChecksToTargetTab();
-            } else if (!tabSources.equals(currentCheckedSourceRefs())) {
-                // Same context → skip the rebuild: no outputs-tree churn when flicking
-                // between tabs that look at the same sources.
+            // Skip the rebuild when the contexts are identical: no outputs-tree churn
+            // when flicking between tabs that look at the same sources.
+            if (!tabSources.equals(currentCheckedSourceRefs())) {
                 timeseriesSourceTree.setCheckedPaths(pathsForSourceRefs(tabSources));
                 updateOutputsTree();
             }
             restoreTreeChecksForSeries(tabSeries);
         } finally {
-            fetchCoordinator.setUpdatingSelection(false);
+            fetchCoordinator.endProgrammaticUpdate();
         }
     }
 }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -378,7 +378,7 @@ class RunTreeController {
                 // Select and check the run
                 fetchCoordinator.setUpdatingSelection(true);
                 timeseriesSourceTree.setSelectionPath(pathToRun);
-                timeseriesSourceTree.setCheckedPaths(java.util.List.of(pathToRun));
+                timeseriesSourceTree.addCheckedPaths(java.util.List.of(pathToRun));
                 fetchCoordinator.setUpdatingSelection(false);
 
                 // Scroll to make the selection visible

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -5,6 +5,7 @@ import com.kalix.ide.cli.SessionManager;
 import com.kalix.ide.components.JCheckboxTree;
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.data.RunSeries;
+import com.kalix.ide.flowviz.data.RunSource;
 import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.flowviz.style.SeriesSlotManager;
 import com.kalix.ide.managers.RunContextMenuManager;
@@ -388,6 +389,9 @@ class RunTreeController {
                 try {
                     timeseriesSourceTree.setSelectionPath(pathToRun);
                     timeseriesSourceTree.addCheckedPaths(java.util.List.of(pathToRun));
+                    // The guard suppresses onSourceTreeCheckedChanged, so record the new
+                    // source context on the target tab explicitly.
+                    window.snapshotSourceChecksToTargetTab();
                     window.updateOutputsTree();
                     Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
                     Set<SeriesRef> restoredSeries = window.restoreTreeChecksForSeries(tabSeries);
@@ -429,6 +433,10 @@ class RunTreeController {
         if (!refs.isEmpty()) {
             tabManager.removeSeriesFromAllTabs(refs);
         }
+
+        // Forget the run from every tab's recorded source context — runIds are never
+        // reused, so no tab should try to restore this source again.
+        tabManager.removeSourceFromAllTabs(new RunSource(runId));
 
         // Clear by UID, not session key: the session has already left the session
         // manager, so key-based lookup cannot reach these entries any more.

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -242,7 +242,10 @@ class RunTreeController {
             if (!removedIndices.isEmpty()) {
                 // Remove nodes from tree
                 for (Object child : removedChildren) {
-                    currentRunsNode.remove((DefaultMutableTreeNode) child);
+                    var node = (DefaultMutableTreeNode) child;
+                    var path = node.getPath();
+                    timeseriesSourceTree.removePath(new TreePath(path));
+                    currentRunsNode.remove(node);
                 }
 
                 // Clean up tracking maps (single-shot removal via the bookkeeping)

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -378,17 +378,26 @@ class RunTreeController {
                 // Expand parent nodes to make the run visible
                 timeseriesSourceTree.expandPath(new TreePath(currentRunsNode.getPath()));
 
-                // Select and check the run
+                // Select and check the run, then rebuild the outputs tree. The rebuild
+                // (reload) wipes the outputs tree's checked state, and checked state is
+                // the source of truth for what's plotted - so restore checks for the
+                // target tab's series and reconcile, exactly as onSourceTreeCheckedChanged
+                // does. Without the restore, the next user check-click would silently
+                // replace the tab's series with only the visibly-checked ones.
                 fetchCoordinator.setUpdatingSelection(true);
-                timeseriesSourceTree.setSelectionPath(pathToRun);
-                timeseriesSourceTree.addCheckedPaths(java.util.List.of(pathToRun));
-                fetchCoordinator.setUpdatingSelection(false);
+                try {
+                    timeseriesSourceTree.setSelectionPath(pathToRun);
+                    timeseriesSourceTree.addCheckedPaths(java.util.List.of(pathToRun));
+                    window.updateOutputsTree();
+                    Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
+                    Set<SeriesRef> restoredSeries = window.restoreTreeChecksForSeries(tabSeries);
+                    window.reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
+                } finally {
+                    fetchCoordinator.setUpdatingSelection(false);
+                }
 
                 // Scroll to make the selection visible
                 timeseriesSourceTree.scrollPathToVisible(pathToRun);
-
-                // Update timeseries tree
-                window.updateOutputsTree();
             }
         });
     }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -348,13 +348,13 @@ class RunTreeController {
         // the new RunInfoImpl (the leaf display via toString() picks up the new run name);
         // and (b) trigger a repaint so any text surfaces that aren't actively reading the
         // resolver see the update.
-        fetchCoordinator.setUpdatingSelection(true);
+        fetchCoordinator.beginProgrammaticUpdate();
         try {
             window.updateOutputsTree();
             Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
             window.restoreTreeChecksForSeries(tabSeries);
         } finally {
-            fetchCoordinator.setUpdatingSelection(false);
+            fetchCoordinator.endProgrammaticUpdate();
         }
 
         // Cheap repaint to pick up the new label in plot legends / stats column headers
@@ -366,9 +366,11 @@ class RunTreeController {
 
     /**
      * Selects and checks the run associated with the given sessionKey, so its outputs are
-     * shown. This will expand the tree, select the run node (for visual focus), and check
-     * it (so {@link RunManager#updateOutputsTree} - which reads checked, not selected,
-     * paths - picks it up) if found.
+     * shown. Expands the tree, selects the run node (visual focus only — selection drives
+     * nothing), and checks it. The check goes through the normal check-change event, so
+     * {@code RunManager.onSourceTreeCheckedChanged} does everything a user click would:
+     * snapshot the tab's source context, rebuild the outputs tree, restore and reconcile
+     * the tab's series checks. One code path, deliberately not mirrored here.
      */
     void selectRun(String sessionKey) {
         SwingUtilities.invokeLater(() -> {
@@ -379,26 +381,8 @@ class RunTreeController {
                 // Expand parent nodes to make the run visible
                 timeseriesSourceTree.expandPath(new TreePath(currentRunsNode.getPath()));
 
-                // Select and check the run, then rebuild the outputs tree. The rebuild
-                // (reload) wipes the outputs tree's checked state, and checked state is
-                // the source of truth for what's plotted - so restore checks for the
-                // target tab's series and reconcile, exactly as onSourceTreeCheckedChanged
-                // does. Without the restore, the next user check-click would silently
-                // replace the tab's series with only the visibly-checked ones.
-                fetchCoordinator.setUpdatingSelection(true);
-                try {
-                    timeseriesSourceTree.setSelectionPath(pathToRun);
-                    timeseriesSourceTree.addCheckedPaths(java.util.List.of(pathToRun));
-                    // The guard suppresses onSourceTreeCheckedChanged, so record the new
-                    // source context on the target tab explicitly.
-                    window.snapshotSourceChecksToTargetTab();
-                    window.updateOutputsTree();
-                    Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-                    Set<SeriesRef> restoredSeries = window.restoreTreeChecksForSeries(tabSeries);
-                    window.reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
-                } finally {
-                    fetchCoordinator.setUpdatingSelection(false);
-                }
+                timeseriesSourceTree.setSelectionPath(pathToRun);
+                timeseriesSourceTree.addCheckedPaths(java.util.List.of(pathToRun));
 
                 // Scroll to make the selection visible
                 timeseriesSourceTree.scrollPathToVisible(pathToRun);

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -17,7 +17,6 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -349,7 +348,7 @@ class RunTreeController {
         try {
             window.updateOutputsTree();
             Set<SeriesRef> tabSeries = tabManager.getTargetTabSelectedSeries();
-            window.restoreTreeSelectionForSeries(tabSeries);
+            window.restoreTreeChecksForSeries(tabSeries);
         } finally {
             fetchCoordinator.setUpdatingSelection(false);
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunTreeController.java
@@ -2,6 +2,7 @@ package com.kalix.ide.windows;
 
 import com.kalix.ide.cli.RunModelProgram;
 import com.kalix.ide.cli.SessionManager;
+import com.kalix.ide.components.JCheckboxTree;
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.data.RunSeries;
 import com.kalix.ide.flowviz.data.SeriesRef;
@@ -11,7 +12,6 @@ import com.kalix.ide.managers.SessionTreeBookkeeping;
 import com.kalix.ide.managers.StdioTaskManager;
 import com.kalix.ide.managers.TimeSeriesRequestManager;
 
-import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
@@ -36,7 +36,7 @@ class RunTreeController {
 
     private final RunManager window;
     private final StdioTaskManager stdioTaskManager;
-    private final JTree timeseriesSourceTree;
+    private final JCheckboxTree timeseriesSourceTree;
     private final DefaultTreeModel treeModel;
     private final DefaultMutableTreeNode currentRunsNode;
     private final VisualizationTabManager tabManager;
@@ -54,7 +54,7 @@ class RunTreeController {
 
     RunTreeController(RunManager window,
                       StdioTaskManager stdioTaskManager,
-                      JTree timeseriesSourceTree,
+                      JCheckboxTree timeseriesSourceTree,
                       DefaultTreeModel treeModel,
                       DefaultMutableTreeNode currentRunsNode,
                       VisualizationTabManager tabManager,
@@ -202,9 +202,9 @@ class RunTreeController {
                             lastRunTracker.onRunCompleted(runInfo, completionTime);
                         }
 
-                        // Update outputs if this run is currently selected
-                        TreePath selectedPath = timeseriesSourceTree.getSelectionPath();
-                        if (selectedPath != null && selectedPath.getLastPathComponent() == existingNode) {
+                        // Update outputs if this run is currently checked
+                        TreePath existingPath = new TreePath(existingNode.getPath());
+                        if (timeseriesSourceTree.isPathChecked(existingPath)) {
                             window.updateOutputsTree();
                         }
                     }
@@ -362,8 +362,10 @@ class RunTreeController {
     }
 
     /**
-     * Selects the run associated with the given sessionKey.
-     * This will expand the tree and select the run node if found.
+     * Selects and checks the run associated with the given sessionKey, so its outputs are
+     * shown. This will expand the tree, select the run node (for visual focus), and check
+     * it (so {@link RunManager#updateOutputsTree} - which reads checked, not selected,
+     * paths - picks it up) if found.
      */
     void selectRun(String sessionKey) {
         SwingUtilities.invokeLater(() -> {
@@ -374,9 +376,10 @@ class RunTreeController {
                 // Expand parent nodes to make the run visible
                 timeseriesSourceTree.expandPath(new TreePath(currentRunsNode.getPath()));
 
-                // Select the run
+                // Select and check the run
                 fetchCoordinator.setUpdatingSelection(true);
                 timeseriesSourceTree.setSelectionPath(pathToRun);
+                timeseriesSourceTree.setCheckedPaths(java.util.List.of(pathToRun));
                 fetchCoordinator.setUpdatingSelection(false);
 
                 // Scroll to make the selection visible

--- a/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
@@ -37,10 +37,12 @@ import java.util.function.Supplier;
  * new selection against the target tab, probing caches, issuing async fetches, writing
  * results into the shared pool, and assigning palette slots.
  *
- * <p>Also owns the {@code isUpdatingSelection} guard used across the window to prevent
- * selection-listener feedback loops during programmatic tree updates: collaborators set
- * it to {@code true} before modifying tree selection and {@code false} after, and both
- * tree listeners consult it before reacting.</p>
+ * <p>Also owns the programmatic-update guard used across the window to prevent
+ * listener feedback loops during programmatic tree updates: collaborators bracket their
+ * tree mutations with {@link #beginProgrammaticUpdate()} / {@link #endProgrammaticUpdate()}
+ * (always in try/finally), and both tree listeners consult {@link #isProgrammaticUpdate()}
+ * before reacting. The guard is a depth counter, so nested programmatic sections are
+ * safe: an inner end cannot prematurely unblock the outer section.</p>
  */
 class SeriesFetchCoordinator {
 
@@ -64,9 +66,9 @@ class SeriesFetchCoordinator {
     /** Defers to {@link LastRunTracker#getLastRunInfo()} for resolving the Last alias. */
     private final Supplier<RunInfoImpl> lastRunInfoSupplier;
 
-    // Flag to prevent selection listener feedback loops during programmatic tree updates
-    // Set to true before modifying tree selection, false after
-    private boolean isUpdatingSelection = false;
+    // Depth of nested programmatic tree-update sections. Listeners stay suppressed while
+    // any section is open. A counter rather than a boolean so that nesting is safe.
+    private int programmaticUpdateDepth = 0;
 
     SeriesFetchCoordinator(RunManager window,
                            JCheckboxTree timeseriesTree,
@@ -95,13 +97,22 @@ class SeriesFetchCoordinator {
     }
 
     /** Returns whether a programmatic tree update is in progress. */
-    boolean isUpdatingSelection() {
-        return isUpdatingSelection;
+    boolean isProgrammaticUpdate() {
+        return programmaticUpdateDepth > 0;
     }
 
-    /** Sets the programmatic-update guard. Callers must clear it when done (try/finally). */
-    void setUpdatingSelection(boolean updating) {
-        this.isUpdatingSelection = updating;
+    /** Opens a programmatic-update section. Pair with {@link #endProgrammaticUpdate()} in a finally block. */
+    void beginProgrammaticUpdate() {
+        programmaticUpdateDepth++;
+    }
+
+    /** Closes a programmatic-update section opened by {@link #beginProgrammaticUpdate()}. */
+    void endProgrammaticUpdate() {
+        if (programmaticUpdateDepth <= 0) {
+            logger.warn("endProgrammaticUpdate() without matching begin — guard call sites are unbalanced");
+            return;
+        }
+        programmaticUpdateDepth--;
     }
 
     /**
@@ -111,7 +122,7 @@ class SeriesFetchCoordinator {
      */
     void onOutputsTreeCheckedChanged() {
         // Ignore checked-state changes during programmatic updates
-        if (isUpdatingSelection) {
+        if (isProgrammaticUpdate()) {
             return;
         }
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
@@ -1,6 +1,7 @@
 package com.kalix.ide.windows;
 
 import com.kalix.ide.cli.SessionManager;
+import com.kalix.ide.components.JCheckboxTree;
 import com.kalix.ide.flowviz.PlotPanel;
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.data.DatasetSeries;
@@ -16,15 +17,10 @@ import com.kalix.ide.managers.TreeFilterManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.JTree;
 import javax.swing.SwingUtilities;
-import javax.swing.event.TreeSelectionEvent;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
-import java.awt.AWTEvent;
-import java.awt.EventQueue;
-import java.awt.event.InputEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -51,7 +47,7 @@ class SeriesFetchCoordinator {
     private static final Logger logger = LoggerFactory.getLogger(SeriesFetchCoordinator.class);
 
     private final RunManager window;
-    private final JTree timeseriesTree;
+    private final JCheckboxTree timeseriesTree;
     private final DefaultTreeModel timeseriesTreeModel;
     private final TreeFilterManager treeFilterManager;
     private final OutputsTreeBuilder outputsTreeBuilder;
@@ -73,7 +69,7 @@ class SeriesFetchCoordinator {
     private boolean isUpdatingSelection = false;
 
     SeriesFetchCoordinator(RunManager window,
-                           JTree timeseriesTree,
+                           JCheckboxTree timeseriesTree,
                            DefaultTreeModel timeseriesTreeModel,
                            TreeFilterManager treeFilterManager,
                            OutputsTreeBuilder outputsTreeBuilder,
@@ -109,27 +105,27 @@ class SeriesFetchCoordinator {
     }
 
     /**
-     * Handles selection changes in the timeseries tree.
-     * Supports recursive selection: selecting a parent node plots all its leaf children.
+     * Handles checked-state changes in the timeseries tree.
+     * Supports recursive checking: checking a parent node plots all its leaf children.
      * Fetches timeseries data for leaf nodes and updates plot and stats.
      */
-    void onOutputsTreeSelectionChanged(TreeSelectionEvent e) {
-        // Ignore selection changes during programmatic updates
+    void onOutputsTreeCheckedChanged() {
+        // Ignore checked-state changes during programmatic updates
         if (isUpdatingSelection) {
             return;
         }
 
-        TreePath[] selectedPaths = timeseriesTree.getSelectionPaths();
+        TreePath[] checkedPaths = timeseriesTree.getCheckedPaths();
 
-        if (selectedPaths == null || selectedPaths.length == 0) {
-            // Clear the target tab's series when nothing is selected
+        if (checkedPaths == null || checkedPaths.length == 0) {
+            // Clear the target tab's series when nothing is checked
             tabManager.setTargetTabSelectedSeries(new LinkedHashSet<>());
             return;
         }
 
-        // Collect all leaf nodes recursively (parent selection = all children)
+        // Collect all leaf nodes recursively (parent checked = all children)
         List<OutputsTreeBuilder.SeriesLeafNode> allLeaves = new ArrayList<>();
-        for (TreePath path : selectedPaths) {
+        for (TreePath path : checkedPaths) {
             DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
             collectLeafNodes(node, allLeaves);
         }
@@ -140,7 +136,7 @@ class SeriesFetchCoordinator {
             return;
         }
 
-        // Build new set of selected series, ref-keyed directly from the leaves
+        // Build new set of checked series, ref-keyed directly from the leaves
         Set<SeriesRef> newSelectedSeries = new LinkedHashSet<>();
         Map<SeriesRef, OutputsTreeBuilder.SeriesLeafNode> refToLeaf = new HashMap<>();
 
@@ -154,8 +150,8 @@ class SeriesFetchCoordinator {
         // Get the target tab's current series for diffing
         Set<SeriesRef> currentTabSeries = tabManager.getTargetTabSelectedSeries();
 
-        // When filtering with an additive click, preserve series hidden by the filter
-        if (treeFilterManager.isFiltering() && isAdditiveSelectionEvent()) {
+        // Preserve series hidden by filter.
+        if (treeFilterManager.isFiltering()) {
             Set<SeriesRef> visibleRefs = getVisibleSeriesKeys();
             for (SeriesRef ref : currentTabSeries) {
                 if (!visibleRefs.contains(ref)) {
@@ -328,22 +324,6 @@ class SeriesFetchCoordinator {
             return lastRunInfo.getSession();
         }
         return runInfo.getSession();
-    }
-
-    /**
-     * Checks whether the event currently being dispatched is an additive selection gesture
-     * (Cmd/Ctrl/Shift held). Uses EventQueue.getCurrentEvent() so that this works correctly
-     * even when called from a TreeSelectionListener (which fires during the UI delegate's
-     * mouse handler, before any separately registered MouseListeners).
-     */
-    private boolean isAdditiveSelectionEvent() {
-        AWTEvent event = EventQueue.getCurrentEvent();
-        if (event instanceof InputEvent inputEvent) {
-            int modifiers = inputEvent.getModifiersEx()
-                    & (InputEvent.SHIFT_DOWN_MASK | InputEvent.CTRL_DOWN_MASK | InputEvent.META_DOWN_MASK);
-            return modifiers != 0;
-        }
-        return false;
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
@@ -117,7 +117,7 @@ class SeriesFetchCoordinator {
 
         TreePath[] checkedPaths = timeseriesTree.getCheckedPaths();
 
-        if (checkedPaths == null || checkedPaths.length == 0) {
+        if (checkedPaths.length == 0) {
             // Clear the target tab's series when nothing is checked
             tabManager.setTargetTabSelectedSeries(new LinkedHashSet<>());
             return;

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -183,9 +183,8 @@ public class VisualizationTabManager {
         final Set<SeriesRef> selectedSeries = new LinkedHashSet<>();
 
         // Per-tab checked data sources — the source-tree context this tab was built in.
-        // Restored (with the series checks) when the tab becomes active, so a tab is a
-        // complete view: sources + series + plot settings. Empty on a fresh tab means
-        // "unconfigured": the tab adopts the current source context instead of clearing it.
+        // Restored verbatim (with the series checks) when the tab becomes active, so a
+        // tab is a complete view: sources + series + plot settings. Empty restores empty.
         final Set<SourceRef> checkedSources = new LinkedHashSet<>();
 
         // Aggregation settings for stats tabs
@@ -822,7 +821,7 @@ public class VisualizationTabManager {
     /**
      * Resolves the source context a new tab should start with: from the settings if
      * recorded there (duplication), otherwise the active tab's (fresh tab created while
-     * another is showing), otherwise empty (startup default tabs — "unconfigured").
+     * another is showing), otherwise empty (startup default tabs).
      */
     private Set<SourceRef> inheritedSources(TabSettings settings) {
         if (settings.checkedSources != null) {

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -113,6 +113,10 @@ public class VisualizationTabManager {
         public boolean autoYMode = true;
         public boolean showCoordinates = false;
         public boolean legendCollapsed = false;
+        // Missing-data handling (context menu > Missing data). Mutually exclusive; both
+        // false = default "break at gaps".
+        public boolean connectAcrossGaps = false;
+        public boolean showOrphanMarkers = false;
 
         // Series selection from source tab (null = inherit from active tab)
         public Set<SeriesRef> selectedSeries = null;
@@ -136,6 +140,8 @@ public class VisualizationTabManager {
             settings.autoYMode = plotPanel.isAutoYMode();
             settings.showCoordinates = plotPanel.isShowCoordinates();
             settings.legendCollapsed = plotPanel.isLegendCollapsed();
+            settings.connectAcrossGaps = plotPanel.isConnectAcrossGaps();
+            settings.showOrphanMarkers = plotPanel.isShowOrphanMarkers();
             settings.selectedSeries = new LinkedHashSet<>(tabInfo.selectedSeries);
             settings.checkedSources = new LinkedHashSet<>(tabInfo.checkedSources);
             settings.sourcePlotPanel = plotPanel;
@@ -315,6 +321,11 @@ public class VisualizationTabManager {
         plotPanel.setYAxisScale(settings.yAxisScale);
         plotPanel.setAutoYMode(settings.autoYMode);
         plotPanel.setShowCoordinates(settings.showCoordinates);
+        // Order matters: setConnectAcrossGaps(true) clears orphan markers and vice versa,
+        // so apply connect first — for every valid (mutually exclusive) combination the
+        // net result matches the source tab.
+        plotPanel.setConnectAcrossGaps(settings.connectAcrossGaps);
+        plotPanel.setShowOrphanMarkers(settings.showOrphanMarkers);
         if (settings.legendCollapsed) {
             plotPanel.setLegendCollapsed(true);
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -5,6 +5,7 @@ import com.kalix.ide.flowviz.PlotPanel;
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.data.LabelResolver;
 import com.kalix.ide.flowviz.data.SeriesRef;
+import com.kalix.ide.flowviz.data.SourceRef;
 import com.kalix.ide.flowviz.data.TimeSeriesData;
 import com.kalix.ide.flowviz.style.SeriesStyleResolver;
 import com.kalix.ide.flowviz.models.StatsTableModel;
@@ -64,8 +65,9 @@ import java.util.Set;
  * from another plot tab also inherit the full undo/redo state history.
  *
  * <h2>Tab Change Sync</h2>
- * When the user switches tabs, a callback notifies RunManager to update the timeseries
- * tree selection to match the new tab's selected series.
+ * When the user switches tabs, a callback notifies RunManager to restore the new tab's
+ * full context: its checked data sources (each tab remembers the source-tree context it
+ * was built in, as stable {@link SourceRef}s) and then its series checks.
  *
  * @see PlotPanel
  * @see com.kalix.ide.windows.RunManager#addSeriesToPool
@@ -115,6 +117,9 @@ public class VisualizationTabManager {
         // Series selection from source tab (null = inherit from active tab)
         public Set<SeriesRef> selectedSeries = null;
 
+        // Checked data sources from source tab (null = inherit from active tab)
+        public Set<SourceRef> checkedSources = null;
+
         // Source plot panel for history duplication (null = no history to copy)
         public PlotPanel sourcePlotPanel = null;
 
@@ -132,6 +137,7 @@ public class VisualizationTabManager {
             settings.showCoordinates = plotPanel.isShowCoordinates();
             settings.legendCollapsed = plotPanel.isLegendCollapsed();
             settings.selectedSeries = new LinkedHashSet<>(tabInfo.selectedSeries);
+            settings.checkedSources = new LinkedHashSet<>(tabInfo.checkedSources);
             settings.sourcePlotPanel = plotPanel;
             return settings;
         }
@@ -144,6 +150,7 @@ public class VisualizationTabManager {
             settings.aggregationPeriod = statsTabInfo.statsPeriod;
             settings.aggregationMethod = statsTabInfo.statsMethod;
             settings.selectedSeries = new LinkedHashSet<>(statsTabInfo.selectedSeries);
+            settings.checkedSources = new LinkedHashSet<>(statsTabInfo.checkedSources);
             return settings;
         }
 
@@ -174,6 +181,12 @@ public class VisualizationTabManager {
 
         // Per-tab selected series (plot tabs only). Preserves insertion order for legend consistency.
         final Set<SeriesRef> selectedSeries = new LinkedHashSet<>();
+
+        // Per-tab checked data sources — the source-tree context this tab was built in.
+        // Restored (with the series checks) when the tab becomes active, so a tab is a
+        // complete view: sources + series + plot settings. Empty on a fresh tab means
+        // "unconfigured": the tab adopts the current source context instead of clearing it.
+        final Set<SourceRef> checkedSources = new LinkedHashSet<>();
 
         // Aggregation settings for stats tabs
         AggregationPeriod statsPeriod = AggregationPeriod.ORIGINAL;
@@ -318,9 +331,10 @@ public class VisualizationTabManager {
         containerPanel.add(toolbar, BorderLayout.NORTH);
         containerPanel.add(plotPanel, BorderLayout.CENTER);
 
-        // Add tab with inherited series selection
+        // Add tab with inherited series selection and source context
         TabInfo tabInfo = new TabInfo(TabInfo.TabType.PLOT, "Plot", containerPanel, plotPanel, null);
         tabInfo.selectedSeries.addAll(inheritedSeries);
+        tabInfo.checkedSources.addAll(inheritedSources(settings));
         tabs.add(tabInfo);
 
         int index = tabbedPane.getTabCount();
@@ -495,6 +509,7 @@ public class VisualizationTabManager {
                 tabInfo.selectedSeries.addAll(sharedDataSet.getSeriesRefs());
             }
         }
+        tabInfo.checkedSources.addAll(inheritedSources(settings));
 
         tabs.add(tabInfo);
 
@@ -802,6 +817,51 @@ public class VisualizationTabManager {
     public Set<SeriesRef> getTargetTabSelectedSeries() {
         TabInfo tab = getTargetTab();
         return tab != null ? Collections.unmodifiableSet(tab.selectedSeries) : Collections.emptySet();
+    }
+
+    /**
+     * Resolves the source context a new tab should start with: from the settings if
+     * recorded there (duplication), otherwise the active tab's (fresh tab created while
+     * another is showing), otherwise empty (startup default tabs — "unconfigured").
+     */
+    private Set<SourceRef> inheritedSources(TabSettings settings) {
+        if (settings.checkedSources != null) {
+            return settings.checkedSources;
+        }
+        TabInfo activeTab = getActiveTab();
+        return activeTab != null ? activeTab.checkedSources : Collections.emptySet();
+    }
+
+    /**
+     * Returns the checked data sources recorded for the target tab, or empty set.
+     */
+    public Set<SourceRef> getTargetTabCheckedSources() {
+        TabInfo tab = getTargetTab();
+        return tab != null ? Collections.unmodifiableSet(tab.checkedSources) : Collections.emptySet();
+    }
+
+    /**
+     * Records the checked data sources on the target tab (in the given order).
+     * Pure bookkeeping — no visual side effects; the source tree itself is the
+     * caller's responsibility.
+     */
+    public void setTargetTabCheckedSources(Set<SourceRef> sources) {
+        TabInfo tab = getTargetTab();
+        if (tab == null) return;
+        tab.checkedSources.clear();
+        tab.checkedSources.addAll(sources);
+    }
+
+    /**
+     * Removes a source from every tab's recorded context. Called when the source is
+     * removed for good (a run removed, a dataset unloaded) so no tab tries to restore
+     * it later. The "Last" alias is deliberately never scrubbed — see
+     * {@link com.kalix.ide.flowviz.data.LastSource}.
+     */
+    public void removeSourceFromAllTabs(SourceRef ref) {
+        for (TabInfo tab : tabs) {
+            tab.checkedSources.remove(ref);
+        }
     }
 
     /**

--- a/kalixide/src/test/java/com/kalix/ide/components/JCheckboxTreeTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/components/JCheckboxTreeTest.java
@@ -1,0 +1,190 @@
+package com.kalix.ide.components;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link JCheckboxTree}'s checked-state model. The mouse hit-testing is
+ * exercised manually (it needs a laid-out tree), but the state logic — recursive
+ * tick/untick, tri-state ancestor roll-up, check-order preservation, and change-only
+ * event firing — is where regressions hide, so it's pinned down here.
+ *
+ * <p>Order matters to consumers: the Run Manager builds the plotted-series list from
+ * {@link JCheckboxTree#getCheckedPaths()}, and the first series is the reference for
+ * difference-style plot types, so iteration must reflect the order paths were checked.
+ */
+class JCheckboxTreeTest {
+
+    private DefaultMutableTreeNode root;
+    private DefaultMutableTreeNode parent1;
+    private DefaultMutableTreeNode parent2;
+    private DefaultMutableTreeNode leafA;
+    private DefaultMutableTreeNode leafB;
+    private DefaultMutableTreeNode leafC;
+    private DefaultMutableTreeNode leafD;
+    private DefaultTreeModel model;
+    private JCheckboxTree tree;
+
+    @BeforeEach
+    void setUp() {
+        root = new DefaultMutableTreeNode("root");
+        parent1 = new DefaultMutableTreeNode("parent1");
+        parent2 = new DefaultMutableTreeNode("parent2");
+        leafA = new DefaultMutableTreeNode("a");
+        leafB = new DefaultMutableTreeNode("b");
+        leafC = new DefaultMutableTreeNode("c");
+        leafD = new DefaultMutableTreeNode("d");
+        parent1.add(leafA);
+        parent1.add(leafB);
+        parent2.add(leafC);
+        parent2.add(leafD);
+        root.add(parent1);
+        root.add(parent2);
+        model = new DefaultTreeModel(root);
+        tree = new JCheckboxTree(model);
+    }
+
+    private TreePath path(DefaultMutableTreeNode node) {
+        return new TreePath(node.getPath());
+    }
+
+    // ---- recursive tick/untick and tri-state roll-up ----
+
+    @Test
+    void checkingParentChecksAllDescendants() {
+        tree.checkPath(path(parent1));
+
+        assertTrue(tree.isPathChecked(path(parent1)));
+        assertTrue(tree.isPathChecked(path(leafA)));
+        assertTrue(tree.isPathChecked(path(leafB)));
+        assertEquals(JCheckboxTree.CheckState.CHECKED, tree.getCheckState(path(parent1)));
+    }
+
+    @Test
+    void parentIsPartialWhenSomeChildrenChecked() {
+        tree.checkPath(path(leafA));
+
+        assertEquals(JCheckboxTree.CheckState.PARTIAL, tree.getCheckState(path(parent1)));
+        assertEquals(JCheckboxTree.CheckState.PARTIAL, tree.getCheckState(path(root)));
+        assertFalse(tree.isPathChecked(path(parent1)));
+    }
+
+    @Test
+    void parentRollsUpToCheckedWhenAllChildrenChecked() {
+        tree.checkPath(path(leafA));
+        tree.checkPath(path(leafB));
+
+        assertEquals(JCheckboxTree.CheckState.CHECKED, tree.getCheckState(path(parent1)));
+        assertTrue(tree.isPathChecked(path(parent1)));
+    }
+
+    @Test
+    void uncheckingOneChildDemotesParentToPartial() {
+        tree.checkPath(path(parent1));
+        tree.setCheckedPaths(List.of(path(leafA)));
+
+        assertEquals(JCheckboxTree.CheckState.PARTIAL, tree.getCheckState(path(parent1)));
+        assertFalse(tree.isPathChecked(path(parent1)));
+        assertTrue(tree.isPathChecked(path(leafA)));
+        assertFalse(tree.isPathChecked(path(leafB)));
+    }
+
+    @Test
+    void recheckingParentPicksUpChildrenInsertedSinceLastTick() {
+        tree.checkPath(path(parent1));
+        DefaultMutableTreeNode leafE = new DefaultMutableTreeNode("e");
+        parent1.add(leafE);
+        model.nodesWereInserted(parent1, new int[]{parent1.getIndex(leafE)});
+
+        tree.checkPath(path(parent1));
+
+        assertTrue(tree.isPathChecked(path(leafE)));
+    }
+
+    // ---- check-order preservation ----
+
+    @Test
+    void checkedPathsPreserveCheckOrder() {
+        tree.checkPath(path(leafC));
+        tree.checkPath(path(leafA));
+
+        assertArrayEquals(new TreePath[]{path(leafC), path(leafA)}, tree.getCheckedPaths());
+    }
+
+    @Test
+    void setCheckedPathsAppliesGivenOrder() {
+        tree.checkPath(path(leafA));
+        tree.setCheckedPaths(List.of(path(leafD), path(leafB)));
+
+        assertArrayEquals(new TreePath[]{path(leafD), path(leafB)}, tree.getCheckedPaths());
+    }
+
+    // ---- change-only event firing ----
+
+    @Test
+    void eventsFireOnlyOnActualChange() {
+        AtomicInteger events = new AtomicInteger();
+        tree.addCheckChangeListener(events::incrementAndGet);
+
+        tree.checkPath(path(leafA));
+        assertEquals(1, events.get());
+
+        tree.checkPath(path(leafA)); // already checked — silent
+        assertEquals(1, events.get());
+
+        tree.removePath(path(leafB)); // never checked — silent
+        assertEquals(1, events.get());
+
+        tree.removePath(path(leafA)); // was checked — fires
+        assertEquals(2, events.get());
+    }
+
+    @Test
+    void batchAddFiresSingleEvent() {
+        AtomicInteger events = new AtomicInteger();
+        tree.addCheckChangeListener(events::incrementAndGet);
+
+        tree.addCheckedPaths(List.of(path(leafA), path(leafC)));
+        assertEquals(1, events.get());
+
+        tree.addCheckedPaths(List.of(path(leafA), path(leafC))); // all already checked — silent
+        assertEquals(1, events.get());
+    }
+
+    // ---- removePath housekeeping ----
+
+    @Test
+    void removePathForgetsSubtreeMetadata() {
+        tree.checkPath(path(parent1));
+        tree.removePath(path(parent1));
+
+        assertEquals(0, tree.getCheckedPaths().length);
+        assertFalse(tree.nodeCheckedStateMap.containsKey(path(parent1)));
+        assertFalse(tree.nodeCheckedStateMap.containsKey(path(leafA)));
+        assertFalse(tree.nodeCheckedStateMap.containsKey(path(leafB)));
+        // Untouched siblings keep their entries
+        assertTrue(tree.nodeCheckedStateMap.containsKey(path(parent2)));
+    }
+
+    // ---- structural rebuilds ----
+
+    @Test
+    void structuralReloadClearsCheckedState() {
+        tree.checkPath(path(parent1));
+        model.reload();
+
+        assertEquals(0, tree.getCheckedPaths().length);
+        assertEquals(JCheckboxTree.CheckState.UNCHECKED, tree.getCheckState(path(leafA)));
+    }
+}

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/data/TimeSeriesDataTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/data/TimeSeriesDataTest.java
@@ -257,6 +257,44 @@ class TimeSeriesDataTest {
     }
 
     /**
+     * The phantom-segment regression: a query window entirely OUTSIDE the series (before the
+     * first sample or after the last) must be empty on both index paths. The contiguous fast
+     * path used to clamp startIndex to pointCount-1, handing the last sample to any
+     * beyond-the-end query — the LOD column partition then dropped the last point into the
+     * final pixel column, and "Draw across gaps" bridged it to the right-hand plot edge as a
+     * phantom segment (auto-Y similarly picked up an out-of-view point).
+     */
+    @Test
+    void viewportEntirelyOutsideSeriesIsEmptyOnBothPaths() {
+        int n = 10;
+        long[] gridTs = new long[n];
+        double[] gridV = new double[n];
+        for (int i = 0; i < n; i++) {
+            gridTs[i] = i * DAY_MS;
+            gridV[i] = i;
+        }
+        TimeSeriesData grid = new TimeSeriesData(gridTs, gridV);
+        assertTrue(grid.isContiguous(), "precondition: series must take the fast path");
+
+        for (TimeSeriesData series : new TimeSeriesData[]{grid, adHocSeries()}) {
+            long[] ts = series.getTimestamps();
+            long first = ts[0];
+            long last = ts[ts.length - 1];
+            String path = series.isContiguous() ? "fast path" : "binary-search path";
+
+            // Just past the end (the LOD trailing-column query) and far past it.
+            assertTrue(series.getIndexRange(last + 1, last + DAY_MS).isEmpty(),
+                "window just past the series end must be empty on " + path);
+            assertTrue(series.getIndexRange(last + 365 * DAY_MS, last + 730 * DAY_MS).isEmpty(),
+                "window far past the series end must be empty on " + path);
+
+            // Entirely before the first sample, including just before it.
+            assertTrue(series.getIndexRange(first - DAY_MS, first - 1).isEmpty(),
+                "window ending just before the first sample must be empty on " + path);
+        }
+    }
+
+    /**
      * Both index paths — the contiguous O(1) arithmetic fast path and the binary-search path —
      * must implement the same half-open, end-inclusive-in-time semantics. Each is checked
      * against the same reference oracle: end bounds everywhere (exactly on a point, between
@@ -289,10 +327,10 @@ class TimeSeriesDataTest {
             java.util.List<Long> ends = new java.util.ArrayList<>();
             for (long t : ts) ends.add(t);
             for (int i = 0; i + 1 < ts.length; i++) ends.add((ts[i] + ts[i + 1]) / 2);
-            // At least one full step before the series: the fast path's integer division
-            // truncates toward zero, so ends within (first - step, first) are a pre-existing
-            // fast-path quirk outside this comparison's scope.
+            // Any end before the first sample is empty on both paths (the fast path
+            // short-circuits before its truncating integer division can misfire).
             ends.add(first - 2 * DAY_MS);
+            ends.add(first - 1);
             ends.add(last + 1);
             ends.add(last + 365 * DAY_MS);
 


### PR DESCRIPTION
Main points of note:
- Extended behaviour of renderers by inheritance (CheckboxTreeCellRenderer)
- Added JCheckboxTree to extend functionality of JTree
- Hooked into LastRunTracker, RunTreeController, RunManager and SeriesFetchCoordinator
- Checkbox works with three states - selected (tick; all children selected), unselected (empty box, no children selected), and "some children selected" (dot).

Some incidental formatting and removal of dead code, especially in RunManager.