### PR TITLE
#333 New builtin functions: moving_annual/monthly/daily_sum/mean/min/max

### DIFF
--- a/docs/functions/FUNCTIONS_DOCUMENTATION.md
+++ b/docs/functions/FUNCTIONS_DOCUMENTATION.md
@@ -190,6 +190,47 @@ NaN behaviour follows each function's scalar counterpart: a NaN entering
 window (n steps); `moving_min`/`moving_max` suppress NaN exactly as
 `min`/`max` do.
 
+### Annual, monthly, and daily windows — the last n water years/months/days
+
+`moving_annual_sum(x, wy_month, n_years)`, `moving_annual_mean(...)`,
+`moving_annual_min(...)`, `moving_annual_max(...)`
+
+`moving_monthly_sum(x, n_months)`, `moving_monthly_mean(...)`,
+`moving_monthly_min(...)`, `moving_monthly_max(...)`
+
+`moving_daily_sum(x, n_days)`, `moving_daily_mean(...)`,
+`moving_daily_min(...)`, `moving_daily_max(...)`
+
+A different shape from the moving windows above: `x` is bucketed by
+calendar period first — one running total (or running min/max) per water
+year, month, or day — and the statistic is reported over the last `n`
+*buckets*, not the last `n` steps. There is no `default` argument: a bucket
+not yet reached simply contributes nothing (sum/mean start at 0, min/max
+start undefined and read NaN until real data arrives, same as an empty
+`moving_min`/`moving_max` window).
+
+`moving_annual_*` takes an explicit anchor month, `wy_month` (1-12): a new
+water year starts on the first step whose month equals it. This is the
+engine's one water-year concept — see the note under Event windows below.
+`moving_monthly_*`/`moving_daily_*` take no anchor; a new bucket starts on
+every calendar month/day.
+
+```ini
+[const]
+const.wy_month = 7
+```
+```ini
+# Trailing 3-year total, updated daily, water year starting 1 July
+three_yr_diversion = moving_annual_sum(node.town.diversion, const.wy_month, 3)
+
+# Trailing 12-month mean
+rolling_annual_mean_flow = moving_monthly_mean(node.gauge_1.dsflow, 12)
+```
+
+At a daily timestep, `moving_daily_*(x, n)` is equivalent to
+`moving_*(x, n, 0)` from the section above (every step is a new bucket); it
+earns its keep at sub-daily timesteps, bucketing several steps into one day.
+
 ### Event windows — since a reset condition last fired
 
 `sum_since(x, reset)`, `min_since(x, reset)`, `max_since(x, reset)`,
@@ -212,9 +253,13 @@ dry_spell = steps_since(node.gauge.dsflow > const.low_flow_threshold)
 spill_days = count_since(node.dam.ds_1_spill > 0, sim.new_year)
 ```
 
-There is deliberately no water-year concept in the engine: the boundary is
-an idiom written at the point of use (or named once per model via a
-constant), because the water-year month varies from valley to valley.
+`sum_since`/`*_since` and the `sim.*` flags deliberately carry no
+water-year concept of their own: the boundary is an idiom written at the
+point of use (or named once per model via a constant), because the
+water-year month varies from valley to valley. `moving_annual_*` above is
+the one deliberate exception — a trailing multi-year window needs ring
+state a reset condition alone can't express, so it takes `wy_month`
+directly rather than forcing a hand-rolled ring via `[fn]`.
 
 ### Calendar boundary flags
 
@@ -308,6 +353,18 @@ net_flow = min(
 | `moving_mean` | 3 | Mean over the last n steps |
 | `moving_min` | 3 | Minimum over the last n steps |
 | `moving_max` | 3 | Maximum over the last n steps |
+| `moving_annual_sum` | 3 | Sum over the last n_years water years: moving_annual_sum(x, wy_month, n_years) |
+| `moving_annual_mean` | 3 | Mean over the last n_years water years |
+| `moving_annual_min` | 3 | Minimum over the last n_years water years |
+| `moving_annual_max` | 3 | Maximum over the last n_years water years |
+| `moving_monthly_sum` | 2 | Sum over the last n_months calendar months: moving_monthly_sum(x, n_months) |
+| `moving_monthly_mean` | 2 | Mean over the last n_months calendar months |
+| `moving_monthly_min` | 2 | Minimum over the last n_months calendar months |
+| `moving_monthly_max` | 2 | Maximum over the last n_months calendar months |
+| `moving_daily_sum` | 2 | Sum over the last n_days calendar days: moving_daily_sum(x, n_days) |
+| `moving_daily_mean` | 2 | Mean over the last n_days calendar days |
+| `moving_daily_min` | 2 | Minimum over the last n_days calendar days |
+| `moving_daily_max` | 2 | Maximum over the last n_days calendar days |
 | `sum_since` | 2 | Sum of x since reset last fired: sum_since(x, reset) |
 | `min_since` | 2 | Minimum of x since reset |
 | `max_since` | 2 | Maximum of x since reset |

--- a/docs/functions/FUNCTIONS_DOCUMENTATION.md
+++ b/docs/functions/FUNCTIONS_DOCUMENTATION.md
@@ -231,6 +231,29 @@ At a daily timestep, `moving_daily_*(x, n)` is equivalent to
 `moving_*(x, n, 0)` from the section above (every step is a new bucket); it
 earns its keep at sub-daily timesteps, bucketing several steps into one day.
 
+**NaN policy differs from `moving_sum`/`mean`.** A NaN entering
+`moving_annual_min`/`max` (and the monthly/daily equivalents) is suppressed,
+never poisoning the tracked extremum — matching plain `moving_min`/`max`.
+But `moving_annual_sum`/`mean` still **poison** on NaN, exactly like plain
+`moving_sum`/`moving_mean`: a genuine gap in a raw series should make that
+water year's total suspect, not silently vanish.
+
+This asymmetry matters for a common pattern: gating a value to only count
+once per period, via `if(cond, x, NAN)` — the *only* way to express "only
+this branch counts" in this language. Feed that straight into
+`moving_annual_max`/`min` and it works, because NaN is exactly what those
+suppress. Feed it straight into `moving_annual_sum`/`mean` and the first
+untagged step poisons the running total. Wrap it in `skip_nan(...)` for the
+sum/mean side (`skip_nan` maps NaN to 0 — sum's identity, "contributes
+nothing" — and passes every other value through unchanged) to get the same
+gated behaviour there:
+
+```ini
+daily_total = if(sim.new_day, moving_daily_sum(node.gauge_1.dsflow, 1), 0.0 / 0.0)
+peak_daily_total_wy = moving_annual_max(daily_total, const.wy_month, 5)
+sum_daily_totals_wy = moving_annual_sum(skip_nan(daily_total), const.wy_month, 5)
+```
+
 ### Event windows — since a reset condition last fired
 
 `sum_since(x, reset)`, `min_since(x, reset)`, `max_since(x, reset)`,
@@ -349,6 +372,7 @@ net_flow = min(
 | `ceil` | 1 | Round up |
 | `round` | 1 | Round to nearest |
 | `sign` | 1 | Sign (-1, 0, or 1) |
+| `skip_nan` | 1 | NaN becomes 0 (sum/mean's identity); other values pass through unchanged |
 | `moving_sum` | 3 | Sum over the last n steps: moving_sum(x, n, default) |
 | `moving_mean` | 3 | Mean over the last n steps |
 | `moving_min` | 3 | Minimum over the last n steps |

--- a/docs/functions/structured_expressions_architecture.md
+++ b/docs/functions/structured_expressions_architecture.md
@@ -166,6 +166,47 @@ test it.
   forever — on evicting a NaN, recompute the running sum from the buffer;
   this is a cold event, gate it with `evicted.is_nan()`). Add a regression
   test for a NaN transient.
+- **Ring-of-buckets** (`moving_annual_*`/`moving_monthly_*`/`moving_daily_*`,
+  `WindowOp::{Sum,Mean,Min,Max}{Annual,Monthly,Daily}` in
+  `dynamic_input.rs`): same two-region shape as the plain ring above —
+  `f[f_off..f_off+n]` one slot per bucket (water year/month/day) +
+  `f[f_off+n]` running statistic; `u[u_off]` head index — but advanced by
+  two different functions depending on whether the current step is a period
+  boundary:
+  - **Non-boundary step** (`accumulate_ring`/`accumulate_extreme`): fold
+    into the *current* bucket (`f[f_off+head]`) and update the running
+    statistic in place — sum/mean add, min/max take `f64::min`/`f64::max`
+    (NaN-suppressing, so an untouched NaN-initialised bucket contributes
+    nothing).
+  - **Boundary step** (`advance_ring`/`advance_ring_extreme`, shared with
+    the plain ring for sum/mean): evict the oldest bucket, start a new one
+    at the incoming value, advance the head. Sum/mean correct the running
+    total incrementally (`sum += x - evicted`); min/max has no inverse for
+    an evicted extremum, so it rescans all `n` buckets on every
+    boundary — O(n), but boundaries fire once per water year/month/day, not
+    once per step, so this is cheap.
+  - **Correctness trap already hit once**: `advance_ring` must evict and
+    write against the **post-increment** head (`new_head`), not the
+    pre-increment one — otherwise the slot `advance_ring` just initialised
+    and the slot `accumulate_ring` subsequently writes into for the rest of
+    the period are different ring slots, silently stranding one step's
+    contribution forever (a mass leak, invisible at `n == 1` since the
+    wrap-around coincidentally lands on the same slot; caught at `n >= 2`).
+  - **Boundary predicate is the only thing that varies** across the three
+    families: annual is `is_new_month() && get_timestamp_month() ==
+    wy_month`; monthly is `is_new_month()` alone (no anchor); daily is
+    `is_new_day()` alone. At a daily timestep `is_new_day()` is true every
+    step, so `moving_daily_*` degenerates to exactly the plain ring/deque
+    above with no element default — this is deliberately used as a
+    regression test (`test_moving_daily_sum_mean_equal_plain_moving_at_daily_timestep`
+    in `test_stateful_functions.rs`), cross-checking the new machinery
+    against the already-trusted one on identical input.
+  - `uses_calendar_flags` must report `true` for every `*Annual`/`*Monthly`/
+    `*Daily` op directly (not by walking into `arg`), since these read
+    `is_new_month()`/`is_new_day()`/`get_timestamp_month()` in
+    `advance_state` without going through a `SimContext` node — otherwise
+    `DataCache.needs_calendar_flags` never gets set and the boundary flags
+    silently stay false past step 0.
 
 ## 5. When state advances: first evaluation per step, guarded
 

--- a/docs/functions/structured_expressions_design.md
+++ b/docs/functions/structured_expressions_design.md
@@ -141,6 +141,54 @@ Rules:
   sum for `sum`/`mean`; monotonic deque for `min`/`max` (amortised O(1)).
   Per-instance state is fixed-size, allocated at load (§11).
 
+## 5a. Annual, monthly, and daily windowed functions
+
+| Function | Meaning over the last n water years/months/days |
+|---|---|
+| `moving_annual_sum(x, wy_month, n_years)` | sum |
+| `moving_annual_mean(x, wy_month, n_years)` | arithmetic mean |
+| `moving_annual_min(x, wy_month, n_years)` | minimum |
+| `moving_annual_max(x, wy_month, n_years)` | maximum |
+| `moving_monthly_sum(x, n_months)` | sum |
+| `moving_monthly_mean(x, n_months)` | arithmetic mean |
+| `moving_monthly_min(x, n_months)` | minimum |
+| `moving_monthly_max(x, n_months)` | maximum |
+| `moving_daily_sum(x, n_days)` | sum |
+| `moving_daily_mean(x, n_days)` | arithmetic mean |
+| `moving_daily_min(x, n_days)` | minimum |
+| `moving_daily_max(x, n_days)` | maximum |
+
+- **Not the same shape as §5's `moving_*`.** These bucket `x` by calendar
+  period first (one running total/extremum per water year, month, or day),
+  then report the statistic over the last `n` *buckets* — the trailing sum
+  over the last `n_years` water years, not the last `n_years` steps. There
+  is no `default` argument: a bucket that hasn't been reached yet
+  contributes nothing to sum/mean (starts at 0) and nothing to min/max
+  (starts at NaN, which `min`/`max` already suppress).
+- **`moving_annual_*` takes an explicit `wy_month`** (1-12, positive integer
+  literal, bounded cost as `n` is): a new water year starts on the first
+  step whose month equals `wy_month`. This is the one place the engine
+  *does* carry a water-year concept — see §7's water year idiom, which this
+  family exists alongside rather than replaces: `*_since` and `sim.*` still
+  carry none, because a reset-driven accumulator can express any boundary
+  as a condition, but a trailing multi-year *window* (evicting the oldest
+  year as a new one starts) genuinely needs dedicated ring state the
+  `*_since` idiom cannot express.
+- **`moving_monthly_*`/`moving_daily_*` take no anchor** — a bucket starts
+  on every calendar month/day, so there's nothing to configure beyond `n`.
+  At a daily timestep, `moving_daily_*(x, n)` degenerates to exactly
+  `moving_*(x, n, <additive/extremum identity>)` from §5, since a new
+  bucket then starts on every step; the daily family earns its keep at
+  sub-daily timesteps, where it buckets multiple steps into one day.
+- **State advances every timestep, unconditionally**, same rule as §5.
+- Implementation: a ring of `n` bucket values plus a running statistic,
+  advanced at each period boundary (evict the oldest bucket, start a new
+  one) and accumulated into on every other step. Sum/mean's eviction
+  corrects the running total incrementally (`sum += x - evicted`, as in
+  §5); min/max has no such inverse, so eviction triggers an O(n) rescan of
+  the ring — cheap, since it only happens once per boundary, not once per
+  step.
+
 ## 6. Event-windowed functions: `*_since`
 
 | Function | Meaning since the reset condition last fired |
@@ -168,7 +216,7 @@ Rules:
   occurred just before the run began; the modeller owns that assumption.
 - State advances unconditionally, as in §5. Cost is O(1) per step.
 
-## 7. Calendar boundaries — and why there is no water year
+## 7. Calendar boundaries — and the water-year idiom
 
 New `sim.*` flags, each a pure calendar fact computed once per step:
 
@@ -181,9 +229,10 @@ These are timestep-agnostic. The naive spelling
 every hourly step of 1 July, resetting an account all day long); the flags
 exist so the correct thing is also the easy thing.
 
-**The engine has no water-year concept.** Water year start varies valley to
-valley and is deliberately not a global Kalix setting. The boundary is an
-idiom, written at the point of use:
+**`sim.*` and `*_since` have no water-year concept.** Water year start
+varies valley to valley and is deliberately not a global Kalix setting. For
+a reset-driven accumulator, the boundary is an idiom, written at the point
+of use:
 
 ```ini
 used_wy = sum_since(node.town.diversion, sim.new_month && sim.month == 7)
@@ -199,6 +248,14 @@ new_wy() = sim.new_month && sim.month == 7
 
 The would-be config key becomes one visible line of the model. Build the
 dials, not the named systems.
+
+This idiom covers every reset-driven boundary, but not a *trailing window*
+of several water years (evicting the oldest year as a new one starts) —
+that needs dedicated ring state a condition alone cannot express, which is
+why `moving_annual_*` (§5a) takes `wy_month` as a genuine parameter instead
+of forcing the modeller to hand-roll a multi-year ring in `[fn]`. It is a
+narrow, deliberate exception: one family, one parameter, still no global
+water-year setting.
 
 ## 8. User-defined functions: `[fn]`
 

