### PR TITLE
[Feature] Force canonical save (#316)

### DIFF
--- a/kalixide/src/main/resources/linter/kalix-model-schema.json
+++ b/kalixide/src/main/resources/linter/kalix-model-schema.json
@@ -8,6 +8,12 @@
           "required": false,
           "type": "version",
           "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "save_method": {
+          "required": false,
+          "type": "string",
+          "pattern": "^(standard|canonical)$",
+          "description": "Save method: 'standard' or 'canonical'"
         }
       }
     },

--- a/regression_tests/simulations/.gitignore
+++ b/regression_tests/simulations/.gitignore
@@ -1,1 +1,4 @@
 **/*.diff
+**/*.resave_check.ini
+**/*.resave_check.mbal.txt
+**/*.canonical_check.ini

--- a/regression_tests/simulations/10_different_data_periods/model_with_different_data_periods.ini
+++ b/regression_tests/simulations/10_different_data_periods/model_with_different_data_periods.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [inputs]

--- a/regression_tests/simulations/11_force_flow/model_with_forced_flow.ini
+++ b/regression_tests/simulations/11_force_flow/model_with_forced_flow.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [inputs]

--- a/regression_tests/simulations/12_storage_variations/storage_variations.ini
+++ b/regression_tests/simulations/12_storage_variations/storage_variations.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.1.2
 
 [constants]

--- a/regression_tests/simulations/13_reg_user_with_routing/model_with_ordering.ini
+++ b/regression_tests/simulations/13_reg_user_with_routing/model_with_ordering.ini
@@ -1,5 +1,6 @@
 # Welcome, friend ...
 [kalix]
+save_method = canonical
 start = 2022-01-01
 end = 2022-01-20
 

--- a/regression_tests/simulations/14_reg_users_with_inflows/ordering_with_inflows.ini
+++ b/regression_tests/simulations/14_reg_users_with_inflows/ordering_with_inflows.ini
@@ -1,5 +1,6 @@
 
 [kalix]
+save_method = canonical
 # start = 2022-01-01
 # end = 2022-01-20
 

--- a/regression_tests/simulations/15_order_controls/model.ini
+++ b/regression_tests/simulations/15_order_controls/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2000-01-01
 end = 2000-04-01
 

--- a/regression_tests/simulations/16_alternating_water_source/model.ini
+++ b/regression_tests/simulations/16_alternating_water_source/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2020-01-01
 end = 2020-03-01
 

--- a/regression_tests/simulations/17_storage_outlets/model.ini
+++ b/regression_tests/simulations/17_storage_outlets/model.ini
@@ -1,5 +1,6 @@
 
 [kalix]
+save_method = canonical
 start = 2025-01-01
 end = 2025-01-07
 

--- a/regression_tests/simulations/18_filling_emptying_storage/model.ini
+++ b/regression_tests/simulations/18_filling_emptying_storage/model.ini
@@ -7,6 +7,7 @@
 #     thereby testing the storage becoming empty.
 
 [kalix]
+save_method = canonical
 start = 2024-01-01
 end = 2024-01-10
 

--- a/regression_tests/simulations/19_lots_of_ordering/model.ini
+++ b/regression_tests/simulations/19_lots_of_ordering/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2021-01-01
 end = 2023-01-01
 

--- a/regression_tests/simulations/1_picnic_gr4j/kalix.ini
+++ b/regression_tests/simulations/1_picnic_gr4j/kalix.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [constants]

--- a/regression_tests/simulations/20_loss_extrapolation/model.ini
+++ b/regression_tests/simulations/20_loss_extrapolation/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 0001-01-01
 end = 0001-04-01
 

--- a/regression_tests/simulations/21_ordering_through_storages/model.ini
+++ b/regression_tests/simulations/21_ordering_through_storages/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2011-01-01
 end = 2011-01-10
 

--- a/regression_tests/simulations/22_storage_target_level/model.ini
+++ b/regression_tests/simulations/22_storage_target_level/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2011-01-01
 end = 2012-01-01
 

--- a/regression_tests/simulations/23_order_lag/model.ini
+++ b/regression_tests/simulations/23_order_lag/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2020-01-01
 end = 2020-01-20
 

--- a/regression_tests/simulations/24_nlm_routing/model.ini
+++ b/regression_tests/simulations/24_nlm_routing/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 
 [inputs]
 inflow.csv

--- a/regression_tests/simulations/25_picnic_gr4h/kalix.ini
+++ b/regression_tests/simulations/25_picnic_gr4h/kalix.ini
@@ -4,6 +4,7 @@
 #       the results ever unexpectedly change.
 
 [kalix]
