### PR TITLE
#339 Fix negative orders

### DIFF
--- a/src/nodes/loss_node.rs
+++ b/src/nodes/loss_node.rs
@@ -153,7 +153,9 @@ impl Node for LossNode {
             data_cache.add_value_at_index(idx, self.dsorders[0]);
         }
 
-        // Calculate usorders
+        // Calculate usorders 
+        // Note: order_translation_table is well-formed and non-negative by
+        // construction, see `initialise()`, so cannot return negative orders
         self.usorders = self.order_translation_table.interpolate_or_extrapolate(self.dsorders[0]);
     }
 

--- a/src/nodes/order_control_node.rs
+++ b/src/nodes/order_control_node.rs
@@ -120,7 +120,8 @@ impl Node for OrderControlNode {
                 order = order.min(self.max_order_value);
             }
         }
-        self.usorders = order;
+        // Defend against setting negative orders
+        self.usorders = order.max(0f64);
     }
 
     fn run_flow_phase(&mut self, data_cache: &mut DataCache, _account_manager: &mut AccountManager) {

--- a/src/nodes/regulated_user_node.rs
+++ b/src/nodes/regulated_user_node.rs
@@ -163,6 +163,9 @@ impl Node for RegulatedUserNode {
                     excess -= debit;
                 }
             }
+        } else {
+            // Ensure non-negativity of orders
+            self.order_value = self.order_value.max(0.0);
         }
 
         // TODO: is this where things are supposed to happen?


### PR DESCRIPTION
TL;DR: This PR enforces non-negativity of orders at creation time.

Fundamentally a small (one commit) change but does include the decisions (hence PR) that 
(a) negative orders are meaningless,
(b) non-negativity of orders are the responsibility of the creator, not the propagators (routing nodes etc., i.e. no checks in line with performance aims), and 
(c) negative orders are not rejected, but clamped to 0 - this arises particularly in the case where an order_control node receives an expression from the user which may go negative. This is recorded as a negative `set_order` or `max_order`, but 0 in the orders recorder (internal variable `self.usorders`).