--- a/kalixide/src/main/java/com/kalix/ide/language/ExpressionLanguage.java
+++ b/kalixide/src/main/java/com/kalix/ide/language/ExpressionLanguage.java
@@ -88,7 +88,7 @@ public final class ExpressionLanguage {
     public record SimVariable(String name, String description) {}
 
     /**
-     * Every builtin recognised by the parser — the 25 pure builtins, the 21
+     * Every builtin recognised by the parser — the 26 pure builtins, the 21
      * temporal (stateful) builtins, and the 2 calendar functions. Mirrors the
      * engine's {@code BuiltinFunction} enum, {@code STATEFUL_FUNCTIONS}, and
      * {@code CALENDAR_FUNCTIONS} ({@code src/functions/functions.rs}).
@@ -121,6 +121,7 @@ public final class ExpressionLanguage {
             new Builtin("round", 1, "round(x)", "round to the nearest integer", false),
             new Builtin("sign", 1, "sign(x)", "-1, 0, or 1 by the sign of x", false),
             new Builtin("is_leap_year", 1, "is_leap_year(yyyy)", "1 in a Gregorian leap year, else 0", false),
+            new Builtin("skip_nan", 1, "skip_nan(x)", "NaN becomes 0 (sum/mean's identity); other values pass through", false),
 
             // Two-argument math
             new Builtin("pow", 2, "pow(x, y)", "x raised to the power y", false),

--- a/kalixide/src/main/java/com/kalix/ide/language/ExpressionLanguage.java
+++ b/kalixide/src/main/java/com/kalix/ide/language/ExpressionLanguage.java
@@ -88,7 +88,7 @@ public final class ExpressionLanguage {
     public record SimVariable(String name, String description) {}
 
     /**
-     * Every builtin recognised by the parser — the 25 pure builtins, the 13
+     * Every builtin recognised by the parser — the 25 pure builtins, the 21
      * temporal (stateful) builtins, and the 2 calendar functions. Mirrors the
      * engine's {@code BuiltinFunction} enum, {@code STATEFUL_FUNCTIONS}, and
      * {@code CALENDAR_FUNCTIONS} ({@code src/functions/functions.rs}).
@@ -140,6 +140,18 @@ public final class ExpressionLanguage {
             new Builtin("moving_annual_mean", 3, "moving_annual_mean(x, wy_month, n_years)", "mean over the last n_years water years", true),
             new Builtin("moving_annual_min", 3, "moving_annual_min(x, wy_month, n_years)", "minimum over the last n_years water years", true),
             new Builtin("moving_annual_max", 3, "moving_annual_max(x, wy_month, n_years)", "maximum over the last n_years water years", true),
+
+            // Temporal (stateful): monthly-window moving_monthly_*(x, n_months)
+            new Builtin("moving_monthly_sum", 2, "moving_monthly_sum(x, n_months)", "sum over the last n_months calendar months", true),
+            new Builtin("moving_monthly_mean", 2, "moving_monthly_mean(x, n_months)", "mean over the last n_months calendar months", true),
+            new Builtin("moving_monthly_min", 2, "moving_monthly_min(x, n_months)", "minimum over the last n_months calendar months", true),
+            new Builtin("moving_monthly_max", 2, "moving_monthly_max(x, n_months)", "maximum over the last n_months calendar months", true),
+
+            // Temporal (stateful): daily-window moving_daily_*(x, n_days)
+            new Builtin("moving_daily_sum", 2, "moving_daily_sum(x, n_days)", "sum over the last n_days calendar days", true),
+            new Builtin("moving_daily_mean", 2, "moving_daily_mean(x, n_days)", "mean over the last n_days calendar days", true),
+            new Builtin("moving_daily_min", 2, "moving_daily_min(x, n_days)", "minimum over the last n_days calendar days", true),
+            new Builtin("moving_daily_max", 2, "moving_daily_max(x, n_days)", "maximum over the last n_days calendar days", true),
 
             // Temporal (stateful): event-windowed *_since (last argument is the reset condition)
             new Builtin("sum_since", 2, "sum_since(x, reset)", "sum of x since reset last fired", true),
@@ -238,12 +250,15 @@ public final class ExpressionLanguage {
     }
 
     /** True if this lowercase name is a moving_* fixed-window builtin
-     *  (window length + element default) — NOT the annual-window family,
-     *  which takes (x, wy_month, n_years) and has different constraints. */
+     *  (window length + element default) — NOT the annual/monthly/daily
+     *  window families, which take no default and have their own
+     *  constraints. */
     public static boolean isMovingWindowFunction(String lowerName) {
         Builtin b = BY_NAME.get(lowerName);
         return b != null && b.stateful() && b.name().startsWith("moving_")
-                && !b.name().startsWith("moving_annual_");
+                && !b.name().startsWith("moving_annual_")
+                && !b.name().startsWith("moving_monthly_")
+                && !b.name().startsWith("moving_daily_");
     }
 
     /** True if this lowercase name is a moving_annual_* annual-window builtin
@@ -252,6 +267,16 @@ public final class ExpressionLanguage {
     public static boolean isAnnualWindowFunction(String lowerName) {
         Builtin b = BY_NAME.get(lowerName);
         return b != null && b.stateful() && b.name().startsWith("moving_annual_");
+    }
+
+    /** True if this lowercase name is a moving_monthly_* or moving_daily_*
+     *  periodic-window builtin (x, n) — same (x, n) shape and validation as
+     *  each other, just anchored to a different calendar boundary; neither
+     *  carries a wy_month like {@link #isAnnualWindowFunction}. */
+    public static boolean isPeriodicWindowFunction(String lowerName) {
+        Builtin b = BY_NAME.get(lowerName);
+        return b != null && b.stateful()
+                && (b.name().startsWith("moving_monthly_") || b.name().startsWith("moving_daily_"));
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/language/ExpressionLanguage.java
+++ b/kalixide/src/main/java/com/kalix/ide/language/ExpressionLanguage.java
@@ -88,7 +88,7 @@ public final class ExpressionLanguage {
     public record SimVariable(String name, String description) {}
 
     /**
-     * Every builtin recognised by the parser — the 25 pure builtins, the 9
+     * Every builtin recognised by the parser — the 25 pure builtins, the 13
      * temporal (stateful) builtins, and the 2 calendar functions. Mirrors the
      * engine's {@code BuiltinFunction} enum, {@code STATEFUL_FUNCTIONS}, and
      * {@code CALENDAR_FUNCTIONS} ({@code src/functions/functions.rs}).
@@ -134,6 +134,12 @@ public final class ExpressionLanguage {
             new Builtin("moving_mean", 3, "moving_mean(x, n, default)", "mean over the last n steps", true),
             new Builtin("moving_min", 3, "moving_min(x, n, default)", "minimum over the last n steps", true),
             new Builtin("moving_max", 3, "moving_max(x, n, default)", "maximum over the last n steps", true),
+
+            // Temporal (stateful): annual-window moving_annual_*(x, wy_month, n_years)
+            new Builtin("moving_annual_sum", 3, "moving_annual_sum(x, wy_month, n_years)", "sum over the last n_years water years", true),
+            new Builtin("moving_annual_mean", 3, "moving_annual_mean(x, wy_month, n_years)", "mean over the last n_years water years", true),
+            new Builtin("moving_annual_min", 3, "moving_annual_min(x, wy_month, n_years)", "minimum over the last n_years water years", true),
+            new Builtin("moving_annual_max", 3, "moving_annual_max(x, wy_month, n_years)", "maximum over the last n_years water years", true),
 
             // Temporal (stateful): event-windowed *_since (last argument is the reset condition)
             new Builtin("sum_since", 2, "sum_since(x, reset)", "sum of x since reset last fired", true),
@@ -231,10 +237,21 @@ public final class ExpressionLanguage {
         return BY_NAME.get(lowerName);
     }
 
-    /** True if this lowercase name is a moving_* fixed-window builtin. */
+    /** True if this lowercase name is a moving_* fixed-window builtin
+     *  (window length + element default) — NOT the annual-window family,
+     *  which takes (x, wy_month, n_years) and has different constraints. */
     public static boolean isMovingWindowFunction(String lowerName) {
         Builtin b = BY_NAME.get(lowerName);
-        return b != null && b.stateful() && b.name().startsWith("moving_");
+        return b != null && b.stateful() && b.name().startsWith("moving_")
+                && !b.name().startsWith("moving_annual_");
+    }
+
+    /** True if this lowercase name is a moving_annual_* annual-window builtin
+     *  (x, wy_month, n_years) — the water-year-anchored counterpart to
+     *  {@link #isMovingWindowFunction}. */
+    public static boolean isAnnualWindowFunction(String lowerName) {
+        Builtin b = BY_NAME.get(lowerName);
+        return b != null && b.stateful() && b.name().startsWith("moving_annual_");
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/linter/validators/FunctionExpressionValidator.java
+++ b/kalixide/src/main/java/com/kalix/ide/linter/validators/FunctionExpressionValidator.java
@@ -1370,6 +1370,29 @@ public class FunctionExpressionValidator {
                             + " — state is sized at model load");
                 }
             }
+
+            // moving_annual_*(x, wy_month, n_years): wy_month must be a
+            // load-time literal integer in [1, 12]; n_years must be a
+            // load-time literal positive integer — mirrors the engine's
+            // lower_stateful_call validation for the annual family.
+            if (ExpressionLanguage.isAnnualWindowFunction(funcName) && argCount == 3) {
+                Double wyMonth = argLiterals.get(1);
+                if (wyMonth == null) {
+                    errors.add(funcName + "'s water year month (2nd argument) must be a constant"
+                            + " — state is sized at model load");
+                } else if (wyMonth != Math.floor(wyMonth) || wyMonth < 1 || wyMonth > 12) {
+                    errors.add(funcName + "'s water year month (2nd argument) must be a positive"
+                            + " integer between 1 and 12, but got " + trimNumber(wyMonth));
+                }
+                Double nYears = argLiterals.get(2);
+                if (nYears == null) {
+                    errors.add(funcName + "'s number of years (3rd argument) must be a constant"
+                            + " — state is sized at model load");
+                } else if (nYears != Math.floor(nYears) || nYears < 1) {
+                    errors.add(funcName + "'s window length (3rd argument) must be a positive"
+                            + " integer, but got " + trimNumber(nYears));
+                }
+            }
         }
 
         /** Render a literal argument value without a needless trailing ".0". */

--- a/kalixide/src/main/java/com/kalix/ide/linter/validators/FunctionExpressionValidator.java
+++ b/kalixide/src/main/java/com/kalix/ide/linter/validators/FunctionExpressionValidator.java
@@ -1393,6 +1393,20 @@ public class FunctionExpressionValidator {
                             + " integer, but got " + trimNumber(nYears));
                 }
             }
+
+            // moving_monthly_*/moving_daily_*(x, n): n must be a load-time
+            // literal positive integer — same rule as n_years above, minus
+            // the wy_month check (no anchor for these two families).
+            if (ExpressionLanguage.isPeriodicWindowFunction(funcName) && argCount == 2) {
+                Double n = argLiterals.get(1);
+                if (n == null) {
+                    errors.add(funcName + "'s window length (2nd argument) must be a constant"
+                            + " — state is sized at model load");
+                } else if (n != Math.floor(n) || n < 1) {
+                    errors.add(funcName + "'s window length (2nd argument) must be a positive"
+                            + " integer, but got " + trimNumber(n));
+                }
+            }
         }
 
         /** Render a literal argument value without a needless trailing ".0". */