+save_method = canonical
 
 [inputs]
 data.csv

--- a/regression_tests/simulations/26_splitters_noextrap/split_nlm_model_noextrap.ini
+++ b/regression_tests/simulations/26_splitters_noextrap/split_nlm_model_noextrap.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 1980-01-01
 end = 2009-12-31
 

--- a/regression_tests/simulations/27_splitters_extrap/split_nlm_model.ini
+++ b/regression_tests/simulations/27_splitters_extrap/split_nlm_model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 1980-01-01
 end = 2009-12-31
 

--- a/regression_tests/simulations/28_forced_release/storage_forced_release.ini
+++ b/regression_tests/simulations/28_forced_release/storage_forced_release.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [inputs]

--- a/regression_tests/simulations/29_storage_existence/model.ini
+++ b/regression_tests/simulations/29_storage_existence/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 
 [inputs]
 exist = data_storage_exists.csv

--- a/regression_tests/simulations/2_pioneer_val/model.ini
+++ b/regression_tests/simulations/2_pioneer_val/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 #execution_order = manual
 

--- a/regression_tests/simulations/30_storage_existence_target_level/model.ini
+++ b/regression_tests/simulations/30_storage_existence_target_level/model.ini
@@ -7,6 +7,7 @@
 # storage under-orders once it returns.
 
 [kalix]
+save_method = canonical
 
 [inputs]
 exist = data_storage_exists.csv

--- a/regression_tests/simulations/31_model_with_table/model.ini
+++ b/regression_tests/simulations/31_model_with_table/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 start = 2000-01-01
 end = 2000-12-31
 

--- a/regression_tests/simulations/3_calibrate_constants/model.ini
+++ b/regression_tests/simulations/3_calibrate_constants/model.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [constants]

--- a/regression_tests/simulations/4_user_variations/user.ini
+++ b/regression_tests/simulations/4_user_variations/user.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [inputs]

--- a/regression_tests/simulations/5_model_with_every_node/model_with_every_node_type.ini
+++ b/regression_tests/simulations/5_model_with_every_node/model_with_every_node_type.ini
@@ -1,5 +1,8 @@
 [kalix]
 #version = 0.0.1
+# save_method deliberately left as 'standard' (not 'canonical'): this file is the
+# fixture for `test_save_noop_is_byte_identical`, which asserts a no-op save
+# reproduces the source byte-for-byte.
 
 [constants]
 c.pi = 3.14

