### PR TITLE
Feature: Zip/unzip context menu item in file tree

### DIFF
--- a/kalixide/build.gradle.kts
+++ b/kalixide/build.gradle.kts
@@ -63,6 +63,9 @@ dependencies {
     // Directory watching with native FSEvents on macOS (project tree live updates)
     implementation("io.methvin:directory-watcher:0.18.0")
 
+    // Source: https://mvnrepository.com/artifact/net.lingala.zip4j/zip4j
+    implementation("net.lingala.zip4j:zip4j:2.11.6")
+
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/FileTreeCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/FileTreeCellRenderer.java
@@ -64,6 +64,9 @@ public class FileTreeCellRenderer extends DefaultTreeCellRenderer {
         if (lower.endsWith(".md") || lower.endsWith(".txt") || lower.endsWith(".log")) {
             return FontAwesomeSolid.FILE_ALT;
         }
+        if (lower.endsWith(".zip")) {
+            return FontAwesomeSolid.FILE_ARCHIVE;
+        }
         return FontAwesomeSolid.FILE;
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/ProjectTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/ProjectTree.java
@@ -36,8 +36,9 @@ import java.util.Set;
  * a native directory watcher (FSEvents on macOS via {@code io.methvin:directory-watcher}).
  *
  * <p>Provides full-width row hover, path tooltips, a right-click context menu (Open, Reveal,
- * New File/Folder, Rename, Delete, Refresh), and open-on-double-click / Enter. Files are
- * opened through the supplied consumer (which adds them as editor tabs).
+ * New File/Folder, Rename, Delete, Refresh), and open-on-double-click / Enter (zip archives
+ * are unzipped instead of opened). Files are opened through the supplied consumer (which adds
+ * them as editor tabs).
  *
  * <p>All model mutations happen on the EDT; watcher callbacks marshal onto it.
  */
@@ -256,20 +257,20 @@ public class ProjectTree extends JTree {
                 if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
                     FileTreeNode node = nodeAt(e.getX(), e.getY());
                     if (node != null && node.getFile().isFile()) {
-                        host.openFile(node.getFile());
+                        openOrUnzip(node.getFile());
                     }
                 }
             }
         });
 
-        // Enter opens the selected file.
+        // Enter opens the selected file (or unzips it, if it's a zip archive).
         getInputMap().put(javax.swing.KeyStroke.getKeyStroke("ENTER"), "openSelected");
         getActionMap().put("openSelected", new javax.swing.AbstractAction() {
             @Override
             public void actionPerformed(java.awt.event.ActionEvent e) {
                 List<FileTreeNode> selection = selectedNodes();
                 if (selection.size() == 1 && !selection.get(0).isDirectory()) {
-                    host.openFile(selection.get(0).getFile());
+                    openOrUnzip(selection.get(0).getFile());
                 }
             }
         });
@@ -302,6 +303,15 @@ public class ProjectTree extends JTree {
                 }
             }
         });