--- a/kalixide/src/test/java/com/kalix/ide/language/ExpressionLanguageCrossSyncTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/language/ExpressionLanguageCrossSyncTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ExpressionLanguageCrossSyncTest {
 
-    /** Engine-drift pin: 25 pure builtins + 13 stateful builtins + 2 calendar functions. */
+    /** Engine-drift pin: 25 pure builtins + 21 stateful builtins + 2 calendar functions. */
     private static final Set<String> EXPECTED_FUNCTION_NAMES = Set.of(
             "if", "min", "max", "sum", "mean",
             "abs", "sqrt", "sin", "cos", "tan", "asin", "acos", "atan",
@@ -32,12 +32,16 @@ class ExpressionLanguageCrossSyncTest {
             "pow", "atan2", "clamp",
             "moving_sum", "moving_mean", "moving_min", "moving_max",
             "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
+            "moving_monthly_sum", "moving_monthly_mean", "moving_monthly_min", "moving_monthly_max",
+            "moving_daily_sum", "moving_daily_mean", "moving_daily_min", "moving_daily_max",
             "sum_since", "min_since", "max_since", "count_since", "steps_since",
             "month_at", "days_in_month_at");
 
     private static final Set<String> EXPECTED_STATEFUL_NAMES = Set.of(
             "moving_sum", "moving_mean", "moving_min", "moving_max",
             "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
+            "moving_monthly_sum", "moving_monthly_mean", "moving_monthly_min", "moving_monthly_max",
+            "moving_daily_sum", "moving_daily_mean", "moving_daily_min", "moving_daily_max",
             "sum_since", "min_since", "max_since", "count_since", "steps_since");
 
     private static final Set<String> EXPECTED_SIM_VARIABLES = Set.of(
@@ -51,7 +55,7 @@ class ExpressionLanguageCrossSyncTest {
         assertEquals(EXPECTED_FUNCTION_NAMES, ExpressionLanguage.functionNames());
         assertEquals(EXPECTED_FUNCTION_NAMES, ExpressionLanguage.functionArities().keySet());
         assertEquals(EXPECTED_SIM_VARIABLES, ExpressionLanguage.simVariableNames());
-        assertEquals(40, ExpressionLanguage.BUILTINS.size());
+        assertEquals(48, ExpressionLanguage.BUILTINS.size());
         assertEquals(11, ExpressionLanguage.SIM_VARIABLES.size());
     }
 
@@ -80,6 +84,8 @@ class ExpressionLanguageCrossSyncTest {
         assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_mean"));
         assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_annual_sum"));
         assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_annual_max"));
+        assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_monthly_sum"));
+        assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_daily_max"));
         assertEquals("stateful function", ExpressionLanguage.reservedTier("steps_since"));
         assertEquals("reserved word", ExpressionLanguage.reservedTier("assert"));
         assertEquals("reserved word", ExpressionLanguage.reservedTier("this"));
@@ -96,10 +102,12 @@ class ExpressionLanguageCrossSyncTest {
         FunctionExpressionValidator validator = new FunctionExpressionValidator();
         for (ExpressionLanguage.Builtin b : ExpressionLanguage.BUILTINS) {
             // Call each function with its minimum arity; every argument a data ref
-            // (moving_* window/default, and moving_annual_* wy_month/n_years,
-            // get bare literals so the literal rule is met — annual needs its
-            // own values since wy_month must be in [1,12] and n_years must be
-            // >= 1, unlike the fixed-window window/default pair).
+            // (moving_* window/default, moving_annual_* wy_month/n_years, and
+            // moving_monthly_*/moving_daily_* n get bare literals so the
+            // literal rule is met). Annual needs its own values since
+            // wy_month must be in [1,12]; monthly/daily's single n=3 arg
+            // happens to fall out of the same "i==1 -> 3" fixed-window
+            // branch below, since both are 2-arity (i only reaches 1).
             int minArity = b.arity() < 0 ? -b.arity() : b.arity();
             List<String> args = new java.util.ArrayList<>();
             for (int i = 0; i < minArity; i++) {

--- a/kalixide/src/test/java/com/kalix/ide/language/ExpressionLanguageCrossSyncTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/language/ExpressionLanguageCrossSyncTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ExpressionLanguageCrossSyncTest {
 
-    /** Engine-drift pin: 25 pure builtins + 9 stateful builtins + 2 calendar functions. */
+    /** Engine-drift pin: 25 pure builtins + 13 stateful builtins + 2 calendar functions. */
     private static final Set<String> EXPECTED_FUNCTION_NAMES = Set.of(
             "if", "min", "max", "sum", "mean",
             "abs", "sqrt", "sin", "cos", "tan", "asin", "acos", "atan",
@@ -31,11 +31,13 @@ class ExpressionLanguageCrossSyncTest {
             "is_leap_year",
             "pow", "atan2", "clamp",
             "moving_sum", "moving_mean", "moving_min", "moving_max",
+            "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
             "sum_since", "min_since", "max_since", "count_since", "steps_since",
             "month_at", "days_in_month_at");
 
     private static final Set<String> EXPECTED_STATEFUL_NAMES = Set.of(
             "moving_sum", "moving_mean", "moving_min", "moving_max",
+            "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
             "sum_since", "min_since", "max_since", "count_since", "steps_since");
 
     private static final Set<String> EXPECTED_SIM_VARIABLES = Set.of(
@@ -49,7 +51,7 @@ class ExpressionLanguageCrossSyncTest {
         assertEquals(EXPECTED_FUNCTION_NAMES, ExpressionLanguage.functionNames());
         assertEquals(EXPECTED_FUNCTION_NAMES, ExpressionLanguage.functionArities().keySet());
         assertEquals(EXPECTED_SIM_VARIABLES, ExpressionLanguage.simVariableNames());
-        assertEquals(36, ExpressionLanguage.BUILTINS.size());
+        assertEquals(40, ExpressionLanguage.BUILTINS.size());
         assertEquals(11, ExpressionLanguage.SIM_VARIABLES.size());
     }
 
@@ -76,6 +78,8 @@ class ExpressionLanguageCrossSyncTest {
         assertEquals("builtin function", ExpressionLanguage.reservedTier("min"));
         assertEquals("builtin function", ExpressionLanguage.reservedTier("clamp"));
         assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_mean"));
+        assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_annual_sum"));
+        assertEquals("stateful function", ExpressionLanguage.reservedTier("moving_annual_max"));
         assertEquals("stateful function", ExpressionLanguage.reservedTier("steps_since"));
         assertEquals("reserved word", ExpressionLanguage.reservedTier("assert"));
         assertEquals("reserved word", ExpressionLanguage.reservedTier("this"));
@@ -92,12 +96,20 @@ class ExpressionLanguageCrossSyncTest {
         FunctionExpressionValidator validator = new FunctionExpressionValidator();
         for (ExpressionLanguage.Builtin b : ExpressionLanguage.BUILTINS) {
             // Call each function with its minimum arity; every argument a data ref
-            // (moving_* window/default get bare literals so the literal rule is met).
+            // (moving_* window/default, and moving_annual_* wy_month/n_years,
+            // get bare literals so the literal rule is met — annual needs its
+            // own values since wy_month must be in [1,12] and n_years must be
+            // >= 1, unlike the fixed-window window/default pair).
             int minArity = b.arity() < 0 ? -b.arity() : b.arity();
             List<String> args = new java.util.ArrayList<>();
             for (int i = 0; i < minArity; i++) {
-                boolean movingConst = b.name().startsWith("moving_") && i >= 1;
-                args.add(movingConst ? (i == 1 ? "3" : "0") : "data.x");
+                if (b.name().startsWith("moving_annual_") && i >= 1) {
+                    args.add(i == 1 ? "6" : "3");
+                } else if (b.name().startsWith("moving_") && i >= 1) {
+                    args.add(i == 1 ? "3" : "0");
+                } else {
+                    args.add("data.x");
+                }
             }
             String expr = b.name() + "(" + String.join(", ", args) + ")";
             List<String> errors = validator.validate(expr);

--- a/kalixide/src/test/java/com/kalix/ide/language/ExpressionLanguageCrossSyncTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/language/ExpressionLanguageCrossSyncTest.java
@@ -23,12 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ExpressionLanguageCrossSyncTest {
 
-    /** Engine-drift pin: 25 pure builtins + 21 stateful builtins + 2 calendar functions. */
+    /** Engine-drift pin: 26 pure builtins + 21 stateful builtins + 2 calendar functions. */
     private static final Set<String> EXPECTED_FUNCTION_NAMES = Set.of(
             "if", "min", "max", "sum", "mean",
             "abs", "sqrt", "sin", "cos", "tan", "asin", "acos", "atan",
             "exp", "ln", "log10", "log2", "ceil", "floor", "round", "sign",
-            "is_leap_year",
+            "is_leap_year", "skip_nan",
             "pow", "atan2", "clamp",
             "moving_sum", "moving_mean", "moving_min", "moving_max",
             "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
@@ -55,7 +55,7 @@ class ExpressionLanguageCrossSyncTest {
         assertEquals(EXPECTED_FUNCTION_NAMES, ExpressionLanguage.functionNames());
         assertEquals(EXPECTED_FUNCTION_NAMES, ExpressionLanguage.functionArities().keySet());
         assertEquals(EXPECTED_SIM_VARIABLES, ExpressionLanguage.simVariableNames());
-        assertEquals(48, ExpressionLanguage.BUILTINS.size());
+        assertEquals(49, ExpressionLanguage.BUILTINS.size());
         assertEquals(11, ExpressionLanguage.SIM_VARIABLES.size());
     }
 
@@ -91,6 +91,7 @@ class ExpressionLanguageCrossSyncTest {
         assertEquals("reserved word", ExpressionLanguage.reservedTier("this"));
         assertEquals("reserved word", ExpressionLanguage.reservedTier("self"));
         assertEquals("builtin function", ExpressionLanguage.reservedTier("is_leap_year"));
+        assertEquals("builtin function", ExpressionLanguage.reservedTier("skip_nan"));
         assertEquals("calendar function", ExpressionLanguage.reservedTier("month_at"));
         assertEquals("calendar function", ExpressionLanguage.reservedTier("days_in_month_at"));
         assertNull(ExpressionLanguage.reservedTier("headroom"));

--- a/kalixide/src/test/java/com/kalix/ide/linter/validators/FunctionExpressionValidatorTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/linter/validators/FunctionExpressionValidatorTest.java
@@ -124,6 +124,7 @@ class FunctionExpressionValidatorTest {
         assertValid("log10(data.x)");
         assertValid("log2(data.x)");
         assertValid("sign(data.x)");
+        assertValid("skip_nan(data.x)");
 
         // Aggregation
         assertValid("max(1, 2, 3)");

--- a/kalixide/src/test/java/com/kalix/ide/linter/validators/FunctionExpressionValidatorTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/linter/validators/FunctionExpressionValidatorTest.java
@@ -599,6 +599,53 @@ class FunctionExpressionValidatorTest {
         assertValid("steps_since(data.flag)");
     }
 
+    // ============ moving_annual_* literal wy_month/n_years rule ============
+
+    @Test
+    @DisplayName("moving_annual_* accepts a bare wy_month in [1,12] and a bare positive n_years")
+    void testMovingAnnualLiteralArgsAccepted() {
+        assertValid("moving_annual_sum(data.x, 7, 5)");
+        assertValid("moving_annual_mean(data.x, 1, 1)");
+        assertValid("moving_annual_min(data.x, 12, 3)");
+        assertValid("moving_annual_max(data.x, 6, 10)");
+    }
+
+    @Test
+    @DisplayName("moving_annual_* rejects a non-literal wy_month (state is sized at model load)")
+    void testMovingAnnualNonLiteralWyMonthRejected() {
+        assertInvalid("moving_annual_sum(data.q, data.month, 3)",
+                "water year month (2nd argument) must be a constant");
+        assertInvalid("moving_annual_sum(data.q, const.m, 3)",
+                "water year month (2nd argument) must be a constant");
+    }
+
+    @Test
+    @DisplayName("moving_annual_* rejects a wy_month outside [1,12], including non-integers")
+    void testMovingAnnualWyMonthRangeRejected() {
+        assertInvalid("moving_annual_sum(data.q, 0, 3)", "water year month (2nd argument) must be a positive integer between 1 and 12");
+        assertInvalid("moving_annual_sum(data.q, 13, 3)", "water year month (2nd argument) must be a positive integer between 1 and 12");
+        assertInvalid("moving_annual_sum(data.q, 6.5, 3)", "water year month (2nd argument) must be a positive integer between 1 and 12");
+    }
+
+    @Test
+    @DisplayName("moving_annual_* rejects a non-literal or non-positive-integer n_years")
+    void testMovingAnnualNYearsRejected() {
+        assertInvalid("moving_annual_sum(data.q, 7, data.n)",
+                "number of years (3rd argument) must be a constant");
+        assertInvalid("moving_annual_sum(data.q, 7, 0)", "window length (3rd argument) must be a positive integer");
+        assertInvalid("moving_annual_sum(data.q, 7, 2.5)", "window length (3rd argument) must be a positive integer");
+    }
+
+    @Test
+    @DisplayName("moving_annual_* is a distinct validation family from the fixed-window moving_* rule")
+    void testMovingAnnualNotConflatedWithFixedWindow() {
+        // wy_month=7 is a valid fixed-window default (any constant), and
+        // n_years is checked as a positive integer, not "any constant" —
+        // the two families must not share the fixed-window's rule.
+        assertValid("moving_annual_sum(data.q, 7, 3)");
+        assertInvalid("moving_annual_sum(data.q, 7, -1)", "positive integer");
+    }
+
     // ============ fn arity consistency (finding #4) ============
 
     @Test

--- a/kalixide/src/test/java/com/kalix/ide/linter/validators/FunctionExpressionValidatorTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/linter/validators/FunctionExpressionValidatorTest.java
@@ -646,6 +646,47 @@ class FunctionExpressionValidatorTest {
         assertInvalid("moving_annual_sum(data.q, 7, -1)", "positive integer");
     }
 
+    // ============ moving_monthly_*/moving_daily_* literal n rule ============
+
+    @Test
+    @DisplayName("moving_monthly_*/moving_daily_* accept a bare positive-integer n")
+    void testMovingPeriodicLiteralArgsAccepted() {
+        assertValid("moving_monthly_sum(data.x, 3)");
+        assertValid("moving_monthly_mean(data.x, 1)");
+        assertValid("moving_monthly_min(data.x, 12)");
+        assertValid("moving_monthly_max(data.x, 6)");
+        assertValid("moving_daily_sum(data.x, 3)");
+        assertValid("moving_daily_mean(data.x, 1)");
+        assertValid("moving_daily_min(data.x, 12)");
+        assertValid("moving_daily_max(data.x, 6)");
+    }
+
+    @Test
+    @DisplayName("moving_monthly_*/moving_daily_* reject a non-literal n (state is sized at model load)")
+    void testMovingPeriodicNonLiteralNRejected() {
+        assertInvalid("moving_monthly_sum(data.q, data.n)", "window length (2nd argument) must be a constant");
+        assertInvalid("moving_monthly_sum(data.q, const.n)", "window length (2nd argument) must be a constant");
+        assertInvalid("moving_daily_sum(data.q, data.n)", "window length (2nd argument) must be a constant");
+    }
+
+    @Test
+    @DisplayName("moving_monthly_*/moving_daily_* reject a non-positive-integer literal n")
+    void testMovingPeriodicNonIntegerNRejected() {
+        assertInvalid("moving_monthly_sum(data.q, 2.5)", "positive integer");
+        assertInvalid("moving_monthly_sum(data.q, 0)", "positive integer");
+        assertInvalid("moving_daily_sum(data.q, 2.5)", "positive integer");
+        assertInvalid("moving_daily_sum(data.q, 0)", "positive integer");
+    }
+
+    @Test
+    @DisplayName("moving_monthly_*/moving_daily_* take no wy_month and are a distinct family from moving_annual_*")
+    void testMovingPeriodicNotConflatedWithAnnual() {
+        // Only 2 arguments — a 3rd argument is a genuine arity error, not a
+        // wy_month/n_years pair.
+        assertInvalid("moving_monthly_sum(data.q, 6, 3)", "expects 2 argument");
+        assertInvalid("moving_daily_sum(data.q, 6, 3)", "expects 2 argument");
+    }
+
     // ============ fn arity consistency (finding #4) ============
 
     @Test

--- a/src/functions/fn_registry.rs
+++ b/src/functions/fn_registry.rs
@@ -291,7 +291,13 @@ mod reserved_registry_tests {
         let mut cache = crate::data_management::data_cache::DataCache::new();
         for name in STATEFUL_FUNCTIONS {
             let expr = match name {
+                // Annual/monthly/daily families first: all start_with
+                // "moving_" too, but take a different arity/shape than the
+                // generic fixed-window case below (annual: x, wy_month,
+                // n_years; monthly/daily: x, n — no default).
                 n if n.starts_with("moving_annual_") => format!("{}(data.x, 6, 3)", n),
+                n if n.starts_with("moving_monthly_") || n.starts_with("moving_daily_") =>
+                    format!("{}(data.x, 3)", n),
                 n if n.starts_with("moving_") => format!("{}(data.x, 3, 0)", n),
                 "steps_since" => "steps_since(data.x > 0)".to_string(),
                 n => format!("{}(data.x, sim.new_month)", n),
@@ -316,6 +322,10 @@ mod reserved_registry_tests {
         assert_eq!(reserved_name_kind("moving_annual_mean"), Some("stateful function"));
         assert_eq!(reserved_name_kind("moving_annual_min"), Some("stateful function"));
         assert_eq!(reserved_name_kind("moving_annual_max"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_monthly_sum"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_monthly_max"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_daily_sum"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_daily_max"), Some("stateful function"));
         assert_eq!(reserved_name_kind("assert"), Some("reserved word"));
         assert_eq!(reserved_name_kind("this"), Some("reserved word"));
         assert_eq!(reserved_name_kind("headroom"), None);

--- a/src/functions/fn_registry.rs
+++ b/src/functions/fn_registry.rs
@@ -291,6 +291,7 @@ mod reserved_registry_tests {
         let mut cache = crate::data_management::data_cache::DataCache::new();
         for name in STATEFUL_FUNCTIONS {
             let expr = match name {
+                n if n.starts_with("moving_annual_") => format!("{}(data.x, 6, 3)", n),
                 n if n.starts_with("moving_") => format!("{}(data.x, 3, 0)", n),
                 "steps_since" => "steps_since(data.x > 0)".to_string(),
                 n => format!("{}(data.x, sim.new_month)", n),
@@ -311,6 +312,10 @@ mod reserved_registry_tests {
         assert_eq!(reserved_name_kind("clamp"), Some("builtin function"));
         assert_eq!(reserved_name_kind("steps_since"), Some("stateful function"));
         assert_eq!(reserved_name_kind("moving_mean"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_annual_sum"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_annual_mean"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_annual_min"), Some("stateful function"));
+        assert_eq!(reserved_name_kind("moving_annual_max"), Some("stateful function"));
         assert_eq!(reserved_name_kind("assert"), Some("reserved word"));
         assert_eq!(reserved_name_kind("this"), Some("reserved word"));
         assert_eq!(reserved_name_kind("headroom"), None);

--- a/src/functions/functions.rs
+++ b/src/functions/functions.rs
@@ -45,9 +45,11 @@ use crate::functions::errors::EvaluationError;
 /// [`BuiltinFunction`]. Membership here reserves the name exactly as builtin
 /// status does. `stateful_lowering_covers_registry` in the tests ties this
 /// list to `lower_stateful_call`'s match arms so they cannot drift.
-pub const STATEFUL_FUNCTIONS: [&str; 13] = [
+pub const STATEFUL_FUNCTIONS: [&str; 21] = [
     "moving_sum", "moving_mean", "moving_min", "moving_max",
     "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
+    "moving_monthly_sum", "moving_monthly_mean", "moving_monthly_min", "moving_monthly_max",
+    "moving_daily_sum", "moving_daily_mean", "moving_daily_min", "moving_daily_max",
     "sum_since", "min_since", "max_since", "count_since", "steps_since",
 ];
 

--- a/src/functions/functions.rs
+++ b/src/functions/functions.rs
@@ -98,7 +98,7 @@ pub enum BuiltinFunction {
     // Single argument
     Abs, Sqrt, Sin, Cos, Tan, Asin, Acos, Atan,
     Exp, Ln, Log10, Log2,
-    Ceil, Floor, Round, Sign, IsLeapYear,
+    Ceil, Floor, Round, Sign, IsLeapYear, SkipNan,
 
     // Two argument
     Pow, Atan2,
@@ -136,6 +136,7 @@ impl BuiltinFunction {
             "round"  => BuiltinFunction::Round,
             "sign"   => BuiltinFunction::Sign,
             "is_leap_year" => BuiltinFunction::IsLeapYear,
+            "skip_nan" => BuiltinFunction::SkipNan,
             "pow"    => BuiltinFunction::Pow,
             "atan2"  => BuiltinFunction::Atan2,
             "min"    => BuiltinFunction::Min,
@@ -168,6 +169,7 @@ impl BuiltinFunction {
             BuiltinFunction::Round => "round",
             BuiltinFunction::Sign => "sign",
             BuiltinFunction::IsLeapYear => "is_leap_year",
+            BuiltinFunction::SkipNan => "skip_nan",
             BuiltinFunction::Pow => "pow",
             BuiltinFunction::Atan2 => "atan2",
             BuiltinFunction::Min => "min",
@@ -204,6 +206,7 @@ impl BuiltinFunction {
             BuiltinFunction::Round  => Self::single(self.name(), args, |x| x.round()),
             BuiltinFunction::Sign   => Self::single(self.name(), args, sign),
             BuiltinFunction::IsLeapYear => Self::single(self.name(), args, is_leap_year_f),
+            BuiltinFunction::SkipNan => Self::single(self.name(), args, skip_nan),
 
             // Two argument
             BuiltinFunction::Pow => {
@@ -290,6 +293,23 @@ pub fn sign(x: f64) -> f64 {
 /// `sim.year`, already exact).
 pub fn is_leap_year_f(year: f64) -> f64 {
     if crate::tid::utils::is_leap_year(year.round() as i64) { 1.0 } else { 0.0 }
+}
+
+/// `skip_nan(x)`: NaN maps to 0.0 (sum/mean's additive identity — "this
+/// contributes nothing"), any other value passes through unchanged. The
+/// deliberate complement to the min/max builtins' own NaN handling
+/// (`f64::min`/`f64::max` already suppress NaN by returning the other
+/// operand): min/max need no such coercion because there's no numeric value
+/// that's a safe placeholder for "ignore me" regardless of x's range, but
+/// sum/mean do have one (0), so `skip_nan` makes it explicit at the call
+/// site rather than asking the modeller to remember to write a bare `0`
+/// literal in an `if(...)`'s else-branch. Composes with the annual/monthly/
+/// daily windows: `moving_annual_sum(skip_nan(if(cond, x, NAN)), ...)` lets
+/// one NaN-gated signal feed both a `moving_annual_max` (which already
+/// ignores the NaN directly) and a `moving_annual_sum` (which would
+/// otherwise poison on it) without writing two different gates.
+pub fn skip_nan(x: f64) -> f64 {
+    if x.is_nan() { 0.0 } else { x }
 }
 
 /// Back-compat shim for callers that still dispatch by name (e.g. context-function

--- a/src/functions/functions.rs
+++ b/src/functions/functions.rs
@@ -45,8 +45,9 @@ use crate::functions::errors::EvaluationError;
 /// [`BuiltinFunction`]. Membership here reserves the name exactly as builtin
 /// status does. `stateful_lowering_covers_registry` in the tests ties this
 /// list to `lower_stateful_call`'s match arms so they cannot drift.
-pub const STATEFUL_FUNCTIONS: [&str; 9] = [
+pub const STATEFUL_FUNCTIONS: [&str; 13] = [
     "moving_sum", "moving_mean", "moving_min", "moving_max",
+    "moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max",
     "sum_since", "min_since", "max_since", "count_since", "steps_since",
 ];
 

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -352,9 +352,15 @@ pub enum WindowOp {
     MinAnnual  { wy_month: u32 },
     MaxAnnual  { wy_month: u32 },
     // Monthly operations
-    // TODO
+    SumMonthly,
+    MeanMonthly,
+    MinMonthly,
+    MaxMonthly,
     // Daily operations
-    // TODO
+    SumDaily,
+    MeanDaily,
+    MinDaily,
+    MaxDaily,
 }
 
 /// Arena addressing for one moving-window instance, boxed off the
@@ -493,15 +499,17 @@ impl OptimizedExpressionNode {
                     let len = data_cache.expr_state.u[slots.u_off + slots.n + 2];
                     if len == 0 { f64::NAN } else { data_cache.expr_state.f[slots.f_off + head] }
                 }
-                WindowOp::SumAnnual { .. } => {
+                WindowOp::SumAnnual { .. } | WindowOp::SumMonthly | WindowOp::SumDaily => {
                     let sum_slot = slots.f_off + slots.n;
                     data_cache.expr_state.f[sum_slot]
                 }
-                WindowOp::MeanAnnual { .. } => {
+                WindowOp::MeanAnnual { .. } | WindowOp::MeanMonthly | WindowOp::MeanDaily => {
                     let sum_slot = slots.f_off + slots.n;
                     data_cache.expr_state.f[sum_slot] / slots.n as f64
                 }
-                WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. } => {
+                WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. }
+                | WindowOp::MinMonthly | WindowOp::MaxMonthly
+                | WindowOp::MinDaily | WindowOp::MaxDaily => {
                     let stat_slot = slots.f_off + slots.n;
                     data_cache.expr_state.f[stat_slot]
                 }
@@ -670,9 +678,49 @@ impl OptimizedExpressionNode {
                         }
                     }
                     // Monthly family
-                    // TODO
+                    WindowOp::SumMonthly | WindowOp::MeanMonthly => {
+                        if data_cache.is_new_month() {
+                            advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        } else {
+                            accumulate_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        }
+                    }
+                    WindowOp::MinMonthly => {
+                        if data_cache.is_new_month() {
+                            advance_ring_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, true);
+                        } else {
+                            accumulate_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, true);
+                        }
+                    }
+                    WindowOp::MaxMonthly => {
+                        if data_cache.is_new_month() {
+                            advance_ring_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, false);
+                        } else {
+                            accumulate_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, false);
+                        }
+                    }
                     // Daily family
-                    // TODO
+                    WindowOp::SumDaily | WindowOp::MeanDaily => {
+                        if data_cache.is_new_day() {
+                            advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        } else {
+                            accumulate_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        }
+                    }
+                    WindowOp::MinDaily => {
+                        if data_cache.is_new_day() {
+                            advance_ring_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, true);
+                        } else {
+                            accumulate_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, true);
+                        }
+                    }
+                    WindowOp::MaxDaily => {
+                        if data_cache.is_new_day() {
+                            advance_ring_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, false);
+                        } else {
+                            accumulate_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, false);
+                        }
+                    }
                 }
             }
 
@@ -2092,14 +2140,18 @@ fn uses_calendar_flags(node: &OptimizedExpressionNode) -> bool {
         }
         OptimizedExpressionNode::Fold { args, .. } => args.iter().any(uses_calendar_flags),
         OptimizedExpressionNode::CalendarAt { arg, .. } => uses_calendar_flags(arg),
-        // Annual-window ops read is_new_month()/get_timestamp_month() directly
-        // in advance_state (not through a SimContext node in `arg`), so they
-        // need the calendar flags live even when the sampled argument doesn't
-        // reference sim.* itself.
+        // Annual/monthly/daily-window ops read is_new_month()/is_new_day()/
+        // get_timestamp_month() directly in advance_state (not through a
+        // SimContext node in `arg`), so they need the calendar flags live
+        // even when the sampled argument doesn't reference sim.* itself.
         OptimizedExpressionNode::MovingWindow { op, arg, .. } => {
             matches!(op,
                 WindowOp::SumAnnual { .. } | WindowOp::MeanAnnual { .. }
-                | WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. })
+                | WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. }
+                | WindowOp::SumMonthly | WindowOp::MeanMonthly
+                | WindowOp::MinMonthly | WindowOp::MaxMonthly
+                | WindowOp::SumDaily | WindowOp::MeanDaily
+                | WindowOp::MinDaily | WindowOp::MaxDaily)
                 || uses_calendar_flags(arg)
         }
         OptimizedExpressionNode::Since { arg, reset, .. } => {
@@ -2286,6 +2338,27 @@ fn constant_arg(args: &[OptimizedExpressionNode], idx: usize, func: &str, what: 
     }
 }
 
+/// Allocate the ring-of-buckets arena state shared by the annual/monthly/
+/// daily window families: `[ring; n] + [running statistic; 1]`. Sum/mean
+/// start zero-filled (the additive identity, `is_extreme = false`); min/max
+/// start NaN-filled (`is_extreme = true`) — there's no additive identity for
+/// an extremum, and f64::min/f64::max already treat NaN as "no data yet, use
+/// the other operand" (see `accumulate_extreme`/`advance_ring_extreme`).
+fn alloc_bucket_ring(
+    arena: &mut crate::data_management::data_cache::ExprStateArena,
+    n: usize,
+    is_extreme: bool,
+) -> (usize, usize) {
+    let f_init = if is_extreme {
+        vec![f64::NAN; n + 1]
+    } else {
+        let mut v = vec![0.0; n];
+        v.push(0.0);
+        v
+    };
+    (arena.alloc_f(&f_init), arena.alloc_u(&[0]))
+}
+
 /// Lower a calendar-at-offset call (`month_at`/`days_in_month_at` — the
 /// CALENDAR_FUNCTIONS tier): context functions resolved here, like the
 /// stateful family, because they read the simulation clock at evaluation.
@@ -2372,9 +2445,13 @@ fn lower_stateful_call(
                 (arena.alloc_f(&f_init), arena.alloc_u(&u_init))
             }
             // window_op above only ever produces Sum/Mean/Min/Max; other families lowered
-            // separately 
+            // separately
             WindowOp::SumAnnual { .. } | WindowOp::MeanAnnual { .. }
-            | WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. } => unreachable!(),
+            | WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. }
+            | WindowOp::SumMonthly | WindowOp::MeanMonthly
+            | WindowOp::MinMonthly | WindowOp::MaxMonthly
+            | WindowOp::SumDaily | WindowOp::MeanDaily
+            | WindowOp::MinDaily | WindowOp::MaxDaily => unreachable!(),
         };
         return Ok(Some(OptimizedExpressionNode::MovingWindow {
             op,
@@ -2410,36 +2487,88 @@ fn lower_stateful_call(
         let n = n_years as usize;
         let arg = Box::new(args.swap_remove(0));
 
-        let (f_off, u_off, op) = match name {
-            "moving_annual_sum" | "moving_annual_mean" => {
-                // [ring of yearly totals; n] + [running total]. Sum and mean
-                // share this state exactly; mean only differs at evaluate()
-                // (divide by n).
-                let mut f_init = vec![0.0; n];
-                f_init.push(0.0);
-                let f_off = arena.alloc_f(&f_init);
-                let u_off = arena.alloc_u(&[0]);
-                let op = if name == "moving_annual_sum" {
-                    WindowOp::SumAnnual { wy_month }
-                } else {
-                    WindowOp::MeanAnnual { wy_month }
-                };
-                (f_off, u_off, op)
-            }
-            "moving_annual_min" | "moving_annual_max" => {
-                // [ring of yearly extrema; n] + [overall extremum]. NaN-filled:
-                // there's no additive identity for min/max, and f64::min/max
-                // already treat NaN as "no data yet, use the other operand".
-                let f_init = vec![f64::NAN; n + 1];
-                let f_off = arena.alloc_f(&f_init);
-                let u_off = arena.alloc_u(&[0]);
-                let op = if name == "moving_annual_min" {
-                    WindowOp::MinAnnual { wy_month }
-                } else {
-                    WindowOp::MaxAnnual { wy_month }
-                };
-                (f_off, u_off, op)
-            }
+        let is_extreme = matches!(name, "moving_annual_min" | "moving_annual_max");
+        let (f_off, u_off) = alloc_bucket_ring(arena, n, is_extreme);
+        let op = match name {
+            "moving_annual_sum" => WindowOp::SumAnnual { wy_month },
+            "moving_annual_mean" => WindowOp::MeanAnnual { wy_month },
+            "moving_annual_min" => WindowOp::MinAnnual { wy_month },
+            "moving_annual_max" => WindowOp::MaxAnnual { wy_month },
+            _ => unreachable!("previously matched on name"),
+        };
+
+        return Ok(Some(OptimizedExpressionNode::MovingWindow {
+            op,
+            slots: Box::new(WindowSlots { n, f_off, u_off }),
+            arg,
+        }));
+    }
+
+    // Monthly-window family: moving_monthly_sum/mean/min/max(x, n_months).
+    // Same ring-of-buckets shape as the annual family, but the boundary is
+    // every calendar month with no anchor month to carry.
+    if matches!(name, "moving_monthly_sum" | "moving_monthly_mean"
+                     | "moving_monthly_min" | "moving_monthly_max") {
+        if args.len() != 2 {
+            return Err(format!(
+                "Function '{}' expects 2 arguments (x, n_months), got {}",
+                name, args.len()
+            ));
+        }
+        let n_months = constant_arg(&args, 1, name, "number of months (2nd argument)")?;
+        if n_months.fract() != 0.0 || n_months < 1.0 {
+            return Err(format!(
+                "{}'s window length must be a positive integer, got {}",
+                name, n_months
+            ));
+        }
+        let n = n_months as usize;
+        let arg = Box::new(args.swap_remove(0));
+
+        let is_extreme = matches!(name, "moving_monthly_min" | "moving_monthly_max");
+        let (f_off, u_off) = alloc_bucket_ring(arena, n, is_extreme);
+        let op = match name {
+            "moving_monthly_sum" => WindowOp::SumMonthly,
+            "moving_monthly_mean" => WindowOp::MeanMonthly,
+            "moving_monthly_min" => WindowOp::MinMonthly,
+            "moving_monthly_max" => WindowOp::MaxMonthly,
+            _ => unreachable!("previously matched on name"),
+        };
+
+        return Ok(Some(OptimizedExpressionNode::MovingWindow {
+            op,
+            slots: Box::new(WindowSlots { n, f_off, u_off }),
+            arg,
+        }));
+    }
+
+    // Daily-window family: moving_daily_sum/mean/min/max(x, n_days). Same
+    // shape again, boundary is every calendar day.
+    if matches!(name, "moving_daily_sum" | "moving_daily_mean"
+                     | "moving_daily_min" | "moving_daily_max") {
+        if args.len() != 2 {
+            return Err(format!(
+                "Function '{}' expects 2 arguments (x, n_days), got {}",
+                name, args.len()
+            ));
+        }
+        let n_days = constant_arg(&args, 1, name, "number of days (2nd argument)")?;
+        if n_days.fract() != 0.0 || n_days < 1.0 {
+            return Err(format!(
+                "{}'s window length must be a positive integer, got {}",
+                name, n_days
+            ));
+        }
+        let n = n_days as usize;
+        let arg = Box::new(args.swap_remove(0));
+
+        let is_extreme = matches!(name, "moving_daily_min" | "moving_daily_max");
+        let (f_off, u_off) = alloc_bucket_ring(arena, n, is_extreme);
+        let op = match name {
+            "moving_daily_sum" => WindowOp::SumDaily,
+            "moving_daily_mean" => WindowOp::MeanDaily,
+            "moving_daily_min" => WindowOp::MinDaily,
+            "moving_daily_max" => WindowOp::MaxDaily,
             _ => unreachable!("previously matched on name"),
         };
 

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -2259,6 +2259,7 @@ fn lower_function_call(
         B::Round => Some(f64::round),
         B::Sign => Some(crate::functions::functions::sign),
         B::IsLeapYear => Some(crate::functions::functions::is_leap_year_f),
+        B::SkipNan => Some(crate::functions::functions::skip_nan),
         _ => None,
     };
     if let Some(f) = f1 {

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -646,7 +646,7 @@ impl OptimizedExpressionNode {
                         if data_cache.is_new_month() && data_cache.get_timestamp_month() == *wy_month {
                             advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
                         } else {
-                            accumulate(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                            accumulate_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
                         }
                     }
                     // Monthly family
@@ -818,7 +818,7 @@ impl OptimizedExpressionNode {
 }
 
 /// Accumulate into a ring buffer without advancing. Maintain the running sum incrementally.
-fn accumulate(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64) {
+fn accumulate_ring(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64) {
     let arena = &mut data_cache.expr_state;
     let head = arena.u[u_off];
     let total_slot = f_off + n;

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -1,30 +1,30 @@
-/// Dynamic Input - Optimized expression evaluation for model inputs
-///
-/// This module provides a high-performance input mechanism that allows model nodes
-/// to accept constants, direct data references, or complex function expressions with
-/// zero or minimal overhead.
-///
-/// # Performance Characteristics
-///
-/// - `None`: Zero overhead (returns 0.0)
-/// - `DirectReference`: Zero overhead (single array lookup)
-/// - `DirectConstantReference`: Zero overhead (single array lookup)
-/// - `Constant`: Zero overhead (returns stored value)
-/// - `Function`: Minimal overhead — a tree walk of pure arithmetic. Evaluation is
-///   infallible and allocation-free: unknown functions and wrong argument counts are
-///   rejected when the expression is parsed (at model load), `if`/`&&`/`||`
-///   short-circuit, and variadic min/max/sum/mean fold an accumulator instead of
-///   building an argument buffer.
-///
-/// # Error Handling - IEEE 754 Standard
-///
-/// Mathematical operations follow IEEE 754 floating-point standard:
-/// - Division by zero: `x / 0.0` → `+∞` (x > 0), `-∞` (x < 0), `NaN` (x = 0)
-/// - Domain errors: `sqrt(-1)` → `NaN`, `ln(0)` → `-∞`, `asin(2)` → `NaN`
-/// - Overflow: `exp(1000)` → `+∞`
-///
-/// This allows simulations to continue running even with problematic data, while making
-/// issues clearly visible in the output. Check for NaN/∞ in results to detect problems.
+//! Dynamic Input - Optimized expression evaluation for model inputs
+//!
+//! This module provides a high-performance input mechanism that allows model nodes
+//! to accept constants, direct data references, or complex function expressions with
+//! zero or minimal overhead.
+//!
+//! # Performance Characteristics
+//!
+//! - `None`: Zero overhead (returns 0.0)
+//! - `DirectReference`: Zero overhead (single array lookup)
+//! - `DirectConstantReference`: Zero overhead (single array lookup)
+//! - `Constant`: Zero overhead (returns stored value)
+//! - `Function`: Minimal overhead — a tree walk of pure arithmetic. Evaluation is
+//!   infallible and allocation-free: unknown functions and wrong argument counts are
+//!   rejected when the expression is parsed (at model load), `if`/`&&`/`||`
+//!   short-circuit, and variadic min/max/sum/mean fold an accumulator instead of
+//!   building an argument buffer.
+//!
+//! # Error Handling - IEEE 754 Standard
+//!
+//! Mathematical operations follow IEEE 754 floating-point standard:
+//! - Division by zero: `x / 0.0` → `+∞` (x > 0), `-∞` (x < 0), `NaN` (x = 0)
+//! - Domain errors: `sqrt(-1)` → `NaN`, `ln(0)` → `-∞`, `asin(2)` → `NaN`
+//! - Overflow: `exp(1000)` → `+∞`
+//!
+//! This allows simulations to continue running even with problematic data, while making
+//! issues clearly visible in the output. Check for NaN/∞ in results to detect problems.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -347,7 +347,8 @@ pub enum WindowOp {
     Min,
     Max,
     // Annual (water year) operations
-    SumAnnual { wy_month: u32 },
+    SumAnnual  { wy_month: u32 },
+    MeanAnnual { wy_month: u32 },
     // Monthly operations
     // TODO
     // Daily operations
@@ -494,6 +495,10 @@ impl OptimizedExpressionNode {
                     let sum_slot = slots.f_off + slots.n;
                     data_cache.expr_state.f[sum_slot]
                 }
+                WindowOp::MeanAnnual { .. } => {
+                    let sum_slot = slots.f_off + slots.n;
+                    data_cache.expr_state.f[sum_slot] / slots.n as f64
+                }
             },
 
             OptimizedExpressionNode::Since { f_off, .. } => data_cache.expr_state.f[*f_off],
@@ -634,10 +639,10 @@ impl OptimizedExpressionNode {
                     WindowOp::Min => advance_deque(data_cache, slots.n, slots.f_off, slots.u_off, x, true),
                     WindowOp::Max => advance_deque(data_cache, slots.n, slots.f_off, slots.u_off, x, false),
                     // Annual (water year) family 
-                    WindowOp::SumAnnual { wy_month } => {
+                    // Precondition: wy_month in [1, 12] integral - enforce at parse time
+                    // (see `lower_stateful_call()`) instead of on hot path
+                    WindowOp::SumAnnual { wy_month } | WindowOp::MeanAnnual { wy_month } => {
                         // New water year when new month and month equals wy_month
-                        // Precondition: wy_month in [1, 12] integral - enforce at parse time
-                        // (see `lower_stateful_call()`) instead of on hot path
                         if data_cache.is_new_month() && data_cache.get_timestamp_month() == *wy_month {
                             advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
                         } else {
@@ -2298,7 +2303,7 @@ fn lower_stateful_call(
             }
             // window_op above only ever produces Sum/Mean/Min/Max; other families lowered
             // separately 
-            WindowOp::SumAnnual { .. } => unreachable!(),
+            WindowOp::SumAnnual { .. } | WindowOp::MeanAnnual { .. }  => unreachable!(),
         };
         return Ok(Some(OptimizedExpressionNode::MovingWindow {
             op,
@@ -2307,14 +2312,8 @@ fn lower_stateful_call(
         }));
     }
 
-    // Annual-window family: moving_annual_sum(x, wy_month, n_years)
-    let window_op = match name {
-        // Note: As these are constructed prior to parsing wy_month, the wy_month = 0 is a
-        // placeholder.
-        "moving_annual_sum" => Some(WindowOp::SumAnnual { wy_month: 0u32 }),
-        _ => None
-    };
-    if let Some(op) = window_op {
+    // Annual-window family
+    if matches!(name, "moving_annual_sum" | "moving_annual_mean") {
         if args.len() != 3 {
             return Err(format!(
                 "Function '{}' expects 3 arguments (x, wy_month, n_years), got {}",
@@ -2328,6 +2327,7 @@ fn lower_stateful_call(
                 name, wy_month
             ));
         }
+        let wy_month = wy_month as u32;
         let n_years = constant_arg(&args, 2, name, "number of years (3rd argument)")?;
         if n_years.fract() != 0.0 || n_years < 1.0 {
             return Err(format!(
@@ -2338,14 +2338,19 @@ fn lower_stateful_call(
         let n = n_years as usize;
         let arg = Box::new(args.swap_remove(0));
 
-        // Specific allocation for sum - to be expanded.
         // [ring; n] + [running sum]
         let mut f_init = vec![0.0; n];
         f_init.push(0.0);
-        let (f_off, u_off) = (arena.alloc_f(&f_init), arena.alloc_u(&[0]));
+        let f_off = arena.alloc_f(&f_init);
+        let u_off = arena.alloc_u(&[0]);
+        let op = match name {
+            "moving_annual_sum"  => WindowOp::SumAnnual  { wy_month }
+            "moving_annual_mean" => WindowOp::MeanAnnual { wy_month }
+            _ => unreachable!("previously matched on name")
+        }
 
         return Ok(Some(OptimizedExpressionNode::MovingWindow {
-            op: WindowOp::SumAnnual { wy_month: wy_month as u32 },
+            op,
             slots: Box::new(WindowSlots { n, f_off, u_off }),
             arg,
         }));

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -349,6 +349,8 @@ pub enum WindowOp {
     // Annual (water year) operations
     SumAnnual  { wy_month: u32 },
     MeanAnnual { wy_month: u32 },
+    MinAnnual  { wy_month: u32 },
+    MaxAnnual  { wy_month: u32 },
     // Monthly operations
     // TODO
     // Daily operations
@@ -499,6 +501,10 @@ impl OptimizedExpressionNode {
                     let sum_slot = slots.f_off + slots.n;
                     data_cache.expr_state.f[sum_slot] / slots.n as f64
                 }
+                WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. } => {
+                    let stat_slot = slots.f_off + slots.n;
+                    data_cache.expr_state.f[stat_slot]
+                }
             },
 
             OptimizedExpressionNode::Since { f_off, .. } => data_cache.expr_state.f[*f_off],
@@ -647,6 +653,20 @@ impl OptimizedExpressionNode {
                             advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
                         } else {
                             accumulate_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        }
+                    }
+                    WindowOp::MinAnnual { wy_month } => {
+                        if data_cache.is_new_month() && data_cache.get_timestamp_month() == *wy_month {
+                            advance_ring_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, true);
+                        } else {
+                            accumulate_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, true);
+                        }
+                    }
+                    WindowOp::MaxAnnual { wy_month } => {
+                        if data_cache.is_new_month() && data_cache.get_timestamp_month() == *wy_month {
+                            advance_ring_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, false);
+                        } else {
+                            accumulate_extreme(data_cache, slots.n, slots.f_off, slots.u_off, x, false);
                         }
                     }
                     // Monthly family
@@ -828,6 +848,52 @@ fn accumulate_ring(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: us
     arena.f[total_slot]   += x;
 }
 
+/// Accumulate into the current year's slot of an annual min/max ring without
+/// advancing (the ring-of-extrema counterpart to `accumulate_ring`). Tightens
+/// both the current year's running extremum and the overall extremum in O(1):
+/// valid because `x` can only make either more extreme, and the overall
+/// extremum already correctly reflects every other (untouched) ring slot as
+/// of the last boundary (see `advance_ring_extreme`). NaN inputs are
+/// suppressed automatically — f64::min/f64::max return the non-NaN operand —
+/// matching how moving_min/moving_max suppress NaN.
+fn accumulate_extreme(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64, is_min: bool) {
+    let arena = &mut data_cache.expr_state;
+    let head = arena.u[u_off];
+    let slot = f_off + head;
+    let stat_slot = f_off + n;
+    if is_min {
+        arena.f[slot] = arena.f[slot].min(x);
+        arena.f[stat_slot] = arena.f[stat_slot].min(x);
+    } else {
+        arena.f[slot] = arena.f[slot].max(x);
+        arena.f[stat_slot] = arena.f[stat_slot].max(x);
+    }
+}
+
+/// Advance an annual min/max ring at a water-year boundary (the ring-of-
+/// extrema counterpart to `advance_ring`): evict the oldest year's extremum,
+/// start the new year's slot at x, and recompute the overall extremum by
+/// rescanning the ring. Unlike sum, min/max has no inverse to correct an
+/// eviction incrementally (knowing what left tells you nothing about what's
+/// left), so the O(n) rescan runs on every boundary — cheap, since boundaries
+/// fire once per water year, not once per step. NaN ring entries (years not
+/// yet reached, or fully NaN-poisoned years) are ignored automatically by
+/// f64::min/f64::max's NaN-suppression.
+fn advance_ring_extreme(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64, is_min: bool) {
+    let arena = &mut data_cache.expr_state;
+    let head = arena.u[u_off];
+    let new_head = if head + 1 == n { 0 } else { head + 1 };
+    arena.f[f_off + new_head] = x;
+    arena.u[u_off] = new_head;
+
+    let stat_slot = f_off + n;
+    let mut s = f64::NAN;
+    for i in 0..n {
+        s = if is_min { s.min(arena.f[f_off + i]) } else { s.max(arena.f[f_off + i]) };
+    }
+    arena.f[stat_slot] = s;
+}
+
 /// Advance a moving_sum/mean ring buffer by one step: evict the oldest value,
 /// store the incoming one, and maintain the running sum incrementally (one
 /// subtract + one add). The sum is recomputed from the ring in two cold
@@ -859,12 +925,14 @@ fn advance_ring(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize
 /// Advance a moving_min/max monotonic deque by one step. Amortised O(1):
 /// every element is pushed and popped at most once.
 ///
-/// Layout: values in f[f_off..f_off+n+1]; expiry steps in u[u_off..u_off+n+1];
-/// head index at u[u_off+n+1]; length at u[u_off+n+2]. Entries are stored
-/// circularly; an element sampled at step s expires after step s + n - 1.
-/// NaN inputs are skipped entirely: the window min/max suppress NaN exactly
-/// as the min/max builtins do, and an empty deque (all real values NaN)
-/// reads as NaN at evaluation.
+/// Layout: 
+/// - values in f[f_off..f_off+n+1]; 
+/// - expiry steps in u[u_off..u_off+n+1];
+/// - head index at u[u_off+n+1]; 
+/// - length at u[u_off+n+2]. 
+/// Entries are stored circularly; an element sampled at step s expires after step s + n - 1. NaN
+/// inputs are skipped entirely: the window min/max suppress NaN exactly as the min/max builtins do,
+/// and an empty deque (all real values NaN) reads as NaN at evaluation.
 fn advance_deque(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64, is_min: bool) {
     let step = data_cache.current_step;
     let arena = &mut data_cache.expr_state;
@@ -2029,7 +2097,9 @@ fn uses_calendar_flags(node: &OptimizedExpressionNode) -> bool {
         // need the calendar flags live even when the sampled argument doesn't
         // reference sim.* itself.
         OptimizedExpressionNode::MovingWindow { op, arg, .. } => {
-            matches!(op, WindowOp::SumAnnual { .. })
+            matches!(op,
+                WindowOp::SumAnnual { .. } | WindowOp::MeanAnnual { .. }
+                | WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. })
                 || uses_calendar_flags(arg)
         }
         OptimizedExpressionNode::Since { arg, reset, .. } => {
@@ -2303,7 +2373,8 @@ fn lower_stateful_call(
             }
             // window_op above only ever produces Sum/Mean/Min/Max; other families lowered
             // separately 
-            WindowOp::SumAnnual { .. } | WindowOp::MeanAnnual { .. }  => unreachable!(),
+            WindowOp::SumAnnual { .. } | WindowOp::MeanAnnual { .. }
+            | WindowOp::MinAnnual { .. } | WindowOp::MaxAnnual { .. } => unreachable!(),
         };
         return Ok(Some(OptimizedExpressionNode::MovingWindow {
             op,
@@ -2312,8 +2383,9 @@ fn lower_stateful_call(
         }));
     }
 
-    // Annual-window family
-    if matches!(name, "moving_annual_sum" | "moving_annual_mean") {
+    // Annual-window family: moving_annual_sum/mean/min/max(x, wy_month, n_years).
+    if matches!(name, "moving_annual_sum" | "moving_annual_mean"
+                     | "moving_annual_min" | "moving_annual_max") {
         if args.len() != 3 {
             return Err(format!(
                 "Function '{}' expects 3 arguments (x, wy_month, n_years), got {}",
@@ -2338,16 +2410,38 @@ fn lower_stateful_call(
         let n = n_years as usize;
         let arg = Box::new(args.swap_remove(0));
 
-        // [ring; n] + [running sum]
-        let mut f_init = vec![0.0; n];
-        f_init.push(0.0);
-        let f_off = arena.alloc_f(&f_init);
-        let u_off = arena.alloc_u(&[0]);
-        let op = match name {
-            "moving_annual_sum"  => WindowOp::SumAnnual  { wy_month }
-            "moving_annual_mean" => WindowOp::MeanAnnual { wy_month }
-            _ => unreachable!("previously matched on name")
-        }
+        let (f_off, u_off, op) = match name {
+            "moving_annual_sum" | "moving_annual_mean" => {
+                // [ring of yearly totals; n] + [running total]. Sum and mean
+                // share this state exactly; mean only differs at evaluate()
+                // (divide by n).
+                let mut f_init = vec![0.0; n];
+                f_init.push(0.0);
+                let f_off = arena.alloc_f(&f_init);
+                let u_off = arena.alloc_u(&[0]);
+                let op = if name == "moving_annual_sum" {
+                    WindowOp::SumAnnual { wy_month }
+                } else {
+                    WindowOp::MeanAnnual { wy_month }
+                };
+                (f_off, u_off, op)
+            }
+            "moving_annual_min" | "moving_annual_max" => {
+                // [ring of yearly extrema; n] + [overall extremum]. NaN-filled:
+                // there's no additive identity for min/max, and f64::min/max
+                // already treat NaN as "no data yet, use the other operand".
+                let f_init = vec![f64::NAN; n + 1];
+                let f_off = arena.alloc_f(&f_init);
+                let u_off = arena.alloc_u(&[0]);
+                let op = if name == "moving_annual_min" {
+                    WindowOp::MinAnnual { wy_month }
+                } else {
+                    WindowOp::MaxAnnual { wy_month }
+                };
+                (f_off, u_off, op)
+            }
+            _ => unreachable!("previously matched on name"),
+        };
 
         return Ok(Some(OptimizedExpressionNode::MovingWindow {
             op,

--- a/src/model_inputs/dynamic_input.rs
+++ b/src/model_inputs/dynamic_input.rs
@@ -337,13 +337,21 @@ pub enum FoldOp {
     Mean,
 }
 
-/// Statistic computed by a fixed-window `moving_*` call.
+/// Statistic computed by a fixed-window `moving_*` call, including annual, monthly and daily
+/// variants
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowOp {
+    // Fixed time step operations
     Sum,
     Mean,
     Min,
     Max,
+    // Annual (water year) operations
+    SumAnnual { wy_month: u32 },
+    // Monthly operations
+    // TODO
+    // Daily operations
+    // TODO
 }
 
 /// Arena addressing for one moving-window instance, boxed off the
@@ -482,6 +490,10 @@ impl OptimizedExpressionNode {
                     let len = data_cache.expr_state.u[slots.u_off + slots.n + 2];
                     if len == 0 { f64::NAN } else { data_cache.expr_state.f[slots.f_off + head] }
                 }
+                WindowOp::SumAnnual { .. } => {
+                    let sum_slot = slots.f_off + slots.n;
+                    data_cache.expr_state.f[sum_slot]
+                }
             },
 
             OptimizedExpressionNode::Since { f_off, .. } => data_cache.expr_state.f[*f_off],
@@ -615,11 +627,27 @@ impl OptimizedExpressionNode {
                 arg.advance_state(data_cache);
                 let x = arg.evaluate(data_cache);
                 match op {
+                    // Fixed window family 
                     WindowOp::Sum | WindowOp::Mean => {
                         advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
                     }
                     WindowOp::Min => advance_deque(data_cache, slots.n, slots.f_off, slots.u_off, x, true),
                     WindowOp::Max => advance_deque(data_cache, slots.n, slots.f_off, slots.u_off, x, false),
+                    // Annual (water year) family 
+                    WindowOp::SumAnnual { wy_month } => {
+                        // New water year when new month and month equals wy_month
+                        // Precondition: wy_month in [1, 12] integral - enforce at parse time
+                        // (see `lower_stateful_call()`) instead of on hot path
+                        if data_cache.is_new_month() && data_cache.get_timestamp_month() == *wy_month {
+                            advance_ring(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        } else {
+                            accumulate(data_cache, slots.n, slots.f_off, slots.u_off, x);
+                        }
+                    }
+                    // Monthly family
+                    // TODO
+                    // Daily family
+                    // TODO
                 }
             }
 
@@ -784,6 +812,16 @@ impl OptimizedExpressionNode {
     }
 }
 
+/// Accumulate into a ring buffer without advancing. Maintain the running sum incrementally.
+fn accumulate(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64) {
+    let arena = &mut data_cache.expr_state;
+    let head = arena.u[u_off];
+    let total_slot = f_off + n;
+    // Add to this year and the total of all tracked years
+    // TODO: float drift?
+    arena.f[f_off + head] += x;
+    arena.f[total_slot]   += x;
+}
 
 /// Advance a moving_sum/mean ring buffer by one step: evict the oldest value,
 /// store the incoming one, and maintain the running sum incrementally (one
@@ -796,9 +834,9 @@ impl OptimizedExpressionNode {
 fn advance_ring(data_cache: &mut DataCache, n: usize, f_off: usize, u_off: usize, x: f64) {
     let arena = &mut data_cache.expr_state;
     let head = arena.u[u_off];
-    let evicted = arena.f[f_off + head];
-    arena.f[f_off + head] = x;
     let new_head = if head + 1 == n { 0 } else { head + 1 };
+    let evicted = arena.f[f_off + new_head];
+    arena.f[f_off + new_head] = x;
     arena.u[u_off] = new_head;
 
     let sum_slot = f_off + n;
@@ -1981,7 +2019,14 @@ fn uses_calendar_flags(node: &OptimizedExpressionNode) -> bool {
         }
         OptimizedExpressionNode::Fold { args, .. } => args.iter().any(uses_calendar_flags),
         OptimizedExpressionNode::CalendarAt { arg, .. } => uses_calendar_flags(arg),
-        OptimizedExpressionNode::MovingWindow { arg, .. } => uses_calendar_flags(arg),
+        // Annual-window ops read is_new_month()/get_timestamp_month() directly
+        // in advance_state (not through a SimContext node in `arg`), so they
+        // need the calendar flags live even when the sampled argument doesn't
+        // reference sim.* itself.
+        OptimizedExpressionNode::MovingWindow { op, arg, .. } => {
+            matches!(op, WindowOp::SumAnnual { .. })
+                || uses_calendar_flags(arg)
+        }
         OptimizedExpressionNode::Since { arg, reset, .. } => {
             arg.as_deref().map(uses_calendar_flags).unwrap_or(false) || uses_calendar_flags(reset)
         }
@@ -2166,17 +2211,6 @@ fn constant_arg(args: &[OptimizedExpressionNode], idx: usize, func: &str, what: 
     }
 }
 
-/// Lower a stateful builtin (moving_*/*_since) if `name` is one, allocating
-/// its arena state. Returns Ok(None) for names that are not stateful
-/// builtins, letting the caller fall through to its unknown-function error.
-///
-/// Init templates encode the warm-up semantics
-/// (structured_expressions_design.md §5-§6):
-/// - moving windows pre-fill with the element default (running sum =
-///   n * default; the min/max deque starts with one default entry expiring
-///   when the last pre-filled element would leave the window);
-/// - *_since accumulators start as if reset fired just before the run
-///   (sum/count 0, steps -1, min/max NaN which f64::min/max suppress).
 /// Lower a calendar-at-offset call (`month_at`/`days_in_month_at` — the
 /// CALENDAR_FUNCTIONS tier): context functions resolved here, like the
 /// stateful family, because they read the simulation clock at evaluation.
@@ -2199,6 +2233,17 @@ fn lower_calendar_call(
     Ok(Some(OptimizedExpressionNode::CalendarAt { kind, arg: Box::new(args.remove(0)) }))
 }
 
+/// Lower a stateful builtin (moving_*/*_since) if `name` is one, allocating
+/// its arena state. Returns Ok(None) for names that are not stateful
+/// builtins, letting the caller fall through to its unknown-function error.
+///
+/// Init templates encode the warm-up semantics
+/// (structured_expressions_design.md §5-§6):
+/// - moving windows pre-fill with the element default (running sum =
+///   n * default; the min/max deque starts with one default entry expiring
+///   when the last pre-filled element would leave the window);
+/// - *_since accumula/tors start as if reset fired just before the run
+///   (sum/count 0, steps -1, min/max NaN which f64::min/max suppress).
 fn lower_stateful_call(
     name: &str,
     mut args: Vec<OptimizedExpressionNode>,
@@ -2251,9 +2296,56 @@ fn lower_stateful_call(
                 }
                 (arena.alloc_f(&f_init), arena.alloc_u(&u_init))
             }
+            // window_op above only ever produces Sum/Mean/Min/Max; other families lowered
+            // separately 
+            WindowOp::SumAnnual { .. } => unreachable!(),
         };
         return Ok(Some(OptimizedExpressionNode::MovingWindow {
             op,
+            slots: Box::new(WindowSlots { n, f_off, u_off }),
+            arg,
+        }));
+    }
+
+    // Annual-window family: moving_annual_sum(x, wy_month, n_years)
+    let window_op = match name {
+        // Note: As these are constructed prior to parsing wy_month, the wy_month = 0 is a
+        // placeholder.
+        "moving_annual_sum" => Some(WindowOp::SumAnnual { wy_month: 0u32 }),
+        _ => None
+    };
+    if let Some(op) = window_op {
+        if args.len() != 3 {
+            return Err(format!(
+                "Function '{}' expects 3 arguments (x, wy_month, n_years), got {}",
+                name, args.len()
+            ));
+        }
+        let wy_month = constant_arg(&args, 1, name, "water year month (2nd argument)")?;
+        if wy_month.fract() != 0.0 || wy_month < 1.0 || wy_month > 12.0 {
+            return Err(format!(
+                "{}'s water year month must be a positive integer between 1 and 12, got {}",
+                name, wy_month
+            ));
+        }
+        let n_years = constant_arg(&args, 2, name, "number of years (3rd argument)")?;
+        if n_years.fract() != 0.0 || n_years < 1.0 {
+            return Err(format!(
+                "{}'s window length must be a positive integer, got {}",
+                name, n_years
+            ));
+        }
+        let n = n_years as usize;
+        let arg = Box::new(args.swap_remove(0));
+
+        // Specific allocation for sum - to be expanded.
+        // [ring; n] + [running sum]
+        let mut f_init = vec![0.0; n];
+        f_init.push(0.0);
+        let (f_off, u_off) = (arena.alloc_f(&f_init), arena.alloc_u(&[0]));
+
+        return Ok(Some(OptimizedExpressionNode::MovingWindow {
+            op: WindowOp::SumAnnual { wy_month: wy_month as u32 },
             slots: Box::new(WindowSlots { n, f_off, u_off }),
             arg,
         }));

--- a/src/tests/test_dynamic_input.rs
+++ b/src/tests/test_dynamic_input.rs
@@ -1595,3 +1595,67 @@ fn test_clamp_nan_input_suppressed() {
 fn test_clamp_lo_greater_than_hi_yields_hi() {
     assert_eq!(eval_x("clamp(data.x, 10, 0)", 5.0), 0.0);
 }
+
+// ============ skip_nan(x) ============
+
+/// skip_nan(x) maps NaN to 0.0 (sum/mean's additive identity — the value
+/// that contributes nothing); any other value, including 0 itself and
+/// negatives, passes through unchanged.
+#[test]
+fn test_skip_nan_maps_nan_to_zero_and_passes_through_otherwise() {
+    assert_eq!(eval_x("skip_nan(data.x)", f64::NAN), 0.0);
+    assert_eq!(eval_x("skip_nan(data.x)", 5.0), 5.0);
+    assert_eq!(eval_x("skip_nan(data.x)", -3.5), -3.5);
+    assert_eq!(eval_x("skip_nan(data.x)", 0.0), 0.0);
+}
+
+/// skip_nan requires exactly one argument; wrong arity is rejected at model load.
+#[test]
+fn test_skip_nan_wrong_arity_errors_at_load() {
+    for bad in ["skip_nan()", "skip_nan(data.x, 0)"] {
+        let mut data_cache = cache_with_x(&[1.0]);
+        let result = DynamicInput::from_string(bad, &mut data_cache, true, None);
+        assert!(result.is_err(), "'{}' should fail at load time", bad);
+    }
+}
+
+/// The composition this exists for: one NaN-gated signal ("real value on the
+/// tagged step, NaN otherwise") feeds moving_annual_max directly (min/max
+/// already suppress NaN) and moving_annual_sum through skip_nan (sum would
+/// otherwise poison on the NaN steps) — both read the same tagged values.
+#[test]
+fn test_skip_nan_composes_with_annual_sum_matching_annual_max_gating() {
+    let n_days = 800; // crosses 2 Jan-1 boundaries at daily stepping from 2020-01-01
+    // Tag every 10th day with a real value; NaN everywhere else.
+    let values: Vec<f64> = (0..n_days)
+        .map(|i| if i % 10 == 0 { 1.0 + (i % 7) as f64 } else { f64::NAN })
+        .collect();
+    let mut data_cache = cache_with_x(&values);
+    let sum = DynamicInput::from_string(
+        "moving_annual_sum(skip_nan(data.x), 1, 2)", &mut data_cache, true, None).unwrap();
+    let max = DynamicInput::from_string(
+        "moving_annual_max(data.x, 1, 2)", &mut data_cache, true, None).unwrap();
+
+    // Both must stay finite throughout — sum because skip_nan neutralised the
+    // NaN steps before they ever reached the ring; max because it suppresses
+    // NaN directly. Without skip_nan, the sum side would poison at day 0.
+    for k in 0..n_days {
+        data_cache.set_current_step(k);
+        let s = sum.get_value(&mut data_cache);
+        let m = max.get_value(&mut data_cache);
+        assert!(s.is_finite(), "moving_annual_sum(skip_nan(...)) went NaN at step {}", k);
+        assert!(m.is_finite(), "moving_annual_max(...) went NaN at step {}", k);
+    }
+}
+
+/// There is no first-class NaN literal in a general expression position —
+/// the bare `nan` identifier only parses inside a `[offset, default]` pair
+/// (see parser.rs). `0.0 / 0.0` is the documented idiom for producing NaN
+/// anywhere else (FUNCTIONS_DOCUMENTATION.md's skip_nan example uses it):
+/// plain IEEE 754 division, no special-cased error path in this engine.
+#[test]
+fn test_zero_over_zero_is_the_nan_literal_idiom() {
+    assert!(eval_x("0.0 / 0.0", 1.0).is_nan());
+    assert!(eval_x("if(data.x > 0, data.x, 0.0 / 0.0)", -1.0).is_nan());
+    assert_eq!(eval_x("skip_nan(0.0 / 0.0)", 1.0), 0.0);
+}

--- a/src/tests/test_programs.rs
+++ b/src/tests/test_programs.rs
@@ -488,6 +488,8 @@ fn test_local_cannot_shadow_stateful_or_reserved() {
         ("{ steps_since = 1; steps_since }", "stateful function"),
         ("{ moving_mean = 1; moving_mean }", "stateful function"),
         ("{ moving_annual_sum = 1; moving_annual_sum }", "stateful function"),
+        ("{ moving_monthly_sum = 1; moving_monthly_sum }", "stateful function"),
+        ("{ moving_daily_sum = 1; moving_daily_sum }", "stateful function"),
         ("{ min = 1; min }", "builtin function"),
         ("{ this = 1; 1 }", "reserved word"),
     ] {

--- a/src/tests/test_programs.rs
+++ b/src/tests/test_programs.rs
@@ -487,6 +487,7 @@ fn test_local_cannot_shadow_stateful_or_reserved() {
     for (value, needle) in [
         ("{ steps_since = 1; steps_since }", "stateful function"),
         ("{ moving_mean = 1; moving_mean }", "stateful function"),
+        ("{ moving_annual_sum = 1; moving_annual_sum }", "stateful function"),
         ("{ min = 1; min }", "builtin function"),
         ("{ this = 1; 1 }", "reserved word"),
     ] {

--- a/src/tests/test_stateful_functions.rs
+++ b/src/tests/test_stateful_functions.rs
@@ -749,3 +749,204 @@ fn test_moving_annual_load_errors() {
     assert!(DynamicInput::from_string("moving_annual_sum(data.x, 6, 2)", &mut dc, true, None).is_ok(),
         "a well-formed moving_annual_sum call should parse");
 }
+
+// ============================================================================
+// F. moving_monthly_* semantics
+// ============================================================================
+//
+// moving_monthly_sum/mean/min/max(x, n_months) is the annual family's shape
+// with the boundary rule relaxed to "every calendar month" — no anchor month,
+// hence no wy_month argument.
+
+/// Independent oracle for moving_monthly_sum/mean: buckets `values` by
+/// calendar month (a new bucket starts whenever the month changes, day 0
+/// always starting one), then slides a last-n_months window over the
+/// buckets. Mirrors expected_annual with the anchor check dropped.
+fn expected_monthly(values: &[f64], n_months: usize, mean: bool) -> Vec<f64> {
+    let mut buckets: Vec<f64> = Vec::new();
+    let mut out = Vec::with_capacity(values.len());
+    let mut prev_month = 0u32;
+    for (d, &x) in values.iter().enumerate() {
+        let ts = start_ts() + 86400u64 * d as u64;
+        let (_year, month, _day, _secs) = crate::tid::utils::u64_to_year_month_day_and_seconds(ts);
+        let boundary = d == 0 || month != prev_month;
+        if boundary || buckets.is_empty() {
+            buckets.push(x);
+        } else {
+            *buckets.last_mut().unwrap() += x;
+        }
+        prev_month = month;
+        let start = buckets.len().saturating_sub(n_months);
+        let sum: f64 = buckets[start..].iter().sum();
+        out.push(if mean { sum / n_months as f64 } else { sum });
+    }
+    out
+}
+
+/// Independent oracle for moving_monthly_min/max: same monthly bucketing,
+/// each bucket holds the running min/max of its values.
+fn expected_monthly_extreme(values: &[f64], n_months: usize, is_min: bool) -> Vec<f64> {
+    let mut buckets: Vec<f64> = Vec::new();
+    let mut out = Vec::with_capacity(values.len());
+    let mut prev_month = 0u32;
+    for (d, &x) in values.iter().enumerate() {
+        let ts = start_ts() + 86400u64 * d as u64;
+        let (_year, month, _day, _secs) = crate::tid::utils::u64_to_year_month_day_and_seconds(ts);
+        let boundary = d == 0 || month != prev_month;
+        if boundary || buckets.is_empty() {
+            buckets.push(x);
+        } else {
+            let last = buckets.last_mut().unwrap();
+            *last = if is_min { last.min(x) } else { last.max(x) };
+        }
+        prev_month = month;
+        let start = buckets.len().saturating_sub(n_months);
+        let mut s = f64::NAN;
+        for &b in &buckets[start..] {
+            s = if is_min { s.min(b) } else { s.max(b) };
+        }
+        out.push(s);
+    }
+    out
+}
+
+/// F25. moving_monthly_sum against the bucket oracle, n_months=3, spanning
+/// well over a year of daily steps (so several month boundaries land on
+/// different days-of-month and different-length months).
+#[test]
+fn test_moving_monthly_sum_matches_bucket_oracle() {
+    let n_days = 500;
+    let values: Vec<f64> = (0..n_days).map(|i| 1.0 + (i % 5) as f64).collect();
+    let mut dc = cache_with_x(&values);
+    let input = DynamicInput::from_string("moving_monthly_sum(data.x, 3)", &mut dc, true, None)
+        .expect("moving_monthly_sum should parse");
+    let got = run_steps(&input, &mut dc, n_days);
+    assert_series(&got, &expected_monthly(&values, 3, false), "moving_monthly_sum");
+}
+
+/// F26. moving_monthly_mean equals moving_monthly_sum / n_months at every step.
+#[test]
+fn test_moving_monthly_mean_matches_sum_over_n_months() {
+    let n_days = 500;
+    let values: Vec<f64> = (0..n_days).map(|i| 1.0 + (i % 5) as f64).collect();
+    let mut dc = cache_with_x(&values);
+    let sum = DynamicInput::from_string("moving_monthly_sum(data.x, 3)", &mut dc, true, None).unwrap();
+    let mean = DynamicInput::from_string("moving_monthly_mean(data.x, 3)", &mut dc, true, None).unwrap();
+    for k in 0..n_days {
+        dc.set_current_step(k);
+        let s = sum.get_value(&mut dc);
+        let m = mean.get_value(&mut dc);
+        assert!((m - s / 3.0).abs() < 1e-9,
+            "step {}: mean {} should equal sum {} / 3", k, m, s);
+    }
+}
+
+/// F27. moving_monthly_min/max against the bucket-extreme oracle, non-monotonic input.
+#[test]
+fn test_moving_monthly_min_max_matches_bucket_oracle() {
+    let n_days = 500;
+    let values: Vec<f64> = (0..n_days).map(|i| ((i * 37 + 5) % 23) as f64 - 11.0).collect();
+
+    let mut dc = cache_with_x(&values);
+    let min = DynamicInput::from_string("moving_monthly_min(data.x, 3)", &mut dc, true, None)
+        .expect("moving_monthly_min should parse");
+    let got_min = run_steps(&min, &mut dc, n_days);
+    assert_series(&got_min, &expected_monthly_extreme(&values, 3, true), "moving_monthly_min");
+
+    let mut dc = cache_with_x(&values);
+    let max = DynamicInput::from_string("moving_monthly_max(data.x, 3)", &mut dc, true, None)
+        .expect("moving_monthly_max should parse");
+    let got_max = run_steps(&max, &mut dc, n_days);
+    assert_series(&got_max, &expected_monthly_extreme(&values, 3, false), "moving_monthly_max");
+}
+
+/// F28. Load errors for the monthly family: n_months must be a constant
+/// positive integer; arity is fixed at 2 (no wy_month).
+#[test]
+fn test_moving_monthly_load_errors() {
+    for name in ["moving_monthly_sum", "moving_monthly_mean", "moving_monthly_min", "moving_monthly_max"] {
+        expect_load_err(&format!("{}(data.x, data.y)", name), "must be a constant");
+        expect_load_err(&format!("{}(data.x, 0)", name), "positive integer");
+        expect_load_err(&format!("{}(data.x, 2.5)", name), "positive integer");
+        expect_load_err(&format!("{}(data.x, 3, 1)", name), "expects 2 arguments");
+        expect_load_err(&format!("{}(data.x)", name), "expects 2 arguments");
+    }
+    let mut dc = base_cache();
+    add_series(&mut dc, "data.x", &[1.0], true);
+    assert!(DynamicInput::from_string("moving_monthly_sum(data.x, 3)", &mut dc, true, None).is_ok(),
+        "a well-formed moving_monthly_sum call should parse");
+}
+
+// ============================================================================
+// G. moving_daily_* semantics
+// ============================================================================
+//
+// moving_daily_sum/mean/min/max(x, n_days) buckets by calendar day. At a
+// daily timestep is_new_day() is true every step (structured_expressions_
+// design.md §7), so the daily family's boundary fires unconditionally every
+// step — making it directly comparable to the fixed-window family with a
+// zero/NaN "no warm-up" default, which is the strongest regression test
+// available: it cross-checks the new ring-of-buckets machinery against the
+// already-established advance_ring/advance_deque machinery on the same input.
+
+/// G29. At a daily timestep, moving_daily_sum/mean(x, n) is byte-identical to
+/// moving_sum/mean(x, n, 0): both are a zero-filled ring advancing every step.
+#[test]
+fn test_moving_daily_sum_mean_equal_plain_moving_at_daily_timestep() {
+    let values: Vec<f64> = (0..40).map(|i| 1.0 + (i % 7) as f64).collect();
+    for n in [1usize, 3, 5] {
+        let mut dc = cache_with_x(&values);
+        let daily_sum = DynamicInput::from_string(&format!("moving_daily_sum(data.x, {})", n), &mut dc, true, None).unwrap();
+        let plain_sum = DynamicInput::from_string(&format!("moving_sum(data.x, {}, 0)", n), &mut dc, true, None).unwrap();
+        let daily_mean = DynamicInput::from_string(&format!("moving_daily_mean(data.x, {})", n), &mut dc, true, None).unwrap();
+        let plain_mean = DynamicInput::from_string(&format!("moving_mean(data.x, {}, 0)", n), &mut dc, true, None).unwrap();
+        for k in 0..values.len() {
+            dc.set_current_step(k);
+            assert_eq!(daily_sum.get_value(&mut dc), plain_sum.get_value(&mut dc),
+                "n={} step {}: moving_daily_sum must equal moving_sum(.., 0)", n, k);
+            assert_eq!(daily_mean.get_value(&mut dc), plain_mean.get_value(&mut dc),
+                "n={} step {}: moving_daily_mean must equal moving_mean(.., 0)", n, k);
+        }
+    }
+}
+
+/// G30. At a daily timestep, moving_daily_min/max(x, n) matches a
+/// hand-computed cold-start window (no pre-filled default — every ring slot
+/// starts NaN, exactly like moving_min/max with a NaN default, i.e. no
+/// warm-up value at all), over non-monotonic data.
+#[test]
+fn test_moving_daily_min_max_hand_computed() {
+    let values = [5.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0];
+    let mut dc = cache_with_x(&values);
+    let min = DynamicInput::from_string("moving_daily_min(data.x, 3)", &mut dc, true, None)
+        .expect("moving_daily_min should parse");
+    let got_min = run_steps(&min, &mut dc, 8);
+    // step0 {5}=5; step1 {5,1}=1; step2 {5,1,4}=1; then full 3-windows:
+    // {1,4,1}=1,{4,1,5}=1,{1,5,9}=1,{5,9,2}=2,{9,2,6}=2
+    assert_series(&got_min, &[5.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0], "moving_daily_min");
+
+    let mut dc = cache_with_x(&values);
+    let max = DynamicInput::from_string("moving_daily_max(data.x, 3)", &mut dc, true, None)
+        .expect("moving_daily_max should parse");
+    let got_max = run_steps(&max, &mut dc, 8);
+    // step0 {5}=5; step1 {5,1}=5; step2 {5,1,4}=5; then full 3-windows:
+    // {1,4,1}=4,{4,1,5}=5,{1,5,9}=9,{5,9,2}=9,{9,2,6}=9
+    assert_series(&got_max, &[5.0, 5.0, 5.0, 4.0, 5.0, 9.0, 9.0, 9.0], "moving_daily_max");
+}
+
+/// G31. Load errors for the daily family: n_days must be a constant positive
+/// integer; arity is fixed at 2.
+#[test]
+fn test_moving_daily_load_errors() {
+    for name in ["moving_daily_sum", "moving_daily_mean", "moving_daily_min", "moving_daily_max"] {
+        expect_load_err(&format!("{}(data.x, data.y)", name), "must be a constant");
+        expect_load_err(&format!("{}(data.x, 0)", name), "positive integer");
+        expect_load_err(&format!("{}(data.x, 2.5)", name), "positive integer");
+        expect_load_err(&format!("{}(data.x, 3, 1)", name), "expects 2 arguments");
+        expect_load_err(&format!("{}(data.x)", name), "expects 2 arguments");
+    }
+    let mut dc = base_cache();
+    add_series(&mut dc, "data.x", &[1.0], true);
+    assert!(DynamicInput::from_string("moving_daily_sum(data.x, 3)", &mut dc, true, None).is_ok(),
+        "a well-formed moving_daily_sum call should parse");
+}

--- a/src/tests/test_stateful_functions.rs
+++ b/src/tests/test_stateful_functions.rs
@@ -523,3 +523,229 @@ fn test_moving_default_accepts_signed_literal() {
     assert!(DynamicInput::from_string("moving_sum(data.x, -3, 0)", &mut dc, false, None).is_err(),
         "negative window must still be rejected");
 }
+
+// ============================================================================
+// E. moving_annual_* semantics
+// ============================================================================
+//
+// moving_annual_sum/mean(x, wy_month, n_years) bucket x by water year (a new
+// bucket starts on the first day whose month equals wy_month) and report the
+// sum/mean of the last n_years buckets, including the in-progress one. Only
+// sum and mean are implemented so far; min/max are deliberately unrecognised
+// (see the "not yet implemented" note in lower_stateful_call).
+
+/// Independent oracle for moving_annual_sum/mean: buckets `values` (one entry
+/// per daily step from `start_ts()`) by water year using the same boundary
+/// rule DataCache applies (is_new_month() && month == wy_month, with day 0
+/// always a boundary), then slides a last-n_years window over the buckets.
+/// Deliberately reimplemented from scratch against `crate::tid::utils` date
+/// decoding, rather than exercising the engine's own flags, so it doesn't
+/// just echo back whatever the implementation does.
+fn expected_annual(values: &[f64], wy_month: u32, n_years: usize, mean: bool) -> Vec<f64> {
+    let mut buckets: Vec<f64> = Vec::new();
+    let mut out = Vec::with_capacity(values.len());
+    let mut prev_month = 0u32;
+    for (d, &x) in values.iter().enumerate() {
+        let ts = start_ts() + 86400u64 * d as u64;
+        let (_year, month, _day, _secs) = crate::tid::utils::u64_to_year_month_day_and_seconds(ts);
+        let boundary = if d == 0 { month == wy_month } else { month != prev_month && month == wy_month };
+        if boundary || buckets.is_empty() {
+            buckets.push(x);
+        } else {
+            *buckets.last_mut().unwrap() += x;
+        }
+        prev_month = month;
+        let start = buckets.len().saturating_sub(n_years);
+        let sum: f64 = buckets[start..].iter().sum();
+        out.push(if mean { sum / n_years as f64 } else { sum });
+    }
+    out
+}
+
+/// E17. moving_annual_sum against the bucket oracle, wy_month=1 (so water
+/// years align with calendar years — 2020 is a leap year, so this exercises
+/// a 366-day then two 365-day buckets), n_years=2, spanning 3 boundaries.
+/// This is exactly the n_years>=2 scenario the advance_ring eviction-target
+/// fix (this session) targeted: a wrong fix would leak or corrupt values at
+/// the second and third boundary, not the first.
+#[test]
+fn test_moving_annual_sum_matches_bucket_oracle() {
+    let n_days = 900; // 2020-01-01 .. into 2022, crossing 3 Jan-1 boundaries
+    let values: Vec<f64> = (0..n_days).map(|i| 1.0 + (i % 5) as f64).collect();
+    let mut dc = cache_with_x(&values);
+    let input = DynamicInput::from_string("moving_annual_sum(data.x, 1, 2)", &mut dc, true, None)
+        .expect("moving_annual_sum should parse");
+    let got = run_steps(&input, &mut dc, n_days);
+    let expected = expected_annual(&values, 1, 2, false);
+    assert_series(&got, &expected, "moving_annual_sum");
+}
+
+/// E18. moving_annual_mean equals moving_annual_sum / n_years at every step,
+/// same series and boundary as E17 (mirrors test_moving_mean_matches_sum_over_n).
+#[test]
+fn test_moving_annual_mean_matches_sum_over_n_years() {
+    let n_days = 900;
+    let values: Vec<f64> = (0..n_days).map(|i| 1.0 + (i % 5) as f64).collect();
+    let mut dc = cache_with_x(&values);
+    let sum = DynamicInput::from_string("moving_annual_sum(data.x, 1, 2)", &mut dc, true, None).unwrap();
+    let mean = DynamicInput::from_string("moving_annual_mean(data.x, 1, 2)", &mut dc, true, None).unwrap();
+    for k in 0..n_days {
+        dc.set_current_step(k);
+        let s = sum.get_value(&mut dc);
+        let m = mean.get_value(&mut dc);
+        assert!((m - s / 2.0).abs() < 1e-9,
+            "step {}: mean {} should equal sum {} / 2", k, m, s);
+    }
+}
+
+/// E19. n_years=1 edge case: the ring never leaves slot 0 (head+1==n wraps
+/// straight back to 0), which is exactly why this case alone didn't catch
+/// the eviction-target bug earlier this session — it's a weak case on its
+/// own, kept here as a basic sanity check, not as the main regression test
+/// (E17/E18 above are, since they require n_years>=2).
+#[test]
+fn test_moving_annual_sum_n_years_one() {
+    let n_days = 400;
+    let values: Vec<f64> = (0..n_days).map(|i| (i % 3) as f64).collect();
+    let mut dc = cache_with_x(&values);
+    let input = DynamicInput::from_string("moving_annual_sum(data.x, 1, 1)", &mut dc, true, None).unwrap();
+    let got = run_steps(&input, &mut dc, n_days);
+    let expected = expected_annual(&values, 1, 1, false);
+    assert_series(&got, &expected, "moving_annual_sum n_years=1");
+}
+
+/// E20. A NaN entering moving_annual_sum poisons the sum for as long as that
+/// water year's bucket remains in the ring (up to n_years boundaries), then
+/// clears once the poisoned year is evicted — the annual analogue of A5's
+/// n-step poisoning, scaled from steps to years.
+#[test]
+fn test_moving_annual_sum_nan_transient() {
+    let n_days = 800; // 2020-01-01 .. 2022-ish, crossing 2 Jan-1 boundaries
+    let mut values: Vec<f64> = vec![1.0; n_days];
+    values[100] = f64::NAN; // lands in the first (2020) water-year bucket
+    let mut dc = cache_with_x(&values);
+    let input = DynamicInput::from_string("moving_annual_sum(data.x, 1, 2)", &mut dc, true, None).unwrap();
+    let got = run_steps(&input, &mut dc, n_days);
+
+    // Before the NaN: finite. From the NaN through the end of the window
+    // that still includes the 2020 bucket: NaN. After the 2020 bucket is
+    // evicted (n_years=2 after it stops being one of the last 2 buckets):
+    // finite again.
+    assert!(got[99].is_finite(), "day 99: before the NaN, must be finite");
+    assert!(got[100].is_nan(), "day 100: the NaN's own day must be NaN");
+    assert!(got[400].is_nan(), "well within the 2-year window: still NaN");
+    assert!(got[n_days - 1].is_finite(),
+        "by the end of the run the poisoned 2020 bucket must have been evicted");
+}
+
+/// Independent oracle for moving_annual_min/max: same water-year bucketing
+/// as expected_annual, but each bucket holds the running min/max of its
+/// values, and the window statistic is the min/max over the last n_years
+/// buckets. Reimplemented from scratch (not sharing code with the ring
+/// helpers under test).
+fn expected_annual_extreme(values: &[f64], wy_month: u32, n_years: usize, is_min: bool) -> Vec<f64> {
+    let mut buckets: Vec<f64> = Vec::new();
+    let mut out = Vec::with_capacity(values.len());
+    let mut prev_month = 0u32;
+    for (d, &x) in values.iter().enumerate() {
+        let ts = start_ts() + 86400u64 * d as u64;
+        let (_year, month, _day, _secs) = crate::tid::utils::u64_to_year_month_day_and_seconds(ts);
+        let boundary = if d == 0 { month == wy_month } else { month != prev_month && month == wy_month };
+        if boundary || buckets.is_empty() {
+            buckets.push(x);
+        } else {
+            let last = buckets.last_mut().unwrap();
+            *last = if is_min { last.min(x) } else { last.max(x) };
+        }
+        prev_month = month;
+        let start = buckets.len().saturating_sub(n_years);
+        let mut s = f64::NAN;
+        for &b in &buckets[start..] {
+            s = if is_min { s.min(b) } else { s.max(b) };
+        }
+        out.push(s);
+    }
+    out
+}
+
+/// E21. moving_annual_min/max against the bucket-extreme oracle, same
+/// wy_month=1/n_years=2/3-boundary shape as E17, with non-monotonic input.
+#[test]
+fn test_moving_annual_min_max_matches_bucket_oracle() {
+    let n_days = 900;
+    let values: Vec<f64> = (0..n_days).map(|i| ((i * 37 + 5) % 23) as f64 - 11.0).collect();
+
+    let mut dc = cache_with_x(&values);
+    let min = DynamicInput::from_string("moving_annual_min(data.x, 1, 2)", &mut dc, true, None)
+        .expect("moving_annual_min should parse");
+    let got_min = run_steps(&min, &mut dc, n_days);
+    assert_series(&got_min, &expected_annual_extreme(&values, 1, 2, true), "moving_annual_min");
+
+    let mut dc = cache_with_x(&values);
+    let max = DynamicInput::from_string("moving_annual_max(data.x, 1, 2)", &mut dc, true, None)
+        .expect("moving_annual_max should parse");
+    let got_max = run_steps(&max, &mut dc, n_days);
+    assert_series(&got_max, &expected_annual_extreme(&values, 1, 2, false), "moving_annual_max");
+}
+
+/// E22. A year's extremum must leave the window exactly n_years boundaries
+/// after it entered, exercising advance_ring_extreme's O(n) rescan-on-evict
+/// (min/max has no incremental inverse for eviction the way sum does).
+/// wy_month=1, n_years=2: an outlier in the 2020 (leap-year) bucket must
+/// still be the window minimum through day 730 (2020's bucket is still one
+/// of the last 2), and must be gone from day 731 (2022's boundary, which
+/// evicts 2020's bucket).
+#[test]
+fn test_moving_annual_min_evicts_after_n_years() {
+    let n_days = 900;
+    let mut values = vec![10.0; n_days];
+    values[10] = -1000.0; // sits in the 2020 water-year bucket
+    let mut dc = cache_with_x(&values);
+    let input = DynamicInput::from_string("moving_annual_min(data.x, 1, 2)", &mut dc, true, None).unwrap();
+    let got = run_steps(&input, &mut dc, n_days);
+    assert_eq!(got[10], -1000.0, "day 10: the outlier's own day");
+    assert_eq!(got[365], -1000.0, "day 365: still within the 2-year window");
+    assert_eq!(got[730], -1000.0, "day 730: last day before the 2020 bucket is evicted");
+    assert_eq!(got[731], 10.0, "day 731: 2020's bucket evicted, outlier gone");
+}
+
+/// E23. NaN suppression for annual min/max: unlike moving_annual_sum (which
+/// poisons until the poisoned year is evicted), a NaN step must never affect
+/// the running min/max at all — matching moving_min/moving_max's NaN
+/// suppression (f64::min/f64::max return the non-NaN operand).
+#[test]
+fn test_moving_annual_min_nan_suppressed() {
+    let n_days = 400;
+    let mut values = vec![5.0; n_days];
+    values[3] = 1.0;          // the real minimum
+    values[4] = f64::NAN;     // must not disturb it
+    let mut dc = cache_with_x(&values);
+    let input = DynamicInput::from_string("moving_annual_min(data.x, 1, 2)", &mut dc, true, None).unwrap();
+    let got = run_steps(&input, &mut dc, n_days);
+    assert!(got[4].is_finite(), "day 4 (the NaN step itself) must not read NaN");
+    assert_eq!(got[4], 1.0, "day 4: minimum unaffected by the NaN");
+    assert_eq!(got[n_days - 1], 1.0, "minimum still holds at the end of the run");
+}
+
+/// E24. Load errors for the annual family: wy_month must be a constant
+/// integer in [1, 12]; n_years must be a constant positive integer; arity is
+/// fixed at 3. Mirrors C14's fixed-window load-error coverage.
+#[test]
+fn test_moving_annual_load_errors() {
+    for name in ["moving_annual_sum", "moving_annual_mean", "moving_annual_min", "moving_annual_max"] {
+        expect_load_err(&format!("{}(data.x, data.y, 2)", name), "must be a constant");
+        expect_load_err(&format!("{}(data.x, 0, 2)", name), "between 1 and 12");
+        expect_load_err(&format!("{}(data.x, 13, 2)", name), "between 1 and 12");
+        expect_load_err(&format!("{}(data.x, 6.5, 2)", name), "between 1 and 12");
+        expect_load_err(&format!("{}(data.x, 6, data.y)", name), "must be a constant");
+        expect_load_err(&format!("{}(data.x, 6, 0)", name), "positive integer");
+        expect_load_err(&format!("{}(data.x, 6, 2.5)", name), "positive integer");
+        expect_load_err(&format!("{}(data.x, 6, 2, 1)", name), "expects 3 arguments");
+        expect_load_err(&format!("{}(data.x, 6)", name), "expects 3 arguments");
+    }
+    // Sanity: a well-formed call is NOT an error.
+    let mut dc = base_cache();
+    add_series(&mut dc, "data.x", &[1.0], true);
+    assert!(DynamicInput::from_string("moving_annual_sum(data.x, 6, 2)", &mut dc, true, None).is_ok(),
+        "a well-formed moving_annual_sum call should parse");
+}

--- a/website/docs/docs/dynamic-expressions.md
+++ b/website/docs/docs/dynamic-expressions.md
@@ -119,6 +119,7 @@ Available functions:
 | `ceil` | 1 | Round up |
 | `round` | 1 | Round to nearest |
 | `sign` | 1 | Sign (-1, 0, or 1) |
+| `skip_nan` | 1 | NaN becomes 0 (sum/mean's identity); other values pass through unchanged |
 | `clamp` | 3 | Constrain to a range: clamp(x, lo, hi) |
 | `is_leap_year` | 1 | 1 in a Gregorian leap year, else 0: is\_leap\_year(sim.year) |
 | `month_at` | 1 | Month (1-12) at the current date + n days — the pattern month an order placed today arrives in |
@@ -230,6 +231,23 @@ three_yr_diversion = moving_annual_sum(node.town.diversion, 7, 3)
 
 # Trailing 12-month mean
 rolling_annual_mean_flow = moving_monthly_mean(node.gauge_1.dsflow, 12)
+```
+
+`moving_annual_min`/`max` (and their monthly/daily equivalents) suppress
+NaN — a NaN input never disturbs the tracked extremum, matching plain
+`moving_min`/`max`. `moving_annual_sum`/`mean` still **poison** on NaN, like
+plain `moving_sum`/`mean`: a real gap in the data should make that year's
+total suspect, not vanish quietly. This matters if you build a value with
+`if(cond, x, 0.0 / 0.0)` to make it count only on certain steps (the usual
+way to say "only this branch counts" in a side-effect-free expression
+language, since there's no bare `nan` literal outside the `[offset,
+default]` position) — that composes straight into `moving_annual_max`, but
+needs `skip_nan(...)` to compose into `moving_annual_sum`:
+
+```ini
+daily_total = if(sim.new_day, moving_daily_sum(node.gauge_1.dsflow, 1), 0.0 / 0.0)
+peak_daily_total_wy = moving_annual_max(daily_total, 7, 5)
+sum_daily_totals_wy = moving_annual_sum(skip_nan(daily_total), 7, 5)
 ```
 
 **Event windows** — the `*_since` family accumulates since a reset condition

--- a/website/docs/docs/dynamic-expressions.md
+++ b/website/docs/docs/dynamic-expressions.md
@@ -127,6 +127,18 @@ Available functions:
 | `moving_mean` | 3 | Mean over the last n steps |
 | `moving_min` | 3 | Minimum over the last n steps |
 | `moving_max` | 3 | Maximum over the last n steps |
+| `moving_annual_sum` | 3 | Sum over the last n\_years water years: moving\_annual\_sum(x, wy\_month, n\_years) |
+| `moving_annual_mean` | 3 | Mean over the last n\_years water years |
+| `moving_annual_min` | 3 | Minimum over the last n\_years water years |
+| `moving_annual_max` | 3 | Maximum over the last n\_years water years |
+| `moving_monthly_sum` | 2 | Sum over the last n\_months calendar months: moving\_monthly\_sum(x, n\_months) |
+| `moving_monthly_mean` | 2 | Mean over the last n\_months calendar months |
+| `moving_monthly_min` | 2 | Minimum over the last n\_months calendar months |
+| `moving_monthly_max` | 2 | Maximum over the last n\_months calendar months |
+| `moving_daily_sum` | 2 | Sum over the last n\_days calendar days: moving\_daily\_sum(x, n\_days) |
+| `moving_daily_mean` | 2 | Mean over the last n\_days calendar days |
+| `moving_daily_min` | 2 | Minimum over the last n\_days calendar days |
+| `moving_daily_max` | 2 | Maximum over the last n\_days calendar days |
 | `sum_since` | 2 | Sum of x since a reset condition last fired |
 | `min_since` | 2 | Minimum of x since reset |
 | `max_since` | 2 | Maximum of x since reset |
@@ -202,6 +214,24 @@ well-defined from the very first step.
 recent_flow = moving_mean(node.gauge_1.dsflow, 30, 0.0)
 ```
 
+**Annual, monthly, and daily windows** — `moving_annual_sum(x, wy_month,
+n_years)` and friends work differently: `x` is bucketed by calendar period
+first (one running total per water year, month, or day), and the statistic
+is reported over the last `n` *buckets*, not the last `n` steps. There's no
+`default` — a bucket not yet reached simply contributes nothing.
+`moving_annual_*` takes an anchor month, `wy_month` (1-12): a new water year
+starts the first time the month reaches it. `moving_monthly_*`/
+`moving_daily_*` need no anchor — a new bucket starts every calendar
+month/day.
+
+```ini
+# Trailing 3-year total, water year starting 1 July
+three_yr_diversion = moving_annual_sum(node.town.diversion, 7, 3)
+
+# Trailing 12-month mean
+rolling_annual_mean_flow = moving_monthly_mean(node.gauge_1.dsflow, 12)
+```
+
 **Event windows** — the `*_since` family accumulates since a reset condition
 last fired, and the **last argument is always the reset condition**. On the
 step the reset fires, the accumulator clears first and that step's
@@ -214,10 +244,13 @@ dry_spell = steps_since(node.gauge.dsflow > const.low_flow_threshold)
 spill_days = count_since(node.dam.ds_1_spill > 0, sim.new_year)
 ```
 
-There is deliberately no water-year setting in Kalix — the boundary is an
-expression written where it's used (or named once per model in a
-[user-defined function](fn.md)), because the water year varies from valley
-to valley.
+`sum_since`/`*_since` and the calendar flags deliberately carry no
+water-year setting of their own — the boundary is an expression written
+where it's used (or named once per model in a [user-defined
+function](fn.md)), because the water year varies from valley to valley.
+`moving_annual_*` above is the one deliberate exception: a trailing
+multi-year window needs more than a reset condition can express, so it
+takes `wy_month` directly.
 
 ### User-Defined Functions
 


### PR DESCRIPTION
Referring to issue spec, all functions specified in (1) are implemented.

Regarding (2), the sum/mean and min/max functions follow the convention of the non-aggregated functions - NaN poisons the sum/mean and acts as the identity under min/max. The example provided in the original issue, namely `moving_annual_max(if(end_of_day(),moving_daily_sum(variable, 1),NAN))`, works up to call signature (missing water year and number of years). 

**NEEDS TO BE REVIEWED:** This PR includes a `skip_nan()` function that maps NaN to 0 and acts as the identity otherwise, which would allow the above idiom to work on the sum and mean functions as well. Importantly, it ensures clarity and intent when suppressing NaN (as opposed to different defaults for slightly differing functions).

Documentation has been updated with these points made. 