--- a/regression_tests/simulations/5_model_with_every_node/model_with_every_node_type_canonical.ini
+++ b/regression_tests/simulations/5_model_with_every_node/model_with_every_node_type_canonical.ini
@@ -1,0 +1,185 @@
+[kalix]
+#version = 0.0.1
+# This version of the model is explicitly saved with save_method=canonical for checking simulation behaviour.
+save_method = canonical
+
+[constants]
+c.pi = 3.14
+c.reference_demand = 1000
+c.rain_factor = 1.1
+
+[inputs]
+flows.csv
+rex_mpot.csv
+rex_rain.csv
+constants.csv
+mask_1990s.csv
+
+[node.node1_inflow]
+type = inflow
+loc = -71.64, 2.05
+inflow = data.flows_csv.by_index.1
+ds_1 = Node2_sacramento
+
+[node.Node2_sacramento]
+type = sacramento
+loc = -191.02, 187.78
+area = 80
+rain = c.rain_factor * data.mask_1990s_csv.by_name.rain
+evap = 1.2 * data.mask_1990s_csv.by_name.evap
+params = 0.01, 40.0, 23.0, 0.009,
+         0.043, 130.0, 0.01, 0.063, # not the default parameters
+         1.0, 0.01, 0.0, 0.0,       # another inline comment
+         40.0, 0.245, 50.0, 40.0, 
+         0.1
+ds_1 = node3_user
+
+[node.node3_user]
+type = unregulated_user
+loc = -152.55, 333.11
+demand = data.constants_csv.by_name.const_20
+ds_1 = node4_storage
+
+[node.node4_storage]
+type = storage
+loc = -109.98, 474.35
+dimensions = 90,   0,   0, 0, 
+             91,   100, 1, 0, 
+             91.1, 101, 1, 1e8, 
+             92,   102, 1, 1e8,
+ds_1 = node5_routing
+ds_2 = node14_regulated_user
+ds_2_outlet = 90
+
+[node.node14_regulated_user]
+loc = 0, 581
+type = regulated_user
+order = 0.03
+
+[node.node5_routing]
+type = routing
+loc = -198.15, 652.40
+lag = 2
+pwl = 0, 3, 
+      10, 3, 
+      100, 2, 
+      200, 1, 
+      500, 0, 
+      1e8, 0, 
+n_divs = 1
+x = 0
+ds_1 = node13_enviro
+
+[node.node13_enviro]
+type = order_control
+loc = -186.50, 787.44
+min_order = 0
+ds_1 = node7_confluence
+
+[node.node6_gr4j]
+type = gr4j
+loc = 122.50, 721.99
+area = 80
+rain = 1.0 * data.rex_rain_csv.by_name.value
+evap = data.rex_mpot_csv.by_name.value
+params = 350.0, 0.0, 90.0, 1.7
+ds_1 = node7_confluence
+
+[node.node7_confluence]
+type = confluence
+loc = 8.89, 845.23
+ds_1 = node8_splitter
+
+[node.node8_splitter]
+type = splitter
+loc = 74.22, 1010.74
+table = 0, 0,
+        10, 0,
+        100, 0,
+        1000, 500,
+        1e8, 5e7
+ds_1 = node9_blackhole
+ds_2 = node10_gauge
+
+[node.node9_blackhole]
+type = blackhole
+loc = -210.70, 1259.85
+
+[node.node10_gauge]
+type = gauge
+loc = 76.80, 1206.53
+#reference_flow = data.mask_1990s_csv.by_index.1
+ds_1 = node11_loss
+
+[node.node11_loss]
+type = loss
+loc = 198.94, 1479.33
+table = 0, 0,
+        1e9, 1e8
+ds_1 = node12_blackhole
+
+[node.node14_gr4h]
+type = gr4j
+loc = 440.16, 1485.29
+area = 80
+variant = gr4h
+rain = 1.0 * data.rex_rain_csv.by_name.value
+evap = data.rex_mpot_csv.by_name.value
+params = 350.0, 0.0, 90.0, 1.7
+ds_1 = node12_blackhole
+
+[node.node12_blackhole]
+type = blackhole
+loc = 311.46, 1619.31
+
+[outputs]
+node.node1_inflow.usflow
+node.node1_inflow.inflow
+node.node1_inflow.dsflow
+node.node1_inflow.ds_1
+node.Node2_sacramento.usflow
+node.Node2_sacramento.runoff_volume
+node.Node2_sacramento.dsflow
+node.Node2_sacramento.ds_1
+node.node3_user.usflow
+node.node3_user.demand
+node.node3_user.diversion
+node.node3_user.dsflow
+node.node3_user.ds_1
+node.node4_storage.usflow
+node.node4_storage.volume
+node.node4_storage.dsflow
+node.node4_storage.ds_1
+node.node4_storage.ds_2
+node.node5_routing.usflow
+node.node5_routing.dsflow
+node.node5_routing.volume
+node.node5_routing.ds_1
+node.node6_gr4j.usflow
+node.node6_gr4j.runoff_volume
+node.node6_gr4j.runoff_depth
+node.node6_gr4j.dsflow
+node.node6_gr4j.ds_1
+node.node7_confluence.usflow
+node.node7_confluence.dsflow
+node.node7_confluence.ds_1
+node.node8_splitter.usflow
+node.node8_splitter.dsflow
+node.node8_splitter.ds_1
+node.node8_splitter.ds_2
+node.node9_blackhole.usflow
+node.node9_blackhole.dsflow
+node.node9_blackhole.ds_1
+node.node10_gauge.usflow
+node.node10_gauge.dsflow
+node.node10_gauge.ds_1
+node.node11_loss.usflow
+node.node11_loss.dsflow
+node.node11_loss.ds_1
+node.node11_loss.loss
+node.node12_blackhole.usflow
+node.node13_enviro.ds_1
+node.node14_gr4h.ds_1
+node.node14_regulated_user.diversion
+
+

--- a/regression_tests/simulations/6_picnic_sacr/picnic_sacr.ini
+++ b/regression_tests/simulations/6_picnic_sacr/picnic_sacr.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [constants]

--- a/regression_tests/simulations/7_picnic_sacr_dmy/picnic_sacr.ini
+++ b/regression_tests/simulations/7_picnic_sacr_dmy/picnic_sacr.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [constants]

--- a/regression_tests/simulations/8_picnic_sacr_no_headder/picnic_sacr.ini
+++ b/regression_tests/simulations/8_picnic_sacr_no_headder/picnic_sacr.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [constants]

--- a/regression_tests/simulations/9_hundred_sacr/kalix.ini
+++ b/regression_tests/simulations/9_hundred_sacr/kalix.ini
@@ -1,4 +1,5 @@
 [kalix]
+save_method = canonical
 #version = 0.0.1
 
 [inputs]