+    }
+
+    /** Unzips {@code file} if it's a zip archive, otherwise opens it as an editor tab. */
+    private void openOrUnzip(File file) {
+        if (TreeFileOperations.isZip(file)) {
+            fileOps.unzipFile(file);
+        } else {
+            host.openFile(file);
+        }
     }
 
     private boolean isRoot(FileTreeNode node) {

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
@@ -97,7 +97,12 @@ class TreeContextMenu {
                 item("Compare with active editor", TreeContextMenu::isSingleFile,
                     sel -> host.compareWithActiveEditor(file(sel))),
                 item("Compare files", TreeContextMenu::isTwoFiles,
-                    sel -> host.compareFiles(file(sel, 0), file(sel, 1)))
+                    sel -> host.compareFiles(file(sel, 0), file(sel, 1))),
+                item("Zip", TreeContextMenu::isNotSingleZip,
+                        sel -> fileOps.zipFiles(files(sel), tree.getRootFile())),
+                item("Unzip", TreeContextMenu::isSingleZip,
+                        sel -> fileOps.unzipFile(file(sel)))
+
             ),
             // External handoff
             List.of(
@@ -120,8 +125,7 @@ class TreeContextMenu {
                 item("New file…", TreeContextMenu::isSingle,
                     sel -> fileOps.createChild(file(sel), false)),
                 item("New folder…", TreeContextMenu::isSingle,
-                    sel -> fileOps.createChild(file(sel), true))
-            ),
+                    sel -> fileOps.createChild(file(sel), true))),
             // Modify
             List.of(
                 item("Rename…", TreeContextMenu::isSingle,
@@ -184,6 +188,21 @@ class TreeContextMenu {
 
     private static boolean hasDirectory(List<FileTreeNode> sel) {
         return sel.stream().anyMatch(FileTreeNode::isDirectory);
+    }
+
+    private static boolean isSingleZip(List<FileTreeNode> sel) {
+        return sel.size() == 1 && TreeFileOperations.isZip(file(sel));
+    }
+
+    private static boolean isNotSingleZip(List<FileTreeNode> sel) {
+        return any(sel) && isNotZip(sel);
+    }
+
+    /**
+     * Return true if none of {@code sel} are zip files
+     */
+    private static boolean isNotZip(List<FileTreeNode> sel) {
+        return sel.stream().noneMatch((x) -> TreeFileOperations.isZip(x.getFile()));
     }
 
     // --- Selection accessors ---

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
@@ -89,12 +89,12 @@ class TreeContextMenu {
         return List.of(
             // Primary
             List.of(
-                item("Open", TreeContextMenu::isSingleFile,
+                item("Open", TreeContextMenu::isSingleNonZipFile,
                     sel -> host.openFile(file(sel)))
             ),
             // Context-specific
             List.of(
-                item("Compare with active editor", TreeContextMenu::isSingleFile,
+                item("Compare with active editor", TreeContextMenu::isSingleNonZipFile,
                     sel -> host.compareWithActiveEditor(file(sel))),
                 item("Compare files", TreeContextMenu::isTwoFiles,
                     sel -> host.compareFiles(file(sel, 0), file(sel, 1))),
@@ -178,8 +178,8 @@ class TreeContextMenu {
         return sel.size() == 1;
     }
 
-    private static boolean isSingleFile(List<FileTreeNode> sel) {
-        return sel.size() == 1 && !sel.get(0).isDirectory();
+    private static boolean isSingleNonZipFile(List<FileTreeNode> sel) {
+        return sel.size() == 1 && !sel.getFirst().isDirectory() && isNotZip(sel);
     }
 
     private static boolean isTwoFiles(List<FileTreeNode> sel) {

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
@@ -183,7 +183,7 @@ class TreeContextMenu {
     }
 
     private static boolean isTwoFiles(List<FileTreeNode> sel) {
-        return sel.size() == 2 && sel.stream().noneMatch(FileTreeNode::isDirectory);
+        return sel.size() == 2 && sel.stream().noneMatch(FileTreeNode::isDirectory) && isNotZip(sel);
     }
 
     private static boolean hasDirectory(List<FileTreeNode> sel) {

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeContextMenu.java
@@ -53,7 +53,7 @@ class TreeContextMenu {
         for (List<Entry> group : groups) {
             List<Entry> visible = group.stream()
                 .filter(e -> e.visible.test(selection))
-                .collect(Collectors.toList());
+                .toList();
             if (visible.isEmpty()) {
                 continue;
             }
@@ -87,22 +87,26 @@ class TreeContextMenu {
         // primary -> context-specific -> external handoff -> clipboard -> create ->
         // modify -> destructive (isolated) -> view/state. Labels are sentence case.
         return List.of(
+            // Primary
             List.of(
                 item("Open", TreeContextMenu::isSingleFile,
                     sel -> host.openFile(file(sel)))
             ),
+            // Context-specific
             List.of(
                 item("Compare with active editor", TreeContextMenu::isSingleFile,
                     sel -> host.compareWithActiveEditor(file(sel))),
                 item("Compare files", TreeContextMenu::isTwoFiles,
                     sel -> host.compareFiles(file(sel, 0), file(sel, 1)))
             ),
+            // External handoff
             List.of(
                 item(revealLabel(), TreeContextMenu::isSingle,
                     sel -> fileOps.reveal(file(sel))),
                 item("Launch Terminal", TreeContextMenu::isSingle,
                     sel -> fileOps.openTerminal(file(sel)))
             ),
+            // Clipboard
             List.of(
                 item("Copy relative path", TreeContextMenu::any,
                     sel -> fileOps.copyRelativePaths(files(sel))),
@@ -111,22 +115,26 @@ class TreeContextMenu {
                 item("Copy trailhead path", TreeContextMenu::any,
                     sel -> fileOps.copyTrailheadPaths(files(sel)))
             ),
+            // Create
             List.of(
                 item("New file…", TreeContextMenu::isSingle,
                     sel -> fileOps.createChild(file(sel), false)),
                 item("New folder…", TreeContextMenu::isSingle,
                     sel -> fileOps.createChild(file(sel), true))
             ),
+            // Modify
             List.of(
                 item("Rename…", TreeContextMenu::isSingle,
                     sel -> fileOps.rename(file(sel))),
                 item("Duplicate…", TreeContextMenu::isSingle,
                     sel -> fileOps.duplicate(file(sel)))
             ),
+            // Destructive (isolated)
             List.of(
                 item("Delete", TreeContextMenu::any,
                     sel -> fileOps.delete(files(sel)), MenuIcons::delete)
             ),
+            // View
             List.of(
                 item("Expand children", TreeContextMenu::hasDirectory,
                     sel -> directories(sel).forEach(tree::expandSubtree)),
@@ -181,7 +189,7 @@ class TreeContextMenu {
     // --- Selection accessors ---
 
     private static File file(List<FileTreeNode> sel) {
-        return sel.get(0).getFile();
+        return sel.getFirst().getFile();
     }
 
     private static File file(List<FileTreeNode> sel, int index) {

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import net.lingala.zip4j.ZipFile;
 
 /**
  * The side-effecting file operations behind the project tree's context menu and keyboard
@@ -439,5 +440,72 @@ class TreeFileOperations {
 
     private void showPathError(String message) {
         JOptionPane.showMessageDialog(parent, message, "Copy Path", JOptionPane.WARNING_MESSAGE);
+    }
+
+    /**
+     * Zip the chosen file(s) in the file tree.
+     */
+    void zipFiles(List<File> files, File rootFile) {
+        if (files == null || files.isEmpty()) { return; }
+
+        String zipFileName = getZipFileName(files, rootFile);
+
+        try (ZipFile zipFile = new ZipFile(zipFileName);) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    zipFile.addFolder(file);
+                } else {
+                    zipFile.addFile(file);
+                }
+            }
+        } catch (IllegalStateException | IOException ex) {
+            showPathError(ex.getMessage());
+        }
+    }
+
+    /**
+     * Determine the zip file name to be used in {@link TreeFileOperations#zipFiles(List, File)}
+     * <br><br>
+     * If {@code files} is length 1, returns the file/folder name with .zip in that directory.
+     * Else it creates a files.zip in the common ancestor directory of all selected files
+     * (bounded below by {@code rootFile}'s parent, in case the selection has no closer
+     * common ancestor within the workspace).
+     * If there is a name collision, it will append {@code (n)} where {@code n} is incremented
+     * until there is no name collision.
+     */
+    private static String getZipFileName(List<File> selFiles, File rootFile) {
+        String baseZFName;
+        if (selFiles.size() == 1) { baseZFName = selFiles.getFirst().getAbsolutePath(); }
+        else {
+            // TODO Multiple files 
+        }
+        // Ensure no name collision
+        String zipFileName = baseZFName + ".zip";
+        int i = 0;
+        while (new File(zipFileName).exists()) {
+            zipFileName = baseZFName + " (" + i + ").zip";
+            i++;
+        }
+        return zipFileName;
+    }
+
+    /**
+     * Detect if {@code file} is a zip file.
+     */
+    static boolean isZip(File file) {
+        return file.toString().endsWith(".zip");
+    }
+
+
+    /**
+     * Unzip the selected zip folder into the same directory.
+     */
+    void unzipFile(File file) {
+        try (ZipFile zipFile = new ZipFile(file);) {
+            String targetPath = file.getParentFile().getAbsolutePath();
+            zipFile.extractAll(targetPath);
+        } catch (IllegalStateException | IOException ex) {
+            showPathError(ex.getMessage());
+        }
     }
 }

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
@@ -447,11 +447,10 @@ class TreeFileOperations {
      */
     void zipFiles(List<File> files, File rootFile) {
         if (files == null || files.isEmpty()) { return; }
-
-        String zipFileName = getZipFileName(files, rootFile);
-
+        List<File> targets = withoutDescendants(files);
+        String zipFileName = getZipFileName(targets, rootFile);
         try (ZipFile zipFile = new ZipFile(zipFileName);) {
-            for (File file : files) {
+            for (File file : targets) {
                 if (file.isDirectory()) {
                     zipFile.addFolder(file);
                 } else {

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
@@ -18,6 +18,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.FileHeader;
 
 /**
  * The side-effecting file operations behind the project tree's context menu and keyboard
@@ -521,14 +522,43 @@ class TreeFileOperations {
     // TODO double click zip folder to unzip
 
     /**
-     * Unzip the selected zip folder into the same directory.
+     * Unzip the selected zip folder into the same directory. Zip4j extracts by overwriting any
+     * existing file of the same name without warning, so entries that would collide with
+     * existing files are surfaced in a confirmation prompt first.
      */
     void unzipFile(File file) {
-        try (ZipFile zipFile = new ZipFile(file);) {
-            String targetPath = file.getParentFile().getAbsolutePath();
-            zipFile.extractAll(targetPath);
+        File targetDir = file.getParentFile();
+        try (ZipFile zipFile = new ZipFile(file)) {
+            List<String> collisions = collidingEntries(zipFile, targetDir);
+            if (!collisions.isEmpty() && !confirmOverwrite(collisions)) {
+                return;
+            }
+            zipFile.extractAll(targetDir.getAbsolutePath());
         } catch (IllegalStateException | IOException ex) {
             showPathError(ex.getMessage());
         }
+    }
+
+    /** The zip entry names that would overwrite a file already present in {@code targetDir}. */
+    private static List<String> collidingEntries(ZipFile zipFile, File targetDir) throws IOException {
+        List<String> collisions = new ArrayList<>();
+        for (FileHeader header : zipFile.getFileHeaders()) {
+            if (new File(targetDir, header.getFileName()).exists()) {
+                collisions.add(header.getFileName());
+            }
+        }
+        return collisions;
+    }
+
+    private boolean confirmOverwrite(List<String> collisions) {
+        String message = (collisions.size() == 1
+            ? "\"" + collisions.get(0) + "\" already exists and will be overwritten."
+            : collisions.size() + " items already exist and will be overwritten:\n\n"
+                + String.join("\n", collisions.subList(0, Math.min(collisions.size(), 10)))
+                + (collisions.size() > 10 ? "\n..." : ""))
+            + "\n\nContinue?";
+        int choice = JOptionPane.showConfirmDialog(parent, message,
+            "Unzip", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+        return choice == JOptionPane.YES_OPTION;
     }
 }

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
@@ -477,7 +477,16 @@ class TreeFileOperations {
         String baseZFName;
         if (selFiles.size() == 1) { baseZFName = selFiles.getFirst().getAbsolutePath(); }
         else {
-            // TODO Multiple files 
+            Path rootDirPath = Path.of(rootFile.getParent()).toAbsolutePath().normalize();
+            Path commonAncestor = null;
+            for (File file : selFiles) {
+                Path parent = file.toPath().toAbsolutePath().normalize().getParent();
+                commonAncestor = (commonAncestor == null) ? parent : commonAncestor(commonAncestor, parent);
+            }
+            if (commonAncestor == null || !commonAncestor.startsWith(rootDirPath)) {
+                commonAncestor = rootDirPath;
+            }
+            baseZFName = commonAncestor.resolve("files").toString();
         }
         // Ensure no name collision
         String zipFileName = baseZFName + ".zip";
@@ -490,12 +499,27 @@ class TreeFileOperations {
     }
 
     /**
+     * The deepest shared ancestor directory of two absolute, normalized paths, or {@code null}
+     * if they share no path components (e.g. different filesystem roots).
+     */
+    private static Path commonAncestor(Path a, Path b) {
+        if (!a.getRoot().equals(b.getRoot())) { return null; }
+        Path result = a.getRoot();
+        int count = Math.min(a.getNameCount(), b.getNameCount());
+        for (int i = 0; i < count && a.getName(i).equals(b.getName(i)); i++) {
+            result = result.resolve(a.getName(i));
+        }
+        return result;
+    }
+
+    /**
      * Detect if {@code file} is a zip file.
      */
     static boolean isZip(File file) {
         return file.toString().endsWith(".zip");
     }
 
+    // TODO double click zip folder to unzip
 
     /**
      * Unzip the selected zip folder into the same directory.

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
@@ -490,7 +490,7 @@ class TreeFileOperations {
         }
         // Ensure no name collision
         String zipFileName = baseZFName + ".zip";
-        int i = 0;
+        int i = 1;
         while (new File(zipFileName).exists()) {
             zipFileName = baseZFName + " (" + i + ").zip";
             i++;
@@ -513,10 +513,11 @@ class TreeFileOperations {
     }
 
     /**
-     * Detect if {@code file} is a zip file.
+     * Detect if {@code file} is a zip file. Case-insensitive: Windows and macOS filesystems
+     * are case-insensitive, so ".ZIP"/".Zip" are just as much a zip as ".zip".
      */
     static boolean isZip(File file) {
-        return file.toString().endsWith(".zip");
+        return file.toString().toLowerCase().endsWith(".zip");
     }
 
     // TODO double click zip folder to unzip
@@ -539,11 +540,15 @@ class TreeFileOperations {
         }
     }
 
-    /** The zip entry names that would overwrite a file already present in {@code targetDir}. */
+    /**
+     * The zip entry names that would overwrite a file already present in {@code targetDir}.
+     * Directory entries are skipped: extracting into an existing folder merges its contents
+     * rather than overwriting the folder itself, so it isn't a collision.
+     */
     private static List<String> collidingEntries(ZipFile zipFile, File targetDir) throws IOException {
         List<String> collisions = new ArrayList<>();
         for (FileHeader header : zipFile.getFileHeaders()) {
-            if (new File(targetDir, header.getFileName()).exists()) {
+            if (!header.isDirectory() && new File(targetDir, header.getFileName()).exists()) {
                 collisions.add(header.getFileName());
             }
         }

--- a/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
+++ b/kalixide/src/main/java/com/kalix/ide/workspace/tree/TreeFileOperations.java
@@ -520,8 +520,6 @@ class TreeFileOperations {
         return file.toString().toLowerCase().endsWith(".zip");
     }
 
-    // TODO double click zip folder to unzip
-
     /**
      * Unzip the selected zip folder into the same directory. Zip4j extracts by overwriting any
      * existing file of the same name without warning, so entries that would collide with


### PR DESCRIPTION
This adds a dependency for zip4j which is an existing library to wrap native Java code - this is widely used and prevents common pitfalls e.g. loss of file properties or corruption of data.

Main implementation is in TreeFileOperations and TreeContextMenu. Double click unzip functionality included, and will confirm before overwriting files if file/folder already exists in the target folder. 

This pull request closes #292.