### PR TITLE
(#355)  Model static scalar properties accessible from DynamicExpressions through const-like register in the DataCache

### DIFF
--- a/docs/node_references.md
+++ b/docs/node_references.md
@@ -42,6 +42,25 @@ Most nodes produce a subset of these outputs:
 | `rain` | Precipitation input (mm) |
 | `evap` | Evapotranspiration (mm) |
 
+## Static Node Properties
+
+Some node properties are fixed for the whole simulation — the value declared
+in the `[node.*]` section itself, not something computed at each timestep.
+These read the same way, as `node.<name>.<property>`:
+
+| Property | Node types | Description |
+|----------|-------------|-------------|
+| `area` | GR4J, Sacramento | Catchment area [km2] — the declared `area` value |
+| `x` | Routing | Inflow bias used by the storage routing solver |
+| `typical_regulated_flow` | Routing | Representative regulated flow [ML] used to estimate travel time for order propagation |
+| `initial_volume` | Storage | Initial storage volume [ML] |
+
+Because these never change during a run, they don't support the offset syntax
+below — there is no history to look back into, the same restriction as
+`const.*` constants. They can be listed directly in `[outputs]` like any
+other result; the recorded series simply repeats the declared value at every
+timestep.
+
 ## Using Node References
 
 Reference another node's output in any dynamic expression:

--- a/docs/water_management/kalix-allocation-components.md
+++ b/docs/water_management/kalix-allocation-components.md
@@ -125,11 +125,11 @@ ledger touched only by node takes.
 
 ### 3.2 Accounts readable in expressions — the `acc.*` namespace
 
-Account state is published as ordinary data-cache series, so it resolves in
+Most account state is published as ordinary data-cache series, resolving in
 expressions by exactly the mechanism that serves `node.<name>.<output>`: a
 reference creates the series, the account manager registers the writer, and
-`[outputs]` records it. Three fields per account, plus the same three summed
-over each group (`acc.<group>.<field>`):
+`[outputs]` records it. Three such fields per account, plus the same three
+summed over each group (`acc.<group>.<field>`):
 
 | Field | Written | Readable within the step |
 |---|---|---|
@@ -139,8 +139,16 @@ over each group (`acc.<group>.<field>`):
 
 `debits` is *water used*: only node takes feed it, and it resets each step, so
 `[ras.*]` credits, resets and write-offs are excluded by construction.
-`acc.<name>.size` remains available as a recorder (it is static, so exposing
-constant properties to expressions properly is a separate piece of work).
+
+`size` and `initial` are different — they're declared, not computed, and
+never change during a run, so they're registered directly into
+`DataCache::static_properties` at load (alongside the equivalent static node
+properties — catchment area, routing's `x`, a storage's `initial_volume` —
+see `docs/node_references.md`), not published as a per-step series. That
+makes them readable *unconditionally*, from the very first line of the model,
+with none of the write-timing caveats above and no account-manager recorder
+wiring at all — a stronger guarantee than the "separate piece of work" this
+section used to defer that to.
 
 **Two views, deliberately.** `opening_balance` is the post-policy, pre-take
 snapshot: every expression reader sees the same value however the nodes happen

--- a/kalixide/src/main/java/com/kalix/ide/linter/utils/ValidationUtils.java
+++ b/kalixide/src/main/java/com/kalix/ide/linter/utils/ValidationUtils.java
@@ -214,9 +214,11 @@ public class ValidationUtils {
     /** Fields published per account, per account group, and per RAS. Mirror
      *  the engine's ACCOUNT_SERIES_FIELDS / GROUP_SERIES_FIELDS
      *  (src/hydrology/accounts/account_manager.rs) — groups aggregate every
-     *  account field, `size` and `use` included. */
+     *  account field, `size` and `use` included. `size` and `initial` are
+     *  static (fixed at load, not per-step), but are still valid field names
+     *  here. */
     private static final java.util.Set<String> ACCOUNT_OUTPUT_FIELDS =
-        java.util.Set.of("opening_balance", "closing_balance", "debits", "allocation", "use", "size");
+        java.util.Set.of("opening_balance", "closing_balance", "debits", "allocation", "use", "size", "initial");
     private static final java.util.Set<String> ACCOUNT_GROUP_OUTPUT_FIELDS = ACCOUNT_OUTPUT_FIELDS;
     private static final java.util.Set<String> RAS_OUTPUT_FIELDS = java.util.Set.of("fired", "pct");
 

--- a/kalixide/src/main/java/com/kalix/ide/linter/validators/FunctionExpressionValidator.java
+++ b/kalixide/src/main/java/com/kalix/ide/linter/validators/FunctionExpressionValidator.java
@@ -368,9 +368,11 @@ public class FunctionExpressionValidator {
     }
 
     /** Fields published per account (`acc.<account>.<field>`). Mirrors the
-     *  engine's ACCOUNT_SERIES_FIELDS (src/hydrology/accounts/account_manager.rs). */
+     *  engine's ACCOUNT_SERIES_FIELDS (src/hydrology/accounts/account_manager.rs).
+     *  `size` and `initial` are static (fixed at load, not per-step), but are
+     *  still valid field names here. */
     private static final java.util.Set<String> ACCOUNT_FIELDS =
-        java.util.Set.of("opening_balance", "closing_balance", "debits", "allocation", "use", "size");
+        java.util.Set.of("opening_balance", "closing_balance", "debits", "allocation", "use", "size", "initial");
 
     /** Fields published per account group: every account field is aggregated
      *  (summed) over the members, `size` and `use` included. Mirrors the

--- a/kalixide/src/main/resources/linter/kalix-model-schema.json
+++ b/kalixide/src/main/resources/linter/kalix-model-schema.json
@@ -72,7 +72,8 @@
         "runoff_depth",
         "dsflow",
         "ds_1",
-        "ds_1_order"
+        "ds_1_order",
+        "area"
       ],
       "required_params": [
         "type",
@@ -175,7 +176,8 @@
         "roimp",
         "flosf",
         "flobf",
-        "floin"
+        "floin",
+        "area"
       ],
       "required_params": [
         "type",
@@ -384,7 +386,8 @@
         "seep_vol",
         "evap_vol",
         "pond_demand",
-        "exists"
+        "exists",
+        "initial_volume"
       ],
       "required_params": [
         "type",
@@ -511,7 +514,9 @@
         "dsflow",
         "volume",
         "ds_1",
-        "ds_1_order"
+        "ds_1_order",
+        "x",
+        "typical_regulated_flow"
       ],
       "required_params": [
         "type",

--- a/src/data_management/constants_cache.rs
+++ b/src/data_management/constants_cache.rs
@@ -46,6 +46,11 @@ impl ConstantsCache {
         }
     }
 
+    /// Returns the index of a constant if it exists
+    pub fn get_idx(&self, name: &str) -> Option<usize> {
+        self.name_idx_map.get(name).copied()
+    }
+
     /// This provides fast access to the f64 values given an idx. Consumers can use this to say
     ///    "Here is an idx I have been provided. Give me the value."
     ///

--- a/src/data_management/constants_cache.rs
+++ b/src/data_management/constants_cache.rs
@@ -1,5 +1,10 @@
 use std::collections::HashMap;
 
+/// A name-addressable cache of scalar f64 values, indexed both by name and by a
+/// stable integer idx for fast repeated access.
+///
+/// Every name-taking entry point lowercases its `name` argument by design, to
+/// ensure case-insensitivity.
 #[derive(Clone, Default)]
 pub struct ConstantsCache {
 
@@ -39,16 +44,17 @@ impl ConstantsCache {
     ///    "Hey I'm going to want to use a constant called this. Please register the name and give
     ///    me an idx that I can use for quick access later."
     pub fn add_if_needed_and_get_idx(&mut self, name: &str) -> usize {
-        if let Some(idx) = self.name_idx_map.get(name) {
+        let name = name.to_lowercase();
+        if let Some(idx) = self.name_idx_map.get(name.as_str()) {
             *idx
         } else {
-            self.push(name.to_string(), false, 0f64)
+            self.push(name, false, 0f64)
         }
     }
 
     /// Returns the index of a constant if it exists
     pub fn get_idx(&self, name: &str) -> Option<usize> {
-        self.name_idx_map.get(name).copied()
+        self.name_idx_map.get(name.to_lowercase().as_str()).copied()
     }
 
     /// This provides fast access to the f64 values given an idx. Consumers can use this to say
@@ -69,6 +75,7 @@ impl ConstantsCache {
     /// Sets the value of a constant and returns the idx. If the constant does not already exist
     /// it will be added.
     pub fn set_value(&mut self, name: &str, value: f64) -> usize {
+        // add_if_needed_and_get_idx normalizes the name.
         let idx = self.add_if_needed_and_get_idx(name);
         self.value[idx] = value;
         self.is_assigned[idx] = true;
@@ -100,7 +107,7 @@ impl ConstantsCache {
 
     /// Get the value of a constant by name
     pub fn get_value_by_name(&self, name: &str) -> Result<f64, String> {
-        match self.name_idx_map.get(name) {
+        match self.name_idx_map.get(name.to_lowercase().as_str()) {
             Some(&idx) => Ok(self.value[idx]),
             None => Err(format!("Constant '{}' does not exist", name)),
         }

--- a/src/data_management/data_cache.rs
+++ b/src/data_management/data_cache.rs
@@ -101,6 +101,9 @@ pub struct DataCache {
     /// Constants cache
     pub constants: ConstantsCache,
 
+    /// Static properties cache - internal index for expression resolution
+    pub static_properties: ConstantsCache,
+
     // --- Cold from here down: touched at load/initialise, not per step ---
 
     pub series_name: Vec<String>,

--- a/src/data_management/data_cache.rs
+++ b/src/data_management/data_cache.rs
@@ -92,13 +92,13 @@ pub struct DataCache {
     /// them. Public so flag-machinery unit tests can opt in explicitly.
     pub needs_calendar_flags: bool,
 
-    // Expression runtime state (program locals; stateful-builtin state).
-    // Slot ranges are allocated during expression lowering. Hot for models
-    // using programs or stateful functions; the Vec headers live here, the
-    // slots on the heap.
+    /// Expression runtime state (program locals; stateful-builtin state).
+    /// Slot ranges are allocated during expression lowering. Hot for models
+    /// using programs or stateful functions; the Vec headers live here, the
+    /// slots on the heap.
     pub expr_state: ExprStateArena,
 
-    // Constants cache
+    /// Constants cache
     pub constants: ConstantsCache,
 
     // --- Cold from here down: touched at load/initialise, not per step ---
@@ -112,12 +112,12 @@ pub struct DataCache {
     /// is O(1) instead of a linear scan over every series name.
     name_lookup: FxHashMap<String, usize>,
 
-    // Named lookup tables ([table.*] sections), resolved by expressions at
-    // model load. Arc-shared, so cloning the cache is cheap.
+    /// Named lookup tables ([table.*] sections), resolved by expressions at
+    /// model load. Arc-shared, so cloning the cache is cheap.
     pub tables: TableRegistry,
 
-    // User-defined functions ([fn] section), inlined into expressions at
-    // lowering. Arc-shared defs, so cloning the cache is cheap.
+    /// User-defined functions ([fn] section), inlined into expressions at
+    /// lowering. Arc-shared defs, so cloning the cache is cheap.
     pub fns: crate::functions::fn_registry::FnRegistry,
 }
 

--- a/src/hydrology/accounts/account_manager.rs
+++ b/src/hydrology/accounts/account_manager.rs
@@ -51,7 +51,6 @@ pub struct AccountManager {
     recorder_acc_debits: Vec<(usize, usize)>,
     recorder_acc_allocation: Vec<(usize, usize)>,
     recorder_acc_use: Vec<(usize, usize)>,
-    recorder_acc_size: Vec<(usize, usize)>,
     recorder_grp_opening: Vec<(usize, usize)>,
     recorder_grp_closing: Vec<(usize, usize)>,
     recorder_grp_debits: Vec<(usize, usize)>,
@@ -87,7 +86,6 @@ impl AccountManager {
             recorder_acc_debits: Vec::new(),
             recorder_acc_allocation: Vec::new(),
             recorder_acc_use: Vec::new(),
-            recorder_acc_size: Vec::new(),
             recorder_grp_opening: Vec::new(),
             recorder_grp_closing: Vec::new(),
             recorder_grp_debits: Vec::new(),
@@ -176,7 +174,6 @@ impl AccountManager {
         self.recorder_acc_debits.clear();
         self.recorder_acc_allocation.clear();
         self.recorder_acc_use.clear();
-        self.recorder_acc_size.clear();
         self.recorder_grp_opening.clear();
         self.recorder_grp_closing.clear();
         self.recorder_grp_debits.clear();
@@ -200,7 +197,11 @@ impl AccountManager {
             register("debits", &mut self.recorder_acc_debits, &mut any);
             register("allocation", &mut self.recorder_acc_allocation, &mut any);
             register("use", &mut self.recorder_acc_use, &mut any);
-            register("size", &mut self.recorder_acc_size, &mut any);
+            // No per-account "size" recorder: acc.<name>.size is static, so it now
+            // lives in DataCache::static_properties (registered at INI load) and is
+            // filled directly wherever it's named in [outputs] - see
+            // Model::configure(). The group aggregate below still needs its own
+            // recorder, since group sums aren't static properties.
             self.has_recorders |= any;
         }
 
@@ -227,20 +228,18 @@ impl AccountManager {
 
         self.has_opening_recorders =
             !self.recorder_acc_opening.is_empty() || !self.recorder_grp_opening.is_empty();
-        self.has_size_recorders =
-            !self.recorder_acc_size.is_empty() || !self.recorder_grp_size.is_empty();
+        self.has_size_recorders = !self.recorder_grp_size.is_empty();
     }
 
-    /// Publish the size series (account and group-sum) for this step. Called
-    /// at the very top of run_timestep, before the [ras.*] loop: sizes are
-    /// static, so writing them first makes `acc.<x>.size` bare-readable at
-    /// any point in the step — including announce-time resource assessments
-    /// like `allocate(table.curve(... / acc.hp.size))`.
+    /// Publish the group-sum size series for this step. Called at the very
+    /// top of run_timestep, before the [ras.*] loop: sizes are static, so
+    /// writing them first makes `acc.<group>.size` bare-readable at any point
+    /// in the step — including announce-time resource assessments like
+    /// `allocate(table.curve(... / acc.hp.size))`. Individual account size
+    /// needs no such write: it's filled once, directly, from
+    /// `static_properties` (see Model::configure()).
     pub fn publish_sizes(&self, data_cache: &mut DataCache) {
         if !self.has_size_recorders { return; }
-        for &(account_idx, series_idx) in &self.recorder_acc_size {
-            data_cache.add_value_at_index(series_idx, self.accounts[account_idx].size);
-        }
         for &(group_idx, series_idx) in &self.recorder_grp_size {
             let total = self.group_sum(group_idx, |a| a.size);
             data_cache.add_value_at_index(series_idx, total);

--- a/src/hydrology/accounts/account_manager.rs
+++ b/src/hydrology/accounts/account_manager.rs
@@ -53,14 +53,17 @@ pub struct AccountManager {
     recorder_grp_use: Vec<(usize, usize)>,
 }
 
-/// Series suffixes an `acc.<name>.<field>` reference may use. Closed set:
-/// anything else is a load error rather than a silently unwritten series.
-/// `use` is water taken since the last reset_allocation — the use term of
-/// the allocation (balance + use), fed only by node takes.
-pub const ACCOUNT_SERIES_FIELDS: [&str; 6] = ["opening_balance", "closing_balance", "debits", "allocation", "use", "size"];
+/// Fields an `acc.<name>.<field>` reference may use. Closed set: anything
+/// else is a load error rather than a silently unwritten series. `use` is
+/// water taken since the last reset_allocation — the use term of the
+/// allocation (balance + use), fed only by node takes. `size` and `initial`
+/// are static (registered into `static_properties`, not published as
+/// per-step series like the rest); everything else is a genuine per-step
+/// recorder.
+pub const ACCOUNT_SERIES_FIELDS: [&str; 7] = ["opening_balance", "closing_balance", "debits", "allocation", "use", "size", "initial"];
 
 /// Of those, the fields a *group* aggregate publishes (summed over members).
-pub const GROUP_SERIES_FIELDS: [&str; 6] = ["opening_balance", "closing_balance", "debits", "allocation", "use", "size"];
+pub const GROUP_SERIES_FIELDS: [&str; 7] = ["opening_balance", "closing_balance", "debits", "allocation", "use", "size", "initial"];
 
 impl AccountManager {
 

--- a/src/hydrology/accounts/account_manager.rs
+++ b/src/hydrology/accounts/account_manager.rs
@@ -41,11 +41,6 @@ pub struct AccountManager {
     //                     unwritten-value error and want a [-1, 0] offset).
     has_recorders: bool,
     has_opening_recorders: bool,
-    /// Size series (account and group-sum) are written at the very top of the
-    /// step, before the [ras.*] loop — sizes are static, so publishing first
-    /// makes them bare-readable everywhere, announce-time resource
-    /// assessments included.
-    has_size_recorders: bool,
     recorder_acc_opening: Vec<(usize, usize)>,
     recorder_acc_closing: Vec<(usize, usize)>,
     recorder_acc_debits: Vec<(usize, usize)>,
@@ -56,7 +51,6 @@ pub struct AccountManager {
     recorder_grp_debits: Vec<(usize, usize)>,
     recorder_grp_allocation: Vec<(usize, usize)>,
     recorder_grp_use: Vec<(usize, usize)>,
-    recorder_grp_size: Vec<(usize, usize)>,
 }
 
 /// Series suffixes an `acc.<name>.<field>` reference may use. Closed set:
@@ -80,7 +74,6 @@ impl AccountManager {
             group_lookup: FxHashMap::default(),
             has_recorders: false,
             has_opening_recorders: false,
-            has_size_recorders: false,
             recorder_acc_opening: Vec::new(),
             recorder_acc_closing: Vec::new(),
             recorder_acc_debits: Vec::new(),
@@ -91,7 +84,6 @@ impl AccountManager {
             recorder_grp_debits: Vec::new(),
             recorder_grp_allocation: Vec::new(),
             recorder_grp_use: Vec::new(),
-            recorder_grp_size: Vec::new(),
         }
     }
 
@@ -168,6 +160,8 @@ impl AccountManager {
         // Initialize result recorders. A series exists here if [outputs] asked
         // for it or an expression referenced it — same opt-in path as node
         // outputs, so referencing acc.x.opening_balance registers the writer.
+        // No need for 'size' recorders - they are static and handled in
+        // Model::configure().
         self.has_recorders = false;
         self.recorder_acc_opening.clear();
         self.recorder_acc_closing.clear();
@@ -179,7 +173,6 @@ impl AccountManager {
         self.recorder_grp_debits.clear();
         self.recorder_grp_allocation.clear();
         self.recorder_grp_use.clear();
-        self.recorder_grp_size.clear();
 
         for account_idx in 0..self.accounts.len() {
             let name = self.accounts[account_idx].name.clone();
@@ -197,15 +190,10 @@ impl AccountManager {
             register("debits", &mut self.recorder_acc_debits, &mut any);
             register("allocation", &mut self.recorder_acc_allocation, &mut any);
             register("use", &mut self.recorder_acc_use, &mut any);
-            // No per-account "size" recorder: acc.<name>.size is static, so it now
-            // lives in DataCache::static_properties (registered at INI load) and is
-            // filled directly wherever it's named in [outputs] - see
-            // Model::configure(). The group aggregate below still needs its own
-            // recorder, since group sums aren't static properties.
             self.has_recorders |= any;
         }
 
-        // Group aggregates: the same fields summed over member accounts
+        // Group aggregates: the same fields summed over member accounts.
         for group_idx in 0..self.groups.len() {
             let name = self.groups[group_idx].name.clone();
             let mut register = |field: &str, target: &mut Vec<(usize, usize)>, flag: &mut bool| {
@@ -222,28 +210,11 @@ impl AccountManager {
             register("debits", &mut self.recorder_grp_debits, &mut any);
             register("allocation", &mut self.recorder_grp_allocation, &mut any);
             register("use", &mut self.recorder_grp_use, &mut any);
-            register("size", &mut self.recorder_grp_size, &mut any);
             self.has_recorders |= any;
         }
 
         self.has_opening_recorders =
             !self.recorder_acc_opening.is_empty() || !self.recorder_grp_opening.is_empty();
-        self.has_size_recorders = !self.recorder_grp_size.is_empty();
-    }
-
-    /// Publish the group-sum size series for this step. Called at the very
-    /// top of run_timestep, before the [ras.*] loop: sizes are static, so
-    /// writing them first makes `acc.<group>.size` bare-readable at any point
-    /// in the step — including announce-time resource assessments like
-    /// `allocate(table.curve(... / acc.hp.size))`. Individual account size
-    /// needs no such write: it's filled once, directly, from
-    /// `static_properties` (see Model::configure()).
-    pub fn publish_sizes(&self, data_cache: &mut DataCache) {
-        if !self.has_size_recorders { return; }
-        for &(group_idx, series_idx) in &self.recorder_grp_size {
-            let total = self.group_sum(group_idx, |a| a.size);
-            data_cache.add_value_at_index(series_idx, total);
-        }
     }
 
     /// Start-of-step accounting, called after the [ras.*] loop and before the

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -149,10 +149,13 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
             let table = parse_account_table(&accounts_prop.value, &mut model)
                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", accounts_prop.line_number, e)))?;
 
-            // Group size is static 
+            // Group size and initial balance are both static
             let group_size: f64 = table.sizes.iter().sum();
             model.data_cache.static_properties.set_value(
                 &format!("acc.{}.size", group_name), group_size);
+            let group_initial: f64 = table.initials.iter().sum();
+            model.data_cache.static_properties.set_value(
+                &format!("acc.{}.initial", group_name), group_initial);
 
             let mut member_ids = Vec::with_capacity(table.names.len());
             for (row, name) in table.names.iter().enumerate() {

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -146,7 +146,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
             let accounts_prop = accounts_prop.ok_or_else(|| KalixIoError::Validate(format!(
                 "Error on line {}: Section '[{}]' is missing its 'accounts' table", ini_section.line_number, section_name)))?;
 
-            let table = parse_account_table(&accounts_prop.value)
+            let table = parse_account_table(&accounts_prop.value, &mut model)
                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", accounts_prop.line_number, e)))?;
 
             let mut member_ids = Vec::with_capacity(table.names.len());
@@ -460,6 +460,9 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.area_km2 = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
+                            model.data_cache.static_properties.set_value(
+                                &format!("node.{}.area", node_name.to_lowercase()), 
+                                n.area_km2);
                         } else if name_lower == "variant" {
                             // Model formulation. Absent/"gr4j" => classic daily; "gr4h" => sub-daily.
                             // Set the field directly; gr4j_model.initialize() (called during model
@@ -560,9 +563,13 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': required non-negative integer",
                                                      ini_property.line_number, name, node_name)))?);
                         } else if name_lower == "x" {
-                            n.set_x(v.parse::<f64>()
+                            let parsed_x = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
-                                                     ini_property.line_number, name, node_name)))?);
+                                                     ini_property.line_number, name, node_name)))?;
+                            n.set_x(parsed_x);
+                            model.data_cache.static_properties.set_value(
+                                format!("node.{}.x", node_name.to_lowercase()).as_str(), 
+                                parsed_x);
                         } else if name_lower == "nlm" {
                             let all_values = csv_string_to_f64_vec(v)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
@@ -592,6 +599,9 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.typical_regulated_flow = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
+                            model.data_cache.static_properties.set_value(
+                                format!("node.{}.typical_regulated_flow", node_name.to_lowercase()).as_str(), 
+                                n.typical_regulated_flow);
                         } else {
                             return Err(KalixIoError::Validate(format!("Error on line {}: Unexpected parameter '{}' for node '{}'",
                                               ini_property.line_number, name, node_name)));
@@ -622,6 +632,9 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.area_km2 = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
+                            model.data_cache.static_properties.set_value(
+                                format!("node.{}.area", node_name.to_lowercase()).as_str(),
+                                n.area_km2);
                         } else if name_lower == "params" {
                             let params = csv_string_to_f64_vec(v)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
@@ -728,6 +741,9 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.vol_initial = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
+                            model.data_cache.static_properties.set_value(
+                                format!("node.{}.initial_volume", node_name.to_lowercase()).as_str(),
+                                n.vol_initial);
                         } else if name_lower == "order_through" {
                             (n.order_through, _) = parse_csv_to_bool_option_u8(v)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
@@ -1548,7 +1564,7 @@ struct AccountTableData {
 /// reaches us as one comma-flattened cell stream (multi-line values are joined
 /// by the ini parser). Header length = leading run of allowed column names;
 /// everything after wraps into rows of that width.
-fn parse_account_table(flat: &str) -> Result<AccountTableData, String> {
+fn parse_account_table(flat: &str, model: &mut Model) -> Result<AccountTableData, String> {
     let trimmed = flat.trim_end_matches(|c: char| c == ',' || c.is_whitespace());
     if trimmed.is_empty() {
         return Err("Empty 'accounts' table".to_string());
@@ -1572,6 +1588,7 @@ fn parse_account_table(flat: &str) -> Result<AccountTableData, String> {
         return Err(format!("Accounts table must start with a header row of column names (allowed: {})",
             ACCOUNT_TABLE_COLUMNS.join(", ")));
     }
+    // Assert that the first column is 'name' - this fact is assumed in parsing logic below.
     if header[0] != "name" {
         return Err("First column of the accounts table must be 'name'".to_string());
     }
@@ -1598,51 +1615,58 @@ fn parse_account_table(flat: &str) -> Result<AccountTableData, String> {
         pairs: if header.iter().any(|h| h == "pair") { Some(Vec::new()) } else { None },
     };
     for row in data.chunks(n_cols) {
+        let mut table_name = String::new();
         let mut size = f64::NAN;
         let mut initial = 0.0;
         for (col_name, cell) in header.iter().zip(row.iter()) {
             match col_name.as_str() {
                 "name" => {
-                    let name = cell.to_lowercase();
-                    if !is_valid_bare_name(&name) {
+                    // NOTE: This is the first property parsed, owing to
+                    // guarantee that iter() preserves order and the assertion
+                    // earlier in this function.
+                    table_name = cell.to_lowercase();
+                    if !is_valid_bare_name(&table_name) {
                         return Err(format!("Invalid account name '{}'", cell));
                     }
                     // A keyword-named account would be swallowed by header
                     // detection when the saved file is re-read.
-                    if ACCOUNT_TABLE_COLUMNS.contains(&name.as_str()) {
+                    if ACCOUNT_TABLE_COLUMNS.contains(&table_name.as_str()) {
                         return Err(format!("Account name '{}' clashes with an accounts-table column name", cell));
                     }
-                    table.names.push(name);
                 }
                 "size" => {
                     size = cell.parse::<f64>()
                         .map_err(|_| format!("Invalid size '{}' for account '{}': must be a number",
-                            cell, table.names.last().map(String::as_str).unwrap_or("?")))?;
-                    if !(size >= 0.0) {
+                            cell, table_name))?;
+                    if size < 0.0 {
                         return Err(format!("Account '{}' has negative size {}",
-                            table.names.last().map(String::as_str).unwrap_or("?"), size));
+                            table_name, size));
                     }
                 }
                 "initial" => {
                     initial = cell.parse::<f64>()
                         .map_err(|_| format!("Invalid initial balance '{}' for account '{}': must be a number",
-                            cell, table.names.last().map(String::as_str).unwrap_or("?")))?;
+                            cell, table_name))?;
                 }
                 "pair" => {
                     let pair = cell.to_lowercase();
                     if !is_valid_bare_name(&pair) {
                         return Err(format!("Invalid pair account name '{}' for account '{}'",
-                            cell, table.names.last().map(String::as_str).unwrap_or("?")));
+                            cell, table_name));
                     }
                     table.pairs.as_mut().expect("header contains pair").push(pair);
                 }
                 _ => unreachable!("header is drawn from ACCOUNT_TABLE_COLUMNS"),
             }
         }
+        model.data_cache.static_properties.set_value(
+            &format!("acc.{}.size", &table_name.as_str()), 
+            size);
         if initial < 0.0 || initial > size {
             return Err(format!("Account '{}' has initial balance {} outside [0, size={}]",
-                table.names.last().map(String::as_str).unwrap_or("?"), initial, size));
+                table_name, initial, size));
         }
+        table.names.push(table_name);
         table.sizes.push(size);
         table.initials.push(initial);
     }

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -190,6 +190,44 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
     }
 
     // -------------------------------------------------------------------------------------
+    // Pre-parsing node static properties - register to data cache
+    // -------------------------------------------------------------------------------------
+    // A node's static scalar properties must be visible to every expression
+    // regardless of file order, the same guarantee the [acc.*] pre-pass above
+    // gives accounts. Without this, a [var.*] block (or any other expression)
+    // placed before the [node.*] section it references would find nothing
+    // registered yet and silently fall back to an unwritten data series
+    // instead of resolving the value - see the main per-section loop below,
+    // which is where node structs actually get built and would otherwise be
+    // the only place this got registered. The single source of truth for
+    // which (node type, property) pairs are static lives here; the main loop
+    // no longer registers them itself, so there is nothing to keep in sync.
+    //
+    // Malformed values are left alone here (silently skipped) rather than
+    // reported - the main loop's existing per-property validation reports
+    // them properly, with its usual line-numbered error, once it gets there.
+    const NODE_STATIC_F64_PROPERTIES: &[(&str, &str)] = &[
+        ("gr4j", "area"),
+        ("sacramento", "area"),
+        ("routing", "x"),
+        ("routing", "typical_regulated_flow"),
+        ("storage", "initial_volume"),
+    ];
+    for (section_name, ini_section) in &ini_doc.sections {
+        let Some(node_name) = section_name.strip_prefix("node.") else { continue };
+        let Some(node_type) = ini_section.properties.get("type").map(|p| p.value.trim().to_lowercase()) else { continue };
+        for (key, ini_property) in &ini_section.properties {
+            let key_lower = key.to_lowercase();
+            if NODE_STATIC_F64_PROPERTIES.contains(&(node_type.as_str(), key_lower.as_str())) {
+                if let Ok(value) = ini_property.value.trim().parse::<f64>() {
+                    model.data_cache.static_properties.set_value(
+                        &format!("node.{}.{}", node_name, key_lower), value);
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------
     // Collecting [ras.*] sections (parsed in a post-pass)
     // -------------------------------------------------------------------------------------
     // A RAS is one trigger + one action applied to the accounts of one or more
@@ -468,9 +506,6 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.area_km2 = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
-                            model.data_cache.static_properties.set_value(
-                                &format!("node.{}.area", node_name),
-                                n.area_km2);
                         } else if name_lower == "variant" {
                             // Model formulation. Absent/"gr4j" => classic daily; "gr4h" => sub-daily.
                             // Set the field directly; gr4j_model.initialize() (called during model
@@ -575,9 +610,6 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
                             n.set_x(parsed_x);
-                            model.data_cache.static_properties.set_value(
-                                format!("node.{}.x", node_name).as_str(),
-                                parsed_x);
                         } else if name_lower == "nlm" {
                             let all_values = csv_string_to_f64_vec(v)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
@@ -607,9 +639,6 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.typical_regulated_flow = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
-                            model.data_cache.static_properties.set_value(
-                                format!("node.{}.typical_regulated_flow", node_name).as_str(),
-                                n.typical_regulated_flow);
                         } else {
                             return Err(KalixIoError::Validate(format!("Error on line {}: Unexpected parameter '{}' for node '{}'",
                                               ini_property.line_number, name, node_name)));
@@ -640,9 +669,6 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.area_km2 = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
-                            model.data_cache.static_properties.set_value(
-                                format!("node.{}.area", node_name).as_str(),
-                                n.area_km2);
                         } else if name_lower == "params" {
                             let params = csv_string_to_f64_vec(v)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
@@ -749,9 +775,6 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                             n.vol_initial = v.parse::<f64>()
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
-                            model.data_cache.static_properties.set_value(
-                                format!("node.{}.initial_volume", node_name).as_str(),
-                                n.vol_initial);
                         } else if name_lower == "order_through" {
                             (n.order_through, _) = parse_csv_to_bool_option_u8(v)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -1638,7 +1638,9 @@ fn parse_account_table(flat: &str, model: &mut Model) -> Result<AccountTableData
                     size = cell.parse::<f64>()
                         .map_err(|_| format!("Invalid size '{}' for account '{}': must be a number",
                             cell, table_name))?;
-                    if size < 0.0 {
+                    // Written as !(size >= 0.0), not size < 0.0, so NaN (which parses fine as f64
+                    // but fails every comparison) is caught here too instead of slipping through.
+                    if !(size >= 0.0) {
                         return Err(format!("Account '{}' has negative size {}",
                             table_name, size));
                     }

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -461,7 +461,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
                             model.data_cache.static_properties.set_value(
-                                &format!("node.{}.area", node_name.to_lowercase()), 
+                                &format!("node.{}.area", node_name),
                                 n.area_km2);
                         } else if name_lower == "variant" {
                             // Model formulation. Absent/"gr4j" => classic daily; "gr4h" => sub-daily.
@@ -568,7 +568,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                                      ini_property.line_number, name, node_name)))?;
                             n.set_x(parsed_x);
                             model.data_cache.static_properties.set_value(
-                                format!("node.{}.x", node_name.to_lowercase()).as_str(), 
+                                format!("node.{}.x", node_name).as_str(),
                                 parsed_x);
                         } else if name_lower == "nlm" {
                             let all_values = csv_string_to_f64_vec(v)
@@ -600,7 +600,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
                             model.data_cache.static_properties.set_value(
-                                format!("node.{}.typical_regulated_flow", node_name.to_lowercase()).as_str(), 
+                                format!("node.{}.typical_regulated_flow", node_name).as_str(),
                                 n.typical_regulated_flow);
                         } else {
                             return Err(KalixIoError::Validate(format!("Error on line {}: Unexpected parameter '{}' for node '{}'",
@@ -633,7 +633,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
                             model.data_cache.static_properties.set_value(
-                                format!("node.{}.area", node_name.to_lowercase()).as_str(),
+                                format!("node.{}.area", node_name).as_str(),
                                 n.area_km2);
                         } else if name_lower == "params" {
                             let params = csv_string_to_f64_vec(v)
@@ -742,7 +742,7 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|_| KalixIoError::Parse(format!("Error on line {}: Invalid '{}' value for node '{}': not a valid number",
                                                      ini_property.line_number, name, node_name)))?;
                             model.data_cache.static_properties.set_value(
-                                format!("node.{}.initial_volume", node_name.to_lowercase()).as_str(),
+                                format!("node.{}.initial_volume", node_name).as_str(),
                                 n.vol_initial);
                         } else if name_lower == "order_through" {
                             (n.order_through, _) = parse_csv_to_bool_option_u8(v)
@@ -1696,7 +1696,7 @@ fn parse_ras_trigger(s: &str, model: &mut Model, line: usize) -> Result<crate::h
         let month_value = if let Ok(m) = arg.parse::<f64>() {
             m
         } else if arg.starts_with("const.") {
-            model.data_cache.constants.get_value_by_name(&arg.to_lowercase())
+            model.data_cache.constants.get_value_by_name(arg)
                 .map_err(|e| format!("Error on line {}: {}", line, e))?
         } else {
             return Err(format!("Error on line {}: Invalid start_water_year month '{}': \

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -149,6 +149,11 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
             let table = parse_account_table(&accounts_prop.value, &mut model)
                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", accounts_prop.line_number, e)))?;
 
+            // Group size is static 
+            let group_size: f64 = table.sizes.iter().sum();
+            model.data_cache.static_properties.set_value(
+                &format!("acc.{}.size", group_name), group_size);
+
             let mut member_ids = Vec::with_capacity(table.names.len());
             for (row, name) in table.names.iter().enumerate() {
                 let account = Account::new_with_size(

--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -1666,6 +1666,9 @@ fn parse_account_table(flat: &str, model: &mut Model) -> Result<AccountTableData
             return Err(format!("Account '{}' has initial balance {} outside [0, size={}]",
                 table_name, initial, size));
         }
+        model.data_cache.static_properties.set_value(
+            &format!("acc.{}.initial", &table_name.as_str()),
+            initial);
         table.names.push(table_name);
         table.sizes.push(size);
         table.initials.push(initial);

--- a/src/model.rs
+++ b/src/model.rs
@@ -894,11 +894,6 @@ impl Model {
     }
 
     pub fn run_timestep(&mut self, _t: u64) {
-        // Sizes first — static, so publishing before the [ras.*] loop makes
-        // acc.<x>.size bare-readable everywhere in the step, announce-time
-        // assessments included. No-op unless a size series is registered.
-        self.account_manager.publish_sizes(&mut self.data_cache);
-
         // The ras slot: assessments (phase = ras var blocks) and policy
         // ([ras.*] sections) interleaved in file order at the top of the
         // step, before ordering and flow — today's orders and takes see

--- a/src/model.rs
+++ b/src/model.rs
@@ -616,6 +616,28 @@ impl Model {
         self.data_cache
             .reserve_all(self.configuration.sim_nsteps as usize);
 
+        // Fill any declared output that names a static property (node.*.area,
+        // acc.*.size, etc.) rather than a per-step computed series. Nothing
+        // writes these during run() - the value is already known in full, so
+        // fill it in now the horizon length is known, instead of leaving the
+        // series empty (which collect_output_series/get_output_series would
+        // then silently drop as "unpopulated"). Only fills untouched series,
+        // so it can never clobber a genuine per-step recorder that happens to
+        // share a name.
+        let sim_nsteps = self.configuration.sim_nsteps as usize;
+        for output_name in &self.outputs {
+            if let Some(prop_idx) = self.data_cache.static_properties.get_idx(output_name) {
+                let value = self.data_cache.static_properties.get_value(prop_idx);
+                if let Some(series_idx) = self.data_cache.get_existing_series_idx(output_name) {
+                    if self.data_cache.series[series_idx].values.is_empty() {
+                        for _ in 0..sim_nsteps {
+                            self.data_cache.series[series_idx].push_value(value);
+                        }
+                    }
+                }
+            }
+        }
+
         //7) Nodes ask data_cache for idx for modelled series they might be responsible for populating
         //TODO: I think this was already appropriately done in step 2.
 

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -199,6 +199,11 @@ pub enum OptimizedExpressionNode {
         cache_index: usize
     },
 
+    /// Direct reference to a static property cache value by index
+    StaticPropertyReference {
+        cache_index: usize
+    },
+
     /// Binary operation
     BinaryOp {
         left: Box<OptimizedExpressionNode>,
@@ -389,6 +394,10 @@ impl OptimizedExpressionNode {
             OptimizedExpressionNode::ConstantReference { cache_index } => {
                 data_cache.constants.get_value(*cache_index)
             }
+            
+            OptimizedExpressionNode::StaticPropertyReference { cache_index } => {
+                data_cache.static_properties.get_value(*cache_index)
+            }
 
             OptimizedExpressionNode::BinaryOp { left, op, right } => match op {
                 // && and || short-circuit: the right operand is only evaluated
@@ -514,6 +523,7 @@ impl OptimizedExpressionNode {
         match self {
             OptimizedExpressionNode::Constant { .. }
             | OptimizedExpressionNode::ConstantReference { .. }
+            | OptimizedExpressionNode::StaticPropertyReference { .. }
             | OptimizedExpressionNode::SimContext { .. }
             | OptimizedExpressionNode::Local { .. }
             | OptimizedExpressionNode::DataCacheReferenceWithOffset { .. } => {}
@@ -579,6 +589,7 @@ impl OptimizedExpressionNode {
         match self {
             OptimizedExpressionNode::Constant { .. }
             | OptimizedExpressionNode::ConstantReference { .. }
+            | OptimizedExpressionNode::StaticPropertyReference { .. }
             | OptimizedExpressionNode::SimContext { .. }
             | OptimizedExpressionNode::Local { .. }
             | OptimizedExpressionNode::DataCacheReference { .. }
@@ -675,6 +686,7 @@ impl OptimizedExpressionNode {
         node: &ExpressionNode,
         data_variable_map: &HashMap<String, usize>,
         constant_variable_map: &HashMap<String, usize>,
+        static_variable_map: &HashMap<String, usize>,
         locals: &HashMap<String, usize>,
         arena: &mut crate::data_management::data_cache::ExprStateArena,
         tables: &TableRegistry
@@ -702,6 +714,12 @@ impl OptimizedExpressionNode {
                 if let Some(&idx) = constant_variable_map.get(&lower_name) {
                     return Ok(OptimizedExpressionNode::ConstantReference { cache_index: idx });
                 }
+
+                // Try static properties 
+                if let Some(&idx) = static_variable_map.get(&lower_name) {
+                    return Ok(OptimizedExpressionNode::StaticPropertyReference { cache_index: idx });
+                }
+
                 // Try data cache (data.* and node.* variables)
                 if let Some(&idx) = data_variable_map.get(&lower_name) {
                     return Ok(OptimizedExpressionNode::DataCacheReference { cache_index: idx });
@@ -755,8 +773,8 @@ impl OptimizedExpressionNode {
                 Err(format!("Variable '{}' not found in variable maps", name))
             }
             ExpressionNode::BinaryOp { left, op, right } => {
-                let left_opt = Self::from_expression_node(left, data_variable_map, constant_variable_map, locals, arena, tables)?;
-                let right_opt = Self::from_expression_node(right, data_variable_map, constant_variable_map, locals, arena, tables)?;
+                let left_opt  = Self::from_expression_node(left,  data_variable_map, constant_variable_map, static_variable_map, locals, arena, tables)?;
+                let right_opt = Self::from_expression_node(right, data_variable_map, constant_variable_map, static_variable_map, locals, arena, tables)?;
 
                 Ok(OptimizedExpressionNode::BinaryOp {
                     left: Box::new(left_opt),
@@ -765,7 +783,7 @@ impl OptimizedExpressionNode {
                 })
             }
             ExpressionNode::UnaryOp { op, operand } => {
-                let operand_opt = Self::from_expression_node(operand, data_variable_map, constant_variable_map, locals, arena, tables)?;
+                let operand_opt = Self::from_expression_node(operand, data_variable_map, constant_variable_map, static_variable_map, locals, arena, tables)?;
 
                 Ok(OptimizedExpressionNode::UnaryOp {
                     op: *op,
@@ -775,7 +793,7 @@ impl OptimizedExpressionNode {
             ExpressionNode::FunctionCall { func, args } => {
                 let args_opt: Result<Vec<_>, String> = args
                     .iter()
-                    .map(|arg| Self::from_expression_node(arg, data_variable_map, constant_variable_map, locals, arena, tables))
+                    .map(|arg| Self::from_expression_node(arg, data_variable_map, constant_variable_map, static_variable_map, locals, arena, tables))
                     .collect();
 
                 lower_function_call(func, args_opt?, arena, tables)
@@ -1116,6 +1134,17 @@ pub enum DynamicInput {
         original: String
     },
 
+    /// Direct reference to a static property cache value 
+    /// 
+    /// At the moment, this holds only fields from acc.*, node.* namespaces as
+    /// determined in the io reader by the data_cache's static_property cache -
+    /// if this changes in future, this will need to be addressed in
+    /// `from_string_impl` and `lower_program`.
+    DirectStaticPropertyReference {
+        idx: usize,
+        original: String
+    },
+
     /// Constant value (evaluated once at initialization)
     Constant {
         value: f64,
@@ -1384,6 +1413,7 @@ impl DynamicInput {
         // and avoid duplicate entries for the same variable with different cases
         let mut data_variable_map = HashMap::new();
         let mut constant_variable_map = HashMap::new();
+        let mut static_variable_map = HashMap::new();
 
         for var_name in variables.iter() {
             let lower_name = var_name.to_lowercase();
@@ -1402,11 +1432,15 @@ impl DynamicInput {
                 constant_variable_map.insert(lower_name.clone(), idx);
             } else if lower_name.starts_with("node.") || lower_name.starts_with("var.")
                 || lower_name.starts_with("acc.") || lower_name.starts_with("ras.") {
-                // Resolve to data cache but NOT as critical input (node outputs,
-                // var values, account state and RAS series are computed during
-                // the run, not loaded)
-                let idx = data_cache.get_or_add_new_series(lower_name.as_str(), false);
-                data_variable_map.insert(lower_name.clone(), idx);
+                if let Some(idx) = data_cache.static_properties.get_idx(&lower_name) {
+                    static_variable_map.insert(lower_name.clone(), idx);
+                } else {
+                    // Resolve to data cache but NOT as critical input (node outputs,
+                    // var values, account state and RAS series are computed during
+                    // the run, not loaded)
+                    let idx = data_cache.get_or_add_new_series(lower_name.as_str(), false);
+                    data_variable_map.insert(lower_name, idx);
+                }
             } else {
                 // Resolve to data cache (data.* references - use flag_as_critical from caller)
                 let idx = data_cache.get_or_add_new_series(lower_name.as_str(), flag_as_critical);
@@ -1481,9 +1515,16 @@ impl DynamicInput {
 
             // sim.* and self.* variables need to go through the Function path
             if lower_var.starts_with("sim.") || lower_var.starts_with("self.") {
-                Self::function_from_parsed(trimmed, &parsed, &data_variable_map, &constant_variable_map, data_cache, self_map)
+                Self::function_from_parsed(trimmed, &parsed, 
+                    &data_variable_map, &constant_variable_map, &static_variable_map, 
+                    data_cache, self_map)
             } else if let Some(&idx) = constant_variable_map.get(&lower_var) {
                 Ok(DynamicInput::DirectConstantReference {
+                    idx,
+                    original: trimmed.to_string()
+                })
+            } else if let Some(&idx) = static_variable_map.get(&lower_var) {
+                Ok(DynamicInput::DirectStaticPropertyReference {
                     idx,
                     original: trimmed.to_string()
                 })
@@ -1497,7 +1538,7 @@ impl DynamicInput {
             }
         } else {
             // Multiple variables or complex expression -> function expression
-            Self::function_from_parsed(trimmed, &parsed, &data_variable_map, &constant_variable_map, data_cache, self_map)
+            Self::function_from_parsed(trimmed, &parsed, &data_variable_map, &constant_variable_map, &static_variable_map, data_cache, self_map)
         }
     }
 
@@ -1511,13 +1552,16 @@ impl DynamicInput {
         parsed: &crate::functions::parser::ParsedFunction,
         data_variable_map: &HashMap<String, usize>,
         constant_variable_map: &HashMap<String, usize>,
+        static_variable_map: &HashMap<String, usize>,
         data_cache: &mut DataCache,
         self_map: Option<&HashMap<String, usize>>,
     ) -> Result<Self, String> {
         let DataCache { expr_state, tables, needs_calendar_flags, .. } = data_cache;
         let f_mark = expr_state.f.len();
         let u_mark = expr_state.u.len();
-        let optimised_ast = transform_to_optimised_ast(parsed, data_variable_map, constant_variable_map, expr_state, tables, self_map)?;
+        let optimised_ast = transform_to_optimised_ast(
+            parsed, data_variable_map, constant_variable_map, static_variable_map, 
+            expr_state, tables, self_map)?;
         if !*needs_calendar_flags && uses_calendar_flags(&optimised_ast) {
             *needs_calendar_flags = true;
         }
@@ -1587,6 +1631,7 @@ impl DynamicInput {
         // the plain-expression path does.
         let mut data_variable_map = HashMap::new();
         let mut constant_variable_map = HashMap::new();
+        let mut static_variable_map = HashMap::new();
         for var_name in program.get_external_variables() {
             let lower_name = var_name.to_lowercase();
 
@@ -1634,9 +1679,13 @@ impl DynamicInput {
                 constant_variable_map.insert(lower_name, idx);
             } else if lower_name.starts_with("node.") || lower_name.starts_with("var.")
                 || lower_name.starts_with("acc.") || lower_name.starts_with("ras.") {
-                // Computed during the run, not loaded: never critical.
-                let idx = data_cache.get_or_add_new_series(lower_name.as_str(), false);
-                data_variable_map.insert(lower_name, idx);
+                if let Some(idx) = data_cache.static_properties.get_idx(&lower_name) {
+                    static_variable_map.insert(lower_name.clone(), idx);
+                } else {
+                    // Computed during the run, not loaded: never critical.
+                    let idx = data_cache.get_or_add_new_series(lower_name.as_str(), false);
+                    data_variable_map.insert(lower_name, idx);
+                }
             } else {
                 let idx = data_cache.get_or_add_new_series(lower_name.as_str(), flag_as_critical);
                 data_variable_map.insert(lower_name, idx);
@@ -1683,6 +1732,7 @@ impl DynamicInput {
         struct LowerCtx<'c> {
             data_variable_map: &'c HashMap<String, usize>,
             constant_variable_map: &'c HashMap<String, usize>,
+            static_variable_map: &'c HashMap<String, usize>,
             locals: HashMap<String, usize>,
             next_slot: usize,
             assert_meta: Vec<String>,
@@ -1698,7 +1748,8 @@ impl DynamicInput {
                 match stmt {
                     Stmt::Assign { name, expr } => {
                         let lowered = OptimizedExpressionNode::from_expression_node(
-                            expr, ctx.data_variable_map, ctx.constant_variable_map, &ctx.locals, expr_state, tables)?;
+                            expr, ctx.data_variable_map, ctx.constant_variable_map, ctx.static_variable_map, 
+                            &ctx.locals, expr_state, tables)?;
                         let next = &mut ctx.next_slot;
                         let slot = *ctx.locals.entry(name.to_lowercase()).or_insert_with(|| {
                             let s = *next;
@@ -1709,14 +1760,16 @@ impl DynamicInput {
                     }
                     Stmt::Assert { expr, source_text } => {
                         let lowered = OptimizedExpressionNode::from_expression_node(
-                            expr, ctx.data_variable_map, ctx.constant_variable_map, &ctx.locals, expr_state, tables)?;
+                            expr, ctx.data_variable_map, ctx.constant_variable_map, ctx.static_variable_map, 
+                            &ctx.locals, expr_state, tables)?;
                         let meta = ctx.assert_meta.len() as u32;
                         ctx.assert_meta.push(source_text.clone());
                         out.push(OptStmt::Assert { expr: lowered, meta });
                     }
                     Stmt::Cond { cond, then_stmts, else_stmts } => {
                         let cond = OptimizedExpressionNode::from_expression_node(
-                            cond, ctx.data_variable_map, ctx.constant_variable_map, &ctx.locals, expr_state, tables)?;
+                            cond, ctx.data_variable_map, ctx.constant_variable_map, ctx.static_variable_map, 
+                            &ctx.locals, expr_state, tables)?;
                         // Arena growth while lowering a side tells us whether
                         // that side carries stateful nodes — the same
                         // detection the Function/StatefulFunction split uses.
@@ -1742,6 +1795,7 @@ impl DynamicInput {
         let mut ctx = LowerCtx {
             data_variable_map: &data_variable_map,
             constant_variable_map: &constant_variable_map,
+            static_variable_map: &static_variable_map,
             // Seed the self slots (dotted keys, so no collision with bare
             // program locals is possible) — self.* then resolves through the
             // ordinary locals-first lookup.
@@ -1754,7 +1808,7 @@ impl DynamicInput {
         let assert_meta = ctx.assert_meta;
 
         let result = OptimizedExpressionNode::from_expression_node(
-            &program.result, &data_variable_map, &constant_variable_map, &locals, expr_state, tables)?;
+            &program.result, &data_variable_map, &constant_variable_map, &static_variable_map, &locals, expr_state, tables)?;
 
         let grew = expr_state.f.len() > f_mark || expr_state.u.len() > u_mark;
 
@@ -1839,6 +1893,9 @@ impl DynamicInput {
             DynamicInput::DirectConstantReference { idx, .. } => {
                 data_cache.constants.get_value(*idx)
             }
+            DynamicInput::DirectStaticPropertyReference { idx, .. } => {
+                data_cache.static_properties.get_value(*idx)
+            }
             DynamicInput::Constant { value, .. } => *value,
             DynamicInput::LinearCombination { data_indices, coefficients, .. } => {
                 // High-performance dot product of weights and data values
@@ -1909,6 +1966,7 @@ impl DynamicInput {
             DynamicInput::DirectReference { original, .. } => original.clone(),
             DynamicInput::DirectReferenceWithOffset { original, .. } => original.clone(),
             DynamicInput::DirectConstantReference { original, .. } => original.clone(),
+            DynamicInput::DirectStaticPropertyReference { original, .. } => original.clone(),
             DynamicInput::Constant { original, .. } => original.clone(),
             DynamicInput::LinearCombination { variable_names, coefficients, .. } => {
                 // Reconstruct the expression with current optimized weights
@@ -1943,6 +2001,7 @@ impl DynamicInput {
             DynamicInput::DirectReference { original, .. } => original.as_str(),
             DynamicInput::DirectReferenceWithOffset { original, .. } => original.as_str(),
             DynamicInput::DirectConstantReference { original, .. } => original.as_str(),
+            DynamicInput::DirectStaticPropertyReference { original, .. } => original.as_str(),
             DynamicInput::Constant { original, .. } => original.as_str(),
             DynamicInput::LinearCombination { original, .. } => original.as_str(),
             DynamicInput::Function { expression, .. } => expression.as_str(),
@@ -1965,6 +2024,7 @@ fn uses_calendar_flags(node: &OptimizedExpressionNode) -> bool {
         | OptimizedExpressionNode::DataCacheReference { .. }
         | OptimizedExpressionNode::DataCacheReferenceWithOffset { .. }
         | OptimizedExpressionNode::ConstantReference { .. }
+        | OptimizedExpressionNode::StaticPropertyReference { .. }
         | OptimizedExpressionNode::Local { .. } => false,
         OptimizedExpressionNode::BinaryOp { left, right, .. } => {
             uses_calendar_flags(left) || uses_calendar_flags(right)
@@ -2009,6 +2069,7 @@ fn transform_to_optimised_ast(
     parsed: &crate::functions::parser::ParsedFunction,
     data_variable_map: &HashMap<String, usize>,
     constant_variable_map: &HashMap<String, usize>,
+    static_variable_map: &HashMap<String, usize>,
     arena: &mut crate::data_management::data_cache::ExprStateArena,
     tables: &TableRegistry,
     self_map: Option<&HashMap<String, usize>>,
@@ -2019,7 +2080,7 @@ fn transform_to_optimised_ast(
         Some(map) => map.clone(),
         None => HashMap::new(),
     };
-    OptimizedExpressionNode::from_expression_node(parsed.get_ast(), data_variable_map, constant_variable_map, &locals, arena, tables)
+    OptimizedExpressionNode::from_expression_node(parsed.get_ast(), data_variable_map, constant_variable_map, static_variable_map, &locals, arena, tables)
 }
 
 /// Lower a parsed function call into its specialised hot-path form, validating

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -1,30 +1,30 @@
-/// Dynamic Input - Optimized expression evaluation for model inputs
-///
-/// This module provides a high-performance input mechanism that allows model nodes
-/// to accept constants, direct data references, or complex function expressions with
-/// zero or minimal overhead.
-///
-/// # Performance Characteristics
-///
-/// - `None`: Zero overhead (returns 0.0)
-/// - `DirectReference`: Zero overhead (single array lookup)
-/// - `DirectConstantReference`: Zero overhead (single array lookup)
-/// - `Constant`: Zero overhead (returns stored value)
-/// - `Function`: Minimal overhead — a tree walk of pure arithmetic. Evaluation is
-///   infallible and allocation-free: unknown functions and wrong argument counts are
-///   rejected when the expression is parsed (at model load), `if`/`&&`/`||`
-///   short-circuit, and variadic min/max/sum/mean fold an accumulator instead of
-///   building an argument buffer.
-///
-/// # Error Handling - IEEE 754 Standard
-///
-/// Mathematical operations follow IEEE 754 floating-point standard:
-/// - Division by zero: `x / 0.0` → `+∞` (x > 0), `-∞` (x < 0), `NaN` (x = 0)
-/// - Domain errors: `sqrt(-1)` → `NaN`, `ln(0)` → `-∞`, `asin(2)` → `NaN`
-/// - Overflow: `exp(1000)` → `+∞`
-///
-/// This allows simulations to continue running even with problematic data, while making
-/// issues clearly visible in the output. Check for NaN/∞ in results to detect problems.
+//! Dynamic Input - Optimized expression evaluation for model inputs
+//!
+//! This module provides a high-performance input mechanism that allows model nodes
+//! to accept constants, direct data references, or complex function expressions with
+//! zero or minimal overhead.
+//!
+//! # Performance Characteristics
+//!
+//! - `None`: Zero overhead (returns 0.0)
+//! - `DirectReference`: Zero overhead (single array lookup)
+//! - `DirectConstantReference`: Zero overhead (single array lookup)
+//! - `Constant`: Zero overhead (returns stored value)
+//! - `Function`: Minimal overhead — a tree walk of pure arithmetic. Evaluation is
+//!   infallible and allocation-free: unknown functions and wrong argument counts are
+//!   rejected when the expression is parsed (at model load), `if`/`&&`/`||`
+//!   short-circuit, and variadic min/max/sum/mean fold an accumulator instead of
+//!   building an argument buffer.
+//!
+//! # Error Handling - IEEE 754 Standard
+//!
+//! Mathematical operations follow IEEE 754 floating-point standard:
+//! - Division by zero: `x / 0.0` → `+∞` (x > 0), `-∞` (x < 0), `NaN` (x = 0)
+//! - Domain errors: `sqrt(-1)` → `NaN`, `ln(0)` → `-∞`, `asin(2)` → `NaN`
+//! - Overflow: `exp(1000)` → `+∞`
+//!
+//! This allows simulations to continue running even with problematic data, while making
+//! issues clearly visible in the output. Check for NaN/∞ in results to detect problems.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -145,3 +145,4 @@ mod test_opportunistic_demand;
 // Confluence order routing (regulated = <upstream node(s)>)
 mod test_confluence_order_routing;
 mod test_output_casing;
+mod test_static_properties;

--- a/src/tests/test_constants_cache.rs
+++ b/src/tests/test_constants_cache.rs
@@ -90,6 +90,39 @@ fn test_constants_cache_assert_all_assigned() {
 
 
 
+/*
+Test that names are case-insensitive at every entry point: registering,
+looking up, or setting a value under any casing all resolve to the same
+entry, and the name stored internally is always lowercase.
+ */
+#[test]
+fn test_constants_cache_case_insensitive() {
+    let mut cache = ConstantsCache::new();
+
+    // Register under one casing, look up under others - same idx every time.
+    let idx1 = cache.add_if_needed_and_get_idx("const.Gravity");
+    assert_eq!(cache.add_if_needed_and_get_idx("const.gravity"), idx1);
+    assert_eq!(cache.add_if_needed_and_get_idx("CONST.GRAVITY"), idx1);
+    assert_eq!(cache.get_idx("const.GrAvItY"), Some(idx1));
+    assert_eq!(cache.len(), 1);
+
+    // set_value under a different casing updates the existing entry rather
+    // than creating a second one.
+    let idx2 = cache.set_value("CONST.gravity", 9.81);
+    assert_eq!(idx2, idx1);
+    assert_eq!(cache.len(), 1);
+    assert_eq!(cache.get_value(idx1), 9.81);
+
+    // get_value_by_name resolves regardless of casing.
+    assert_eq!(cache.get_value_by_name("const.gravity").unwrap(), 9.81);
+    assert_eq!(cache.get_value_by_name("Const.Gravity").unwrap(), 9.81);
+    assert_eq!(cache.get_value_by_name("CONST.GRAVITY").unwrap(), 9.81);
+
+    // The stored name itself is normalized to lowercase regardless of how it
+    // was first registered.
+    assert_eq!(cache.list_names(), vec!["const.gravity".to_string()]);
+}
+
 #[test]
 fn test_variable_name_checker() {
     assert!(is_valid_variable_name("const.temperature"));

--- a/src/tests/test_static_properties.rs
+++ b/src/tests/test_static_properties.rs
@@ -236,3 +236,32 @@ acc.g1.size
     let vals = series(&model, "acc.g1.size");
     assert_eq!(vals, vec![150.0; vals.len()]);
 }
+
+/// A group's `initial` is the sum of its members' declared opening balances -
+/// same static-aggregate treatment as size.
+#[test]
+fn group_initial_is_the_static_sum_of_member_initials() {
+    let ini = format!("{HEADER}
+[acc.g1]
+accounts = name, size, initial,
+           a1,   100,  10,
+           a2,   50,   5,
+           a3,   20,   0,
+
+[node.src]
+type = inflow
+loc = 0, 0
+inflow = 0
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 10
+
+[outputs]
+acc.g1.initial
+");
+    let model = run_model(&ini);
+    let vals = series(&model, "acc.g1.initial");
+    assert_eq!(vals, vec![15.0; vals.len()]);
+}

--- a/src/tests/test_static_properties.rs
+++ b/src/tests/test_static_properties.rs
@@ -1,0 +1,181 @@
+//! End-to-end INI-pipeline tests for static scalar node/account properties
+//! (`node.<name>.<property>`, `acc.<name>.size`) - the values registered into
+//! `DataCache::static_properties` while nodes/accounts are parsed, readable
+//! from any expression thereafter.
+
+use crate::io::ini_model_io::IniModelIO;
+use crate::model::Model;
+
+/// Load, configure and run a model from INI, panicking with context on any
+/// failure.
+fn run_model(ini: &str) -> Model {
+    let mut model = IniModelIO::read_model_string(ini)
+        .unwrap_or_else(|e| panic!("model should load: {e}"));
+    model.configure().unwrap_or_else(|e| panic!("configure should succeed: {e}"));
+    model.run().unwrap_or_else(|e| panic!("run should succeed: {e}"));
+    model
+}
+
+/// Read a series' values by name, panicking if the series does not exist.
+fn series(model: &Model, name: &str) -> Vec<f64> {
+    let idx = model.data_cache.get_existing_series_idx(name)
+        .unwrap_or_else(|| panic!("series '{name}' should exist"));
+    model.data_cache.series[idx].values.clone()
+}
+
+const HEADER: &str = "\
+[kalix]
+start = 2020-01-30
+end = 2020-02-01
+";
+
+/// A storage node whose INI section name has uppercase letters must still
+/// resolve its own static properties under the (always-lowercase) expression
+/// spelling of its name - node names are case-insensitive everywhere else.
+#[test]
+fn uppercase_node_name_resolves_its_own_static_properties() {
+    let ini = format!("{HEADER}
+[node.MyStore]
+type = storage
+loc = 0, 0
+initial_volume = 500
+dimensions = Level [m], Volume [ML], Area [km2], Spill [ML],
+             0.0      , 0.0        , 0.0       , 0.0,
+             1.0      , 1000.0     , 0.1       , 0.0,
+             2.0      , 2000.0     , 0.1       , 1.0e9,
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 10
+
+[var.calc]
+initial = node.mystore.initial_volume
+
+[outputs]
+var.calc.initial
+");
+    let model = run_model(&ini);
+    let vals = series(&model, "var.calc.initial");
+    assert_eq!(vals, vec![500.0; vals.len()],
+        "node.mystore.initial_volume should resolve to the value declared under [node.MyStore], every step");
+}
+
+/// A routing node's static properties (`x`, `typical_regulated_flow`) resolve
+/// the same way, under a mixed-case section name.
+#[test]
+fn uppercase_routing_node_resolves_x_and_typical_regulated_flow() {
+    let ini = format!("{HEADER}
+[node.Src]
+type = inflow
+loc = 0, 0
+inflow = 10
+ds_1 = Rte
+
+[node.Rte]
+type = routing
+loc = 0, 10
+lag = 0
+n_divs = 1
+x = 0.25
+nlm = 1.0, 1.0
+typical_regulated_flow = 42
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 20
+
+[var.calc]
+x_val = node.rte.x
+trf_val = node.rte.typical_regulated_flow
+
+[outputs]
+var.calc.x_val
+var.calc.trf_val
+");
+    let model = run_model(&ini);
+    let x_vals = series(&model, "var.calc.x_val");
+    let trf_vals = series(&model, "var.calc.trf_val");
+    assert_eq!(x_vals, vec![0.25; x_vals.len()]);
+    assert_eq!(trf_vals, vec![42.0; trf_vals.len()]);
+}
+
+/// gr4j and sacramento both expose their catchment area under the same
+/// `node.<name>.area` key for the same INI `area` property - previously
+/// sacramento registered it as `node.<name>.area_km2` instead.
+#[test]
+fn gr4j_and_sacramento_expose_area_under_the_same_key() {
+    let ini = format!("{HEADER}
+[node.g]
+type = gr4j
+loc = 0, 0
+area = 100
+rain = 0
+evap = 0
+params = 350, 0, 90, 1.7
+ds_1 = sink
+
+[node.s]
+type = sacramento
+loc = 10, 0
+area = 80
+rain = 0
+evap = 0
+params = 0.01, 40.0, 23.0, 0.009,
+         0.043, 130.0, 0.01, 0.063,
+         1.0, 0.01, 0.0, 0.0,
+         40.0, 0.245, 50.0, 40.0,
+         0.1
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 5, 10
+
+[var.calc]
+g_area = node.g.area
+s_area = node.s.area
+
+[outputs]
+var.calc.g_area
+var.calc.s_area
+");
+    let model = run_model(&ini);
+    let g_area = series(&model, "var.calc.g_area");
+    let s_area = series(&model, "var.calc.s_area");
+    assert_eq!(g_area, vec![100.0; g_area.len()]);
+    assert_eq!(s_area, vec![80.0; s_area.len()],
+        "node.s.area should resolve sacramento's area under the same key gr4j uses, not node.s.area_km2");
+}
+
+/// An account's `size` is registered as a static property under
+/// `acc.<name>.size`, resolvable regardless of the casing used to declare
+/// the account name.
+#[test]
+fn account_size_resolves_as_a_static_property() {
+    let ini = format!("{HEADER}
+[acc.g1]
+accounts = name, size, initial,
+           A1, 100, 10,
+
+[node.src]
+type = inflow
+loc = 0, 0
+inflow = 0
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 10
+
+[var.calc]
+a1_size = acc.a1.size
+
+[outputs]
+var.calc.a1_size
+");
+    let model = run_model(&ini);
+    let vals = series(&model, "var.calc.a1_size");
+    assert_eq!(vals, vec![100.0; vals.len()]);
+}

--- a/src/tests/test_static_properties.rs
+++ b/src/tests/test_static_properties.rs
@@ -61,6 +61,35 @@ var.calc.initial
         "node.mystore.initial_volume should resolve to the value declared under [node.MyStore], every step");
 }
 
+/// A static property can be listed directly in [outputs], with no [var.*]
+/// detour, and comes back filled for the whole simulation horizon.
+#[test]
+fn static_property_listed_directly_in_outputs_is_filled() {
+    let ini = format!("{HEADER}
+[node.MyStore]
+type = storage
+loc = 0, 0
+initial_volume = 500
+dimensions = Level [m], Volume [ML], Area [km2], Spill [ML],
+             0.0      , 0.0        , 0.0       , 0.0,
+             1.0      , 1000.0     , 0.1       , 0.0,
+             2.0      , 2000.0     , 0.1       , 1.0e9,
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 10
+
+[outputs]
+node.mystore.initial_volume
+");
+    let model = run_model(&ini);
+    let vals = series(&model, "node.mystore.initial_volume");
+    // 2020-01-30 .. 2020-02-01 inclusive, daily: Jan30, Jan31, Feb1 = 3 steps.
+    assert_eq!(vals.len(), 3, "static-property output should span the whole simulation horizon");
+    assert_eq!(vals, vec![500.0; 3]);
+}
+
 /// A routing node's static properties (`x`, `typical_regulated_flow`) resolve
 /// the same way, under a mixed-case section name.
 #[test]

--- a/src/tests/test_static_properties.rs
+++ b/src/tests/test_static_properties.rs
@@ -61,6 +61,39 @@ var.calc.initial
         "node.mystore.initial_volume should resolve to the value declared under [node.MyStore], every step");
 }
 
+/// A reference to a node's static property must resolve even when it appears
+/// *before* that node's [node.*] section in the file - static properties are
+/// registered in a pre-pass, not inline as each section is parsed, so file
+/// order can't leave a forward reference silently unresolved (reading 0
+/// instead of the declared value).
+#[test]
+fn static_property_resolves_when_referenced_before_its_node_section() {
+    let ini = format!("{HEADER}
+[var.calc]
+scaled = node.later_catchment.area * 0.1
+
+[node.later_catchment]
+type = gr4j
+loc = 0, 0
+area = 100
+rain = 0
+evap = 0
+params = 350, 0, 90, 1.7
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 10
+
+[outputs]
+var.calc.scaled
+");
+    let model = run_model(&ini);
+    let vals = series(&model, "var.calc.scaled");
+    assert_eq!(vals, vec![10.0; vals.len()],
+        "node.later_catchment.area should resolve to 100 even though [var.calc] is declared first, not silently read as 0");
+}
+
 /// A static property can be listed directly in [outputs], with no [var.*]
 /// detour, and comes back filled for the whole simulation horizon.
 #[test]

--- a/src/tests/test_static_properties.rs
+++ b/src/tests/test_static_properties.rs
@@ -208,3 +208,31 @@ var.calc.a1_size
     let vals = series(&model, "var.calc.a1_size");
     assert_eq!(vals, vec![100.0; vals.len()]);
 }
+
+/// A group's `size` is the sum of its members' declared sizes, also a static
+/// property, also directly output-able with no [var.*] detour.
+#[test]
+fn group_size_is_the_static_sum_of_member_sizes() {
+    let ini = format!("{HEADER}
+[acc.g1]
+accounts = name, size,
+           a1,   100,
+           a2,   50,
+
+[node.src]
+type = inflow
+loc = 0, 0
+inflow = 0
+ds_1 = sink
+
+[node.sink]
+type = blackhole
+loc = 0, 10
+
+[outputs]
+acc.g1.size
+");
+    let model = run_model(&ini);
+    let vals = series(&model, "acc.g1.size");
+    assert_eq!(vals, vec![150.0; vals.len()]);
+}

--- a/website/docs/docs/accounts.md
+++ b/website/docs/docs/accounts.md
@@ -97,22 +97,26 @@ Account state is published as ordinary series — readable in any
 | `acc.<name>.debits` | Water taken by users this step (not policy changes). |
 | `acc.<name>.allocation` | Allocation to date: balance plus use since the last reset (see [Allocation systems](allocation-systems.md)). |
 | `acc.<name>.use` | Water taken since the last `reset_allocation` — the use term of the allocation. Fed only by user takes, like `debits`. |
-| `acc.<name>.size` | Account size. |
+| `acc.<name>.size` | Account size, as declared. |
+| `acc.<name>.initial` | Opening balance at the start of the run, as declared (defaults to 0 if omitted). |
 
-<a id="groups"></a>Every field is also published for the **group aggregate**,
-summed over its members: `acc.<group>.size`, `acc.<group>.use`,
-`acc.<group>.closing_balance`, and so on — so a resource assessment can write
-`/ acc.gs.size` instead of a magic total that silently goes stale when an
-entitlement changes.
+<a id="groups"></a>`opening_balance`, `closing_balance`, `debits`, `allocation`
+and `use` are also published for the **group aggregate**, summed over its
+members: `acc.<group>.use`, `acc.<group>.closing_balance`, and so on — so a
+resource assessment can write `/ acc.gs.size` instead of a magic total that
+silently goes stale when an entitlement changes.
 
-`size` is written at the very top of the step — before even the `[ras.*]`
-sections — so it reads cleanly *everywhere*, announce-time assessments
-included. `opening_balance` is written before ordering and flow, so it reads
-cleanly mid-step. The others are written at end of step; reading them earlier
-in the same step needs the previous-step offset, e.g.
-`acc.smith.closing_balance[-1, 0]` — including `use`, whose `[-1, 0]` read on
-a reset morning is still the *old* period's total (the reset fires later that
-same step).
+`size` and `initial` are also group aggregates — the sum of member sizes and
+opening balances — but like their per-account counterparts above, they're
+fixed for the whole run rather than computed, so they read cleanly
+*everywhere*, from the very first line of the model, with no write-timing
+caveat and (like [`const.*`](constants.md)) no
+[offset syntax](referencing-model-results.md#temporal-offset-for-node-outputs).
+`opening_balance` is written before ordering and flow, so it reads cleanly
+mid-step. The others are written at end of step; reading them earlier in the
+same step needs the previous-step offset, e.g. `acc.smith.closing_balance[-1,
+0]` — including `use`, whose `[-1, 0]` read on a reset morning is still the
+*old* period's total (the reset fires later that same step).
 
 ## Rules
 

--- a/website/docs/docs/gr4j.md
+++ b/website/docs/docs/gr4j.md
@@ -47,6 +47,7 @@ The four model parameters — and the rainfall-weighting terms, when `rain` is a
 | runoff\_depth | Catchment runoff depth from GR4J model [mm] |
 | rain | Input rainfall [mm] |
 | evap | Input evapotranspiration [mm] |
+| area | Catchment area [km2] — the declared `area` value, static for the whole run. See [Static Node Properties](referencing-model-results.md#static-node-properties). |
 
 ## How the node works
 

--- a/website/docs/docs/model-outputs.md
+++ b/website/docs/docs/model-outputs.md
@@ -17,6 +17,12 @@ node.dam.volume
 var.accounting.headroom
 ```
 
+A handful of node/account properties are fixed for the whole run rather than
+computed each step — see [Static Node Properties](referencing-model-results.md#static-node-properties)
+and [`[acc.*]`](accounts.md#recordable-series). These are recordable the same
+way too; the resulting series simply repeats the declared value at every
+timestep.
+
 ### Output file format
 
 The CSV format has a single header row, and a single timestamp column.

--- a/website/docs/docs/referencing-model-results.md
+++ b/website/docs/docs/referencing-model-results.md
@@ -93,6 +93,37 @@ node.reservoir.volume - node.reservoir.volume[-1, 0.0]
 if(node.catchment.dsflow > node.catchment.dsflow[-1, 0.0], 1, 0)
 ```
 
+### Static Node Properties
+
+A handful of node properties are fixed for the whole simulation — the value
+declared in the `[node.*]` section itself, not something computed at each
+timestep. They read the same way, as `node.<name>.<property>`:
+
+| Property | Node types | Description |
+| --- | --- | --- |
+| `area` | GR4J, Sacramento | Catchment area [km2] |
+| `x` | Routing | Inflow bias used by the storage routing solver |
+| `typical_regulated_flow` | Routing | Representative regulated flow [ML] used to estimate travel time through the reach for order propagation (see [Ordering](ordering.md)) |
+| `initial_volume` | Storage | Initial storage volume [ML] |
+
+```
+[node.my_catchment]
+type = gr4j
+area = 250
+...
+
+[node.pump]
+type = unregulated_user
+; Scale demand by catchment area elsewhere in the model
+demand = 0.05 * node.my_catchment.area
+```
+
+Because the value never changes during a run, these don't support the
+[offset syntax](#temporal-offset-for-node-outputs) above — there is no history
+to look back into, the same restriction as [`const.*`](constants.md). They can
+be listed directly in [`[outputs]`](model-outputs.md) like any other result;
+the recorded series simply repeats the declared value at every timestep.
+
 ### Name Handling
 
 Node names follow the same sanitisation rules as data references:

--- a/website/docs/docs/routing.md
+++ b/website/docs/docs/routing.md
@@ -32,6 +32,7 @@ ds_1 = my_other_node
 | nlm (optional) | Nonlinear Muskingum parameters: k, m. Using these parameters will activate nonlinear Muskingum routing algorithm. Cannot be used in conjunction with piecewise linear on the same reach. Units for k are [meters^(3(1-m)) · s^m]. Following the convention of other platforms, if n\_divs > 1 then k applies per division. Example: `nlm = 183000, 0.75` |
 | n\_divs (optional) | The number of divisions used in the pwl storage routing solver. Default value is 1. Example: `n_divs = 10` |
 | x (optional) | Inflow bias. This sets the bias of the upstream flow (as opposed to the downstream flow) in the index flow term used in the pwl storage routing solver. Default value is 0. Example: `x = 0` |
+| typical\_regulated\_flow (optional) | A representative regulated flow rate [ML], used to estimate travel time through this reach when propagating orders upstream (see [Ordering](ordering.md)). Default value is 0. Example: `typical_regulated_flow = 250` |
 | ds\_1 (optional) | Name of the downstream node. This property defines a downstream link. Inflow nodes may only have 1 downstream link.  Example: `ds_1 = my_other_node` |
 
 The routing parameters — the `nlm` pair, or the travel times of the `pwl` table — can be calibrated with the built-in optimiser: see [Optimisable parameters](optimisable-parameters.md).
@@ -45,6 +46,8 @@ The routing parameters — the `nlm` pair, or the travel times of the `pwl` tabl
 | ds\_1 | Downstream flow on link ds\_1 [ML] |
 | ds\_1\_order | Orders on the link ds\_1 [ML] |
 | volume | Volume of water in the reach storage [ML] |
+| x | The declared `x` value, static for the whole run. See [Static Node Properties](referencing-model-results.md#static-node-properties). |
+| typical\_regulated\_flow | The declared `typical_regulated_flow` value, static for the whole run. See [Static Node Properties](referencing-model-results.md#static-node-properties). |
 
 ## How the node works
 

--- a/website/docs/docs/sacramento.md
+++ b/website/docs/docs/sacramento.md
@@ -50,6 +50,7 @@ All seventeen model parameters — and the rainfall-weighting terms, when `rain`
 | floin | Internal flux component - interflow [ML] |
 | flobf | Internal flux component - baseflow [ML] |
 | roimp | Internal flux component - impervious runoff [ML] |
+| area | Catchment area [km2] — the declared `area` value, static for the whole run. See [Static Node Properties](referencing-model-results.md#static-node-properties). |
 
 ## How the node works
 

--- a/website/docs/docs/storage.md
+++ b/website/docs/docs/storage.md
@@ -63,6 +63,7 @@ ds_1 = my_other_node
 | volume | Volume of water in the storage at the end of the timestep [ML] |
 | level | Level of water in the storage at the end of the timestep [m] |
 | area | Area of the water surface at the end of the timestep [km2] |
+| initial\_volume | The declared `initial_volume` value, static for the whole run. See [Static Node Properties](referencing-model-results.md#static-node-properties). |
 
 ## How the node works
 


### PR DESCRIPTION
TL;DR:
- Adds a new `ConstantsCache` `static_properties` field to the `DataCache` which serves as an internal index for expression resolution - hooked in and provides access to all properties for both expression resolution and model outputs.
- Refactors ConstantsCache to enforce case insensitivity.


# Changes
## Style/convention
Doc comments for dynamic_input.rs module and some fields were either outer doc comments (///) on a blank line, or normal comments (//) describing a field. aae8a15 changes the former to inner doc comments (//!) and 8ef5b76 changes the latter to doc comments.


## IO reader
Registered statically defined constants (i.e. those explicitly parsed as f64). In particular, the following properties are exposed:
- `node.gr4j.area`
- `node.sacramento.area`
- `node.routing.x`
- `node.routing.typical_regulated_flow`
- `node.storage.initial_volume`
- `acc.*.size`
- `acc.*.initial` (added later in 863f12a)
These are registered to the data cache in a pre-pass (5c0094f8217198da62a9d154fb6b6273986bc5cc).


## `DynamicInput`
- Add a new enum variant to required sites which is hooked in to all matches.
- Function signatures updated to take a new `static_variable_map` in line with the existing `*_variable_map`s
- Main logic change when matching "node." "var." "acc." or "ras.", where it was previously inserted into `data_variable_map` unconditionally - now checked against `data_cache.static_properties` first, before falling back to existing branch.


## `ConstantsCache` refactor 
Previously, it was enforced by convention only to lowercase `name` inputs to `ConstantsCache`'s methods. 5c7698a and fbf7944 moves the responsibility of enforcing case insensitivity to `ConstantsCache` itself, instead of giving an erroneous (zeroed) result when the caller forgets.


## Outputs 
- All static properties have been exposed to the outputs section, to assist in any debugging etc instead of requiring a workaround via a [var.*]. Any static property's series is filled in eagerly at `configure()` time (when all required information is already known). 
 - Note: constants are never exposed to outputs, which I feel is consistent with a "compile time" constant intent.
- As part of this, the recorders for static properties in `account_manager.rs` have been removed.
- Group properties (size and initial balance) are also now exposed via the same mechanism as individual accounts - determined at load time during pre-pass.


# Gaps
- Routing lag etc. is parsed as usize, not f64 - do we want to expose these structural parameters?
- GR4J and Sacramento node parameters are static per run but not exposed


# Closing keywords
Closes #355 