--- a/regression_tests/simulations/verify_all_models.py
+++ b/regression_tests/simulations/verify_all_models.py
@@ -19,12 +19,19 @@ import numpy as np
 # backend only, so the CLI backend works without the wheel installed.
 
 
+# Suffix used for the debug artifact that verify_resave leaves on disk when it
+# fails (see its docstring). Excluded from find_model_files so a leftover
+# artifact from a previous failing run is never picked up as a model to
+# verify in its own right.
+_RESAVE_CHECK_SUFFIX = '.resave_check.ini'
+
+
 def find_model_files(root_dir):
-    """Find all .ini files in the directory tree."""
+    """Find all .ini files in the directory tree, excluding debug artifacts."""
     ini_files = []
     for root, dirs, files in os.walk(root_dir):
         for file in files:
-            if file.endswith('.ini'):
+            if file.endswith('.ini') and not file.endswith(_RESAVE_CHECK_SUFFIX):
                 ini_files.append(os.path.join(root, file))
     return sorted(ini_files)
 
@@ -152,6 +159,118 @@ def _simulate(backend, cli_bin, model_path, mass_balance_path):
         kalix.simulate(model_path, mass_balance=mass_balance_path)
 
 
+def _resave(cli_bin, model_path, resaved_path):
+    """Run `kalix resave model_path resaved_path`, raising RuntimeError on failure."""
+    result = subprocess.run(
+        [str(cli_bin), 'resave', model_path, resaved_path],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or '').strip()
+        raise RuntimeError(f"resave failed: {detail or f'kalix exited with code {result.returncode}'}")
+
+
+def _write_diff(lines_a, lines_b, diff_path, fromfile, tofile):
+    """Write a unified diff between two line lists to diff_path."""
+    diff = difflib.unified_diff(lines_a, lines_b, fromfile=fromfile, tofile=tofile)
+    with open(diff_path, 'w') as diff_f:
+        diff_f.writelines(diff)
+    return Path(diff_path).relative_to(Path.cwd()).as_posix()
+
+
+def verify_resave(model_path, backend, cli_bin, mbal_filename='mbal.txt'):
+    """
+    Verify that a model still simulates identically after a save round-trip.
+
+    Loads the model, saves it back out (per its own [kalix] save_method — see
+    SaveMethod in src/misc/configuration.rs), and re-simulates the resaved copy.
+    Catches load/save bugs that a plain load-and-simulate check can't: a
+    round-trip that silently drops or corrupts a property still simulates fine
+    on the *original* file, but would show up here as a mass balance mismatch
+    on the *resaved* one. Only supported on the CLI backend (`kalix resave`);
+    the Python package backend has no equivalent entry point.
+
+    Args:
+        model_path: Path to the .ini model file
+        backend: 'cli' or 'package' (see resolve_backend)
+        cli_bin: Path to the CLI binary when backend == 'cli', else None
+        mbal_filename: Name of the reference mass balance file to verify against
+
+    On failure, the resaved model, an ini diff against the source, and (if the
+    mismatch was in the mass balance) the generated mass balance are left on
+    disk next to the source model — as `<stem>.resave_check.ini` /
+    `<stem>.resave_check.diff` / `<stem>.resave_check.mbal.txt` — for manual
+    debugging. They are cleaned up automatically on success. All are
+    gitignored (see .gitignore).
+
+    Returns:
+        tuple: (success: bool, message: str) — success is True with a "SKIPPED"
+        message on the package backend.
+    """
+    if backend != 'cli':
+        return True, "SKIPPED (resave round-trip needs the CLI backend)"
+
+    model_dir = os.path.dirname(model_path)
+    mbal_path = os.path.join(model_dir, mbal_filename)
+    if not os.path.exists(mbal_path):
+        return False, f"Mass balance file not found: {mbal_path}"
+
+    # Resave alongside the original (not a system temp dir) so the model's
+    # relative input-file paths still resolve when we re-simulate it.
+    stem = Path(model_path).stem
+    resaved_path = os.path.join(model_dir, stem + _RESAVE_CHECK_SUFFIX)
+    ini_diff_path = os.path.join(model_dir, f"{stem}.resave_check.diff")
+    tmp_mbal_path = None
+    success = False
+    try:
+        _resave(cli_bin, model_path, resaved_path)
+
+        # Diff the resave against the source up front, so it's available for
+        # a mass balance mismatch below *and* for a simulate-time exception
+        # (e.g. the resave silently dropped an input alias).
+        with open(model_path, 'r') as f:
+            source_lines = f.readlines()
+        with open(resaved_path, 'r') as f:
+            resaved_lines = f.readlines()
+        rel_ini_diff = _write_diff(
+            source_lines, resaved_lines, ini_diff_path, fromfile='source', tofile='resaved',
+        )
+        rel_ini = Path(resaved_path).relative_to(Path.cwd()).as_posix()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as tmp_mbal:
+            tmp_mbal_path = tmp_mbal.name
+
+        _simulate(backend, cli_bin, resaved_path, tmp_mbal_path)
+
+        matched, detail = compare_mass_balance_files(tmp_mbal_path, mbal_path)
+        if matched:
+            success = True
+            return True, "VERIFIED! (resave round-trip)"
+
+        kept_mbal_path = os.path.join(model_dir, f"{stem}.resave_check.mbal.txt")
+        shutil.copy(tmp_mbal_path, kept_mbal_path)
+        rel_mbal = Path(kept_mbal_path).relative_to(Path.cwd()).as_posix()
+        return False, (f"Resaved model's mass balance mismatch ({detail}): "
+                        f"resaved model kept at {rel_ini}, mass balance at {rel_mbal}, "
+                        f"ini diff at {rel_ini_diff}")
+    except Exception as e:
+        detail = f"Error: {str(e)}"
+        if os.path.exists(ini_diff_path):
+            rel_ini_diff = Path(ini_diff_path).relative_to(Path.cwd()).as_posix()
+            detail += f" (ini diff at {rel_ini_diff})"
+        return False, detail
+    finally:
+        # Only clean up the resaved model and its diff on success — a failure
+        # leaves them (and the mass balance above) on disk for manual debugging.
+        if success:
+            if os.path.exists(resaved_path):
+                os.unlink(resaved_path)
+            if os.path.exists(ini_diff_path):
+                os.unlink(ini_diff_path)
+        if tmp_mbal_path and os.path.exists(tmp_mbal_path):
+            os.unlink(tmp_mbal_path)
+
+
 def verify_model(model_path, backend, cli_bin, mbal_filename='mbal.txt'):
     """
     Verify a model against its mass balance report via the selected backend.
@@ -188,15 +307,11 @@ def verify_model(model_path, backend, cli_bin, mbal_filename='mbal.txt'):
             else:
                 # Copy the generated file and write a diff for inspection
                 shutil.copy(tmp_mbal_path, mbal_path + '.log')
-                diff_path = mbal_path + '.diff'
                 with open(mbal_path, 'r') as ref_f, open(tmp_mbal_path, 'r') as gen_f:
-                    diff = difflib.unified_diff(
+                    rel_diff = _write_diff(
                         ref_f.readlines(), gen_f.readlines(),
-                        fromfile='reference', tofile='generated',
+                        mbal_path + '.diff', fromfile='reference', tofile='generated',
                     )
-                    with open(diff_path, 'w') as diff_f:
-                        diff_f.writelines(diff)
-                rel_diff = Path(diff_path).relative_to(Path.cwd()).as_posix()
                 return False, f"Mass balance mismatch ({detail}): diff saved to {rel_diff}"
         finally:
             # Clean up temporary file
@@ -304,19 +419,24 @@ def main():
 
     log(f"Found {len(model_files)} model file(s)\n")
 
-    # Verify each model
+    # Verify each model. Each entry is (result label suffix, check function);
+    # checks beyond the first are additional angles on the same model (currently
+    # just a save/reload round-trip via verify_resave).
+    checks = [
+        (None, lambda p: verify_model(p, backend, cli_bin)),
+        ('resave', lambda p: verify_resave(p, backend, cli_bin)),
+    ]
+
     results = []
     for model_path in model_files:
         rel_path = os.path.relpath(model_path, root_dir)
         log(f"Verifying: {rel_path}")
 
-        success, message = verify_model(model_path, backend, cli_bin)
-        results.append((rel_path, success, message))
-
-        if success:
-            log(f"  [PASS] {message}")
-        else:
-            log(f"  [FAIL] {message}")
+        for label, run in checks:
+            success, message = run(model_path)
+            result_key = rel_path if label is None else f"{rel_path} ({label})"
+            results.append((result_key, success, message))
+            log(f"  [{'PASS' if success else 'FAIL'}] {message}")
         log()
 
     # Summary

--- a/src/bin/kalix.rs
+++ b/src/bin/kalix.rs
@@ -73,6 +73,18 @@ enum Commands {
         #[arg(short = 'p', long)]
         profile: bool,
     },
+    /// Load a model and save it back out (per its save_method), without simulating.
+    ///
+    /// Used to exercise the save/round-trip path in isolation, e.g. to verify
+    /// that a canonical save reproduces a model that reloads and simulates
+    /// identically to the source.
+    #[command(visible_alias = "resave")]
+    Resave {
+        /// Path to the model file to load
+        model_file: String,
+        /// Path to write the resaved model file
+        output_file: Option<String>,
+    },
 }
 
 fn main() {
@@ -220,6 +232,22 @@ fn main() {
                 println!("  ─────────────────────────────");
                 println!("  Total time:      {:>10.3} ms", total_time.as_secs_f64() * 1000.0);
             }
+        }
+        Commands::Resave { model_file, output_file } => {
+            let model = match IniModelIO::new().read_model_file(model_file.as_str()) {
+                Ok(model) => model,
+                Err(s) => {
+                    eprintln!("Error: {}", s);
+                    std::process::exit(1);
+                }
+            };
+            let model_string = IniModelIO::new().model_to_string(&model);
+            let target_file = output_file.unwrap_or(model_file.clone());
+            if let Err(s) = fs::write(&target_file, model_string) {
+                eprintln!("Error: {}", s);
+                std::process::exit(1);
+            }
+            println!("Resaved model to: {}", target_file);
         }
         Commands::Optimise { config_file, model_file, save_model, quiet, report_frequency, profile } => {
             use kalix::numerical::opt::{

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -1145,7 +1145,6 @@ pub fn model_to_ini_doc_0_0_1(model: &Model) -> IniDocument {
                 } else {
                     // Changed, new, or not present in the original: emit canonically.
                     {
-                        let out: &mut IniDocument = &mut out;
                         for (key, prop) in &current_section.properties {
                             out.set_property(section_name, key, &prop.value);
                         }

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::hydrology::accounts::account::Account;
 use crate::io::csv_io::{csv_string_to_f64_vec, csv_to_string_vec};
 use crate::io::custom_ini_parser::{IniDocument, IniSection};
@@ -852,7 +854,12 @@ pub fn render_canonical_0_0_1(model: &Model) -> IniDocument {
 
     // List all input files
     for file_path in &model.input_file_paths {
-        ini_doc.set_property("inputs", file_path.as_str(), "");
+        let alias = model.alias_map.get(file_path);
+        let (k, v) = match alias {
+            Some(alias_string) => (alias_string.as_str(), file_path.as_str()),
+            None => (file_path.as_str(), ""),
+        };
+        ini_doc.set_property("inputs", k, v);
     }
 
     // List all constants

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::hydrology::accounts::account::Account;
 use crate::io::csv_io::{csv_string_to_f64_vec, csv_to_string_vec};
 use crate::io::custom_ini_parser::{IniDocument, IniSection};
@@ -1014,6 +1012,10 @@ pub fn render_canonical_0_0_1(model: &Model) -> IniDocument {
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "pond_demand", &n.pond_demand_input.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "target_level", &n.target_level.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "exists", &n.exists.to_string());
+                for (i, ds_force_release) in n.ds_force_release_input.iter().enumerate() {
+                    let property_name = format!("ds_{}_force_release", i + 1);
+                    set_property_if_not_empty(&mut ini_doc, section_name.as_str(), &property_name, &ds_force_release.to_string());
+                }
                 set_property_unless_default(&mut ini_doc, section_name.as_str(), "initial_volume", &n.vol_initial.to_string(), "0");
                 // order_through defaults to false; emit only when enabled.
                 if n.order_through {

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -1,6 +1,7 @@
 use crate::hydrology::accounts::account::Account;
 use crate::io::csv_io::{csv_string_to_f64_vec, csv_to_string_vec};
 use crate::io::custom_ini_parser::{IniDocument, IniSection};
+use crate::misc::configuration::SaveMethod;
 use crate::misc::location::Location;
 use crate::model_inputs::DynamicInput;
 use crate::numerical::lookup_table::LookupTable;
@@ -126,6 +127,12 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                 } else if name_lower == "end" {
                     let timestamp = date_string_to_u64_flexible(ini_property.value.as_str())?.0;
                     model.configuration.specified_sim_end_timestamp = Some(timestamp);
+                } else if name_lower == "save_method" {
+                    match ini_property.value.to_lowercase().as_str() {
+                        "standard" => model.configuration.save_method = SaveMethod::Standard,
+                        "canonical" => model.configuration.save_method = SaveMethod::Canonical,
+                        other => return Err(format!("Error on line {}: Invalid save_method '{}'. Expected 'standard' or 'canonical'.", ini_property.line_number, other)),
+                    }
                 }
             }
         } else if section_name == "inputs" {
@@ -829,6 +836,19 @@ pub fn render_canonical_0_0_1(model: &Model) -> IniDocument {
     if let Some(end_timestamp) = model.configuration.specified_sim_end_timestamp {
         ini_doc.set_property("kalix", "end", &u64_to_date_string_for_step_size(end_timestamp, sim_stepsize));
     }
+    
+    // Save method
+    match model.configuration.save_method {
+        SaveMethod::Standard => {
+            ini_doc.set_property("kalix", "save_method", "standard");
+        }
+        SaveMethod::Canonical => {
+            ini_doc.set_property("kalix", "save_method", "canonical");
+        }
+        SaveMethod::StandardUnset => {
+            // no-op
+        }
+    }
 
     // List all input files
     for file_path in &model.input_file_paths {
@@ -1087,41 +1107,52 @@ pub fn render_canonical_0_0_1(model: &Model) -> IniDocument {
 /// document to preserve (e.g. a model built programmatically).
 pub fn model_to_ini_doc_0_0_1(model: &Model) -> IniDocument {
     let current = render_canonical_0_0_1(model);
+    // Exhaustive match is a compiler-enforced guarantee that all save methods are handled.
+    match model.configuration.save_method {
+        SaveMethod::Standard | SaveMethod::StandardUnset => {
+            // Standard save method
+            let (baseline, original) = match (&model.baseline_canonical, &model.ini_document) {
+            (Some(baseline), Some(original)) => (baseline, original),
+            _ => return current, // nothing to preserve
+            };
 
-    let (baseline, original) = match (&model.baseline_canonical, &model.ini_document) {
-        (Some(baseline), Some(original)) => (baseline, original),
-        _ => return current, // nothing to preserve
-    };
+            // Rebuild the original (formatting-preserving) document by mark-and-sweep:
+            // validate the sections we keep verbatim, set the ones that changed, and let
+            // the sweep drop everything left invalid (deleted sections/properties).
+            let mut out = original.clone();
+            out.invalidate_all();
 
-    // Rebuild the original (formatting-preserving) document by mark-and-sweep:
-    // validate the sections we keep verbatim, set the ones that changed, and let
-    // the sweep drop everything left invalid (deleted sections/properties).
-    let mut out = original.clone();
-    out.invalidate_all();
+            for (section_name, current_section) in &current.sections {
+                let unchanged = baseline.sections.get(section_name)
+                    .map_or(false, |base| sections_canonically_equal(base, current_section));
 
-    for (section_name, current_section) in &current.sections {
-        let unchanged = baseline.sections.get(section_name)
-            .map_or(false, |base| sections_canonically_equal(base, current_section));
-
-        if unchanged && out.sections.contains_key(section_name) {
-            // Keep the original section verbatim (preserves raw_lines and comments).
-            out.validate_section(section_name);
-            let keys: Vec<String> = out.sections[section_name].properties.keys().cloned().collect();
-            for key in keys {
-                out.validate_property(section_name, &key);
+                if unchanged && out.sections.contains_key(section_name) {
+                    // Keep the original section verbatim (preserves raw_lines and comments).
+                    out.validate_section(section_name);
+                    let keys: Vec<String> = out.sections[section_name].properties.keys().cloned().collect();
+                    for key in keys {
+                        out.validate_property(section_name, &key);
+                    }
+                } else {
+                    // Changed, new, or not present in the original: emit canonically.
+                    {
+                        let out: &mut IniDocument = &mut out;
+                        for (key, prop) in &current_section.properties {
+                            out.set_property(section_name, key, &prop.value);
+                        }
+                    };
+                }
             }
-        } else {
-            // Changed, new, or not present in the original: emit canonically.
-            for (key, prop) in &current_section.properties {
-                out.set_property(section_name, key, &prop.value);
-            }
+            out.remove_invalid_sections_and_properties();
+            out
         }
+        SaveMethod::Canonical => {
+            // Canonical save method
+            current
+        }
+        // Note: never use a wildcard match here, to ensure compiler enforces exhaustive handling.
     }
-
-    out.remove_invalid_sections_and_properties();
-    out
 }
-
 
 /// Two sections are canonically equal when they hold the same property keys with
 /// the same (canonical) values. Comments, ordering and raw formatting are

--- a/src/misc/configuration.rs
+++ b/src/misc/configuration.rs
@@ -1,7 +1,6 @@
 
 #[derive(Debug)]
 #[derive(Clone)]
-#[derive(Default)]
 pub struct Configuration {
     pub specified_sim_start_timestamp: Option<u64>, //If specified in model - the time at the start of the FIRST simulated timestep.
     pub specified_sim_end_timestamp: Option<u64>,   //If specified in model - the time at the start of the LAST simulated timestep.
@@ -10,6 +9,16 @@ pub struct Configuration {
     pub sim_start_timestamp: u64,                   //The time (u64 representation) at the start of the FIRST simulated timestep.
     pub sim_end_timestamp: u64,                     //The time (u64 representation) at the start of the LAST simulated timestep.
     pub sim_nsteps: u64,                            //The number of simulated timesteps including the FIRST and LAST.
+
+    pub save_method: SaveMethod,                    // Method of saving to disk, see SaveMethod enum.
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum SaveMethod {
+    #[default]
+    StandardUnset, // Standard method will only overwrite sections that are invalidated. (Not set by user)
+    Standard,  // Standard method will only overwrite sections that are invalidated.
+    Canonical  // Force a canonical save of the model i.e. all sections of the ini will be rewritten
 }
 
 impl Configuration {
@@ -17,10 +26,20 @@ impl Configuration {
         Configuration {
             specified_sim_end_timestamp: None,
             specified_sim_start_timestamp: None,
+
             sim_stepsize: 1,
             sim_start_timestamp: 0,
             sim_end_timestamp: 0,
             sim_nsteps: 1, //1 + ((sim_end_timestamp - sim_start_timestamp) / sim_stepsize)
+
+            save_method: SaveMethod::StandardUnset,
         }
+    }
+}
+
+// Pin Default implementation to new()
+impl Default for Configuration {
+    fn default() -> Self {
+        Configuration::new()
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -58,6 +58,8 @@ pub struct Model {
     pub configuration: Configuration,
     pub inputs: Vec<TimeseriesInput>,
     pub input_file_paths: Vec<String>,
+    /// Maps file_path to the alias provided for quick lookup
+    pub alias_map: HashMap<String, String>, 
     pub outputs: Vec<String>,
     pub account_manager: AccountManager,
     pub data_cache: DataCache,
@@ -116,6 +118,7 @@ impl Model {
             input_file_paths: vec![],
             outputs: vec![],
             working_directory: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            alias_map: HashMap::new(),
             ..Default::default()
         }
     }
@@ -146,6 +149,7 @@ impl Model {
             node_lookup: self.node_lookup.clone(),
             ini_document: None,
             baseline_canonical: None,
+            alias_map: self.alias_map.clone(),
         }
     }
 
@@ -649,9 +653,16 @@ impl Model {
         Ok(kp.resolved)
     }
 
+    /// Load input data from a file and store it in the model's inputs vector.
+    /// Responsible for remembering how the input was loaded (original path, alias) and for resolving the path.
+    /// Construction of the TimeseriesInput is delegated to the TimeseriesInput::load function.
     pub fn load_input_data(&mut self, file_path: &str, alias: Option<&str>) -> Result<usize, String> {
         // Remember the ORIGINAL input file path (for serialization/display)
         self.input_file_paths.push(file_path.to_string());
+        // Remember also the alias if provided
+        if let Some(alias_str) = alias {
+            self.alias_map.insert(file_path.to_string(), alias_str.to_string());
+        }
 
         // Resolve the path (supports absolute, relative, and trailhead paths)
         let resolved_path = self.resolve_path(file_path)?;

--- a/src/tests/test_model_io_ini.rs
+++ b/src/tests/test_model_io_ini.rs
@@ -275,6 +275,10 @@ fn test_save_noop_is_byte_identical() {
     // Phase 2: loading then saving with NO change must reproduce the source
     // byte-for-byte, including original number formatting, spacing, comments,
     // continuations and the awkward node types.
+    // This is the reason the fixture's [kalix] section must NOT set
+    // save_method = canonical: canonical mode intentionally reformats values
+    // (e.g. drops trailing zeros), which would break the byte-identical
+    // assertion below.
     // `include_str!` captures the file with the checkout's line endings (CRLF on
     // Windows via core.autocrlf, LF elsewhere). The serializer emits LF by design
     // (the parser strips `\r` via `str::lines()`), so normalise the expected side


### PR DESCRIPTION
This PR addresses #316.

Three main parts to this PR:
- Adds "save_method" property to [kalix] section
  - Implemented via enum in configuration and exhaustive match, enforcing correctness from the compiler on the cold path (run once model initialisation), at the expense of some boilerplate to be considered if/when we add new save methods.
- Add a "resave" command to expose a dedicated "read and save" utility. This is used to extend verify_all_models.py to catch errors on canonicalisation. This doubles the number of tests run (i.e. run once to check mass balance, then run again to check that canonicalisation does not introduce bugs (e.g. dropped properties).
- The last two commits (48c401f and 7756921) address specific bugs that have not been previously detected - see #287 for aliases, and an undocumented bug dropping force_release parameters from PR #295.

Note that there is no test that pins the canonicalised format down (down to e.g. number of spaces) or tests for idempotency.

# Closing keywords

Closes #316, closes #287.