### PR TITLE
Plotting UX improvements + axis setting

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
+++ b/kalixide/src/main/java/com/kalix/ide/components/JCheckboxTree.java
@@ -421,6 +421,24 @@ public class JCheckboxTree extends JTree {
                     togglePath(path);
                 }
             }
+
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                // Double-click anywhere on a leaf row acts as a click on its checkbox.
+                // Restricted to leaves so this never fights JTree's own double-click
+                // expand/collapse behaviour on parent rows.
+                if (e.isPopupTrigger() || !SwingUtilities.isLeftMouseButton(e) || e.getClickCount() != 2) {
+                    return;
+                }
+                TreePath path = getPathForLocation(e.getX(), e.getY());
+                if (path == null || isOverCheckbox(e.getX(), path)) {
+                    return;
+                }
+                Object lastComponent = path.getLastPathComponent();
+                if (lastComponent instanceof DefaultMutableTreeNode treeNode && treeNode.isLeaf()) {
+                    togglePath(path);
+                }
+            }
         });
 
         // Keyboard equivalent: Space toggles the focused row's checkbox.

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/CoordinateDisplayManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/CoordinateDisplayManager.java
@@ -446,7 +446,7 @@ public class CoordinateDisplayManager {
         // Check if we're in percentile mode (exceedance plots)
         if (currentViewport != null && currentViewport.getXAxisType() == XAxisType.PERCENTILE) {
             // Convert fake timestamp to percentile
-            double percentile = timestampMs / 1_000_000.0;
+            double percentile = (double) timestampMs / com.kalix.ide.flowviz.transform.PlotTypeTransformer.PERCENTILE_SCALE;
 
             // Format with appropriate precision
             if (percentile == Math.floor(percentile)) {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -1066,7 +1066,8 @@ public class PlotInteractionManager {
                     return TimeFormatUtil.parseFlexible(trimmed);
                 } catch (Exception e) {
                     throw new IllegalArgumentException(
-                        "Not a valid date/time: \"" + trimmed + "\" (expected yyyy-MM-dd or yyyy-MM-dd HH:mm:ss)");
+                        "Not a valid date/time: \"" + trimmed
+                            + "\" (expected 2024-02-01 or 01-02-2024, optionally with HH:mm[:ss])");
                 }
         }
     }

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -916,7 +916,7 @@ public class PlotInteractionManager {
         try {
             Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, selection);
         } catch (IllegalStateException ex) {
-            showInvalidInput(parentComponent, "The clipboard is not available right now.");
+            showClipboardError("The clipboard is not available right now.");
         }
     }
 
@@ -929,10 +929,18 @@ public class PlotInteractionManager {
     private String readClipboardText() {
         try {
             return (String) Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
-        } catch (UnsupportedFlavorException | IOException | IllegalStateException ex) {
-            showInvalidInput(parentComponent, "The clipboard does not contain text.");
+        } catch (UnsupportedFlavorException | IOException ex) {
+            showClipboardError("The clipboard does not contain text.");
+            return null;
+        } catch (IllegalStateException ex) {
+            showClipboardError("The clipboard is not available right now.");
             return null;
         }
+    }
+
+    /** A clipboard transport failure: nothing the user typed was wrong. */
+    private void showClipboardError(String message) {
+        JOptionPane.showMessageDialog(parentComponent, message, "Clipboard", JOptionPane.ERROR_MESSAGE);
     }
 
     /** One error dialog for every rejected axis limit, whichever path it arrived by. */

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import com.kalix.ide.constants.UIConstants;
@@ -79,7 +80,6 @@ public class PlotInteractionManager {
     // State management
     private Point lastMousePos;
     private boolean isDragging = false;
-    private boolean autoYMode = false;
     private JPopupMenu contextMenu;
     private JCheckBoxMenuItem autoYMenuItem;
     private JCheckBoxMenuItem connectGapsMenuItem;
@@ -101,6 +101,7 @@ public class PlotInteractionManager {
     private Supplier<java.io.File> baseDirectorySupplier;
     private Supplier<com.kalix.ide.flowviz.transform.PlotType> plotTypeSupplier;
     private Supplier<com.kalix.ide.flowviz.data.LabelResolver> labelResolverSupplier;
+    private BooleanSupplier autoYModeSupplier;
 
 
     /**
@@ -284,10 +285,16 @@ public class PlotInteractionManager {
     }
 
     /**
-     * Sets the auto-Y mode for zooming and panning operations.
+     * Supplies the panel's auto-Y mode, which decides whether X-only navigation refits
+     * Y. Read on every use rather than mirrored, so undo/redo and every other path that
+     * changes the mode on the panel are seen here without any synchronisation.
      */
-    public void setAutoYMode(boolean autoYMode) {
-        this.autoYMode = autoYMode;
+    public void setAutoYModeSupplier(BooleanSupplier autoYModeSupplier) {
+        this.autoYModeSupplier = autoYModeSupplier;
+    }
+
+    private boolean isAutoYMode() {
+        return autoYModeSupplier.getAsBoolean();
     }
 
     /**
@@ -330,7 +337,7 @@ public class PlotInteractionManager {
         ViewPort currentViewport = viewportSupplier.get();
         if (currentViewport == null) return;
 
-        if (autoYMode) {
+        if (isAutoYMode()) {
             // Auto-Y mode: only zoom X-axis, then auto-fit Y
             long centerTime = (currentViewport.getStartTimeMs() + currentViewport.getEndTimeMs()) / 2;
             long timeRange = currentViewport.getTimeRangeMs();
@@ -358,7 +365,7 @@ public class PlotInteractionManager {
         ViewPort currentViewport = viewportSupplier.get();
         if (currentViewport == null) return;
 
-        if (autoYMode) {
+        if (isAutoYMode()) {
             // Auto-Y mode: only zoom X-axis, then auto-fit Y
             long centerTime = (currentViewport.getStartTimeMs() + currentViewport.getEndTimeMs()) / 2;
             long timeRange = currentViewport.getTimeRangeMs();
@@ -405,7 +412,7 @@ public class PlotInteractionManager {
         // Check for modifier keys: Ctrl (Windows/Linux) or Cmd (Mac)
         boolean isYAxisOnlyZoom = e.isControlDown() || e.isMetaDown();
 
-        if (autoYMode) {
+        if (isAutoYMode()) {
             // Auto-Y mode: only zoom X-axis centered on mouse, then auto-fit Y
             long mouseTime = currentViewport.screenXToTime(e.getX());
             long currentStartTime = currentViewport.getStartTimeMs();
@@ -506,7 +513,7 @@ public class PlotInteractionManager {
         int dx = e.getX() - lastMousePos.x;
         int dy = e.getY() - lastMousePos.y;
 
-        if (autoYMode) {
+        if (isAutoYMode()) {
             // Auto-Y mode: only pan X-axis, then auto-fit Y
             long timeRange = currentViewport.getTimeRangeMs();
             long deltaTime = -dx * timeRange / currentViewport.getPlotWidth();
@@ -717,10 +724,8 @@ public class PlotInteractionManager {
 
         autoYMenuItem = new JCheckBoxMenuItem("Auto-scale Y axis");
         autoYMenuItem.addActionListener(e -> {
-            autoYMode = autoYMenuItem.isSelected();
-            // Update the parent PlotPanel's auto-Y mode if it has the method
-            if (parentComponent instanceof PlotPanel) {
-                ((PlotPanel) parentComponent).setAutoYMode(autoYMode);
+            if (parentComponent instanceof PlotPanel plotPanel) {
+                plotPanel.setAutoYMode(autoYMenuItem.isSelected());
             }
         });
         contextMenu.add(autoYMenuItem);

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -2,9 +2,9 @@ package com.kalix.ide.flowviz;
 
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.data.SeriesRef;
+import com.kalix.ide.flowviz.rendering.AxisLimitCodec;
 import com.kalix.ide.flowviz.rendering.ViewPort;
 import com.kalix.ide.flowviz.rendering.XAxisType;
-import com.kalix.ide.flowviz.transform.PlotTypeTransformer;
 import com.kalix.ide.flowviz.transform.YAxisScale;
 import com.kalix.ide.io.TimeSeriesCsvExporter;
 import com.kalix.ide.io.SourceResCsvExporter;
@@ -12,7 +12,6 @@ import com.kalix.ide.io.SourceResCsvFormat;
 import com.kalix.ide.io.PixieWriter;
 import com.kalix.ide.filedialog.FileDialogFilter;
 import com.kalix.ide.filedialog.KalixFileDialog;
-import com.kalix.ide.utils.TimeFormatUtil;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
@@ -41,7 +40,6 @@ import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -50,7 +48,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.io.File;
 import java.io.IOException;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -737,88 +734,58 @@ public class PlotInteractionManager {
         // dialog -- per 2.4 -- where the copy/paste items act immediately and do not.
         JMenuItem copyXAxis = new JMenuItem("Copy X axis");
 
-        // Copy/paste go through formatXValue/parseX -- the same pair the Set-axis-limits
-        // dialog uses -- so the clipboard always carries the axis' own units. X bounds are
-        // real timestamps only on a TIME axis; on the others they are encoded values
-        // (percentile x 1e6, numeric x NUMERIC_SCALE) that formatting as a date would
-        // render as meaningless 1970 instants.
+        // Copy/paste go through AxisLimitCodec -- the same codec the Set-axis-limits
+        // dialog uses -- so the clipboard always carries the axis' own units.
         copyXAxis.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
-            if (currentViewport == null) {
-                return;
+            if (currentViewport != null) {
+                copyStringToClipboard(AxisLimitCodec.formatXLimits(currentViewport));
             }
-            copyStringToClipboard(getCurrentXLimits(currentViewport));
         });
         contextMenu.add(copyXAxis);
         JMenuItem pasteXAxis = new JMenuItem("Paste X axis");
         pasteXAxis.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
-            if (currentViewport == null) {
+            String text = readClipboardText();
+            if (currentViewport == null || text == null) {
                 return;
             }
-            String[] parts = readBoundsFromClipboard("values");
-            if (parts == null) {
-                return;
-            }
-
-            long startTime;
-            long endTime;
+            long[] x;
             try {
-                // bounds-safe owing to the pair check in readBoundsFromClipboard
-                XAxisType xAxisType = currentViewport.getXAxisType();
-                startTime = parseX(parts[0], xAxisType);
-                endTime = parseX(parts[1], xAxisType);
-                ViewPort.validateBounds(startTime, endTime,
-                    currentViewport.getMinValue(), currentViewport.getMaxValue());
+                x = AxisLimitCodec.parseXLimits(text, currentViewport.getXAxisType());
+                ViewPort.validateBounds(x[0], x[1], currentViewport.getMinValue(), currentViewport.getMaxValue());
             } catch (IllegalArgumentException ex) {
-                JOptionPane.showMessageDialog(
-                    parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                showInvalidInput(parentComponent, ex.getMessage());
                 return;
             }
-            acceptNewAxes(
-                startTime, endTime,
-                currentViewport.getMinValue(), currentViewport.getMaxValue()
-            );
+            applyXLimits(x[0], x[1]);
         });
         contextMenu.add(pasteXAxis);
 
         JMenuItem copyYAxis = new JMenuItem("Copy Y axis");
         copyYAxis.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
-            if (currentViewport == null) {
-                return;
+            if (currentViewport != null) {
+                copyStringToClipboard(AxisLimitCodec.formatYLimits(currentViewport));
             }
-            copyStringToClipboard(getCurrentYLimits(currentViewport));
         });
         contextMenu.add(copyYAxis);
         JMenuItem pasteYAxis = new JMenuItem("Paste Y axis");
         pasteYAxis.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
-            if (currentViewport == null) {
+            String text = readClipboardText();
+            if (currentViewport == null || text == null) {
                 return;
             }
-            String[] parts = readBoundsFromClipboard("numbers");
-            if (parts == null) {
-                return;
-            }
-
-            double minVal;
-            double maxVal;
+            double[] y;
             try {
-                // bounds-safe owing to the pair check in readBoundsFromClipboard
-                minVal = parseY(parts[0]);
-                maxVal = parseY(parts[1]);
-                ViewPort.validateBounds(currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(),
-                    minVal, maxVal);
+                y = AxisLimitCodec.parseYLimits(text);
+                ViewPort.validateBounds(currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(), y[0], y[1]);
             } catch (IllegalArgumentException ex) {
-                JOptionPane.showMessageDialog(
-                    parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                showInvalidInput(parentComponent, ex.getMessage());
                 return;
             }
-            acceptNewAxes(
-                currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(),
-                minVal, maxVal
-            );
+            applyExplicitLimits(currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(), y[0], y[1]);
         });
         contextMenu.add(pasteYAxis);
 
@@ -908,61 +875,66 @@ public class PlotInteractionManager {
     }
 
     /**
-     * Puts a string on the system clipboard
+     * Puts a string on the system clipboard.
      */
-    private static void copyStringToClipboard(String formatted) {
+    private void copyStringToClipboard(String formatted) {
         StringSelection selection = new StringSelection(formatted);
-        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        clipboard.setContents(selection, selection);
-    }
-
-    /**
-     * Reads a {@code "lower, upper"} pair off the clipboard, the inverse of
-     * {@link #copyStringToClipboard}. Returns the two trimmed halves, or {@code null} when
-     * the clipboard is unreadable or does not hold exactly two comma-separated values --
-     * having reported that to the user, so callers need only bail out.
-     *
-     * @param expected what the halves should look like, for the error message ("values",
-     *                 "numbers") -- the units differ per axis and per X-axis type
-     */
-    private String[] readBoundsFromClipboard(String expected) {
-        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-        String clipboardString;
         try {
-            clipboardString = (String) clipboard.getData(DataFlavor.stringFlavor);
-        } catch (UnsupportedFlavorException | IOException ex) {
-            JOptionPane.showMessageDialog(parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-            return null;
-        }
-
-        try {
-            return splitLimitString(clipboardString);
-        }
-        catch (IllegalArgumentException ex) {
-            JOptionPane.showMessageDialog(
-                parentComponent,
-                String.format("Expected two comma-separated %s but received \"%s\"", expected, clipboardString),
-                "Error", JOptionPane.ERROR_MESSAGE
-            );
-            return null;
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(selection, selection);
+        } catch (IllegalStateException ex) {
+            showInvalidInput(parentComponent, "The clipboard is not available right now.");
         }
     }
 
     /**
-     * Splits a {@code "lower, upper"} string into its two trimmed halves.
-     *
-     * @param parseString the raw field text to split
-     * @return the two trimmed halves, {@code {lower, upper}}
-     * @throws IllegalArgumentException if {@code parseString} does not hold exactly two
-     *                                   comma-separated values
+     * Reads the clipboard's text, or reports why it could not and returns {@code null} so
+     * callers need only bail out. Text is unavailable when the clipboard is empty or holds
+     * something else (which paste items are disabled for, but the contents can change
+     * between the menu opening and the click), or when another application holds it.
      */
-    private String[] splitLimitString(String parseString) {
-        String[] parts = parseString.split("\\s*,\\s*");
-        if (parts.length != 2) {
-            throw new IllegalArgumentException(
-                String.format("Expected two comma-separated values but received \"%s\"", parseString));
+    private String readClipboardText() {
+        try {
+            return (String) Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor);
+        } catch (UnsupportedFlavorException | IOException | IllegalStateException ex) {
+            showInvalidInput(parentComponent, "The clipboard does not contain text.");
+            return null;
         }
-        return new String[]{ parts[0].trim(), parts[1].trim() };
+    }
+
+    /** One error dialog for every rejected axis limit, whichever path it arrived by. */
+    private static void showInvalidInput(java.awt.Component parent, String message) {
+        JOptionPane.showMessageDialog(parent, message, "Invalid input", JOptionPane.ERROR_MESSAGE);
+    }
+
+    /**
+     * Applies an X-only change: obeys auto-Y exactly as wheel zoom and drag pan do, so a
+     * pasted time window shows its own data rather than the previous window's Y range.
+     */
+    private void applyXLimits(long startTime, long endTime) {
+        ViewPort currentViewport = viewportSupplier.get();
+        if (currentViewport == null) {
+            return;
+        }
+        if (isAutoYMode()) {
+            updateViewportWithFittedY(startTime, endTime);
+            parentComponent.repaint();
+        } else {
+            acceptNewAxes(startTime, endTime, currentViewport.getMinValue(), currentViewport.getMaxValue());
+        }
+    }
+
+    /**
+     * Applies limits that include an explicit Y range: the user has opted out of auto-Y,
+     * otherwise the next wheel tick or drag would silently refit Y and discard them. The
+     * viewport lands first and the mode second, because {@code setAutoYMode} pushes a
+     * history entry immediately while the viewport update is coalesced -- this order
+     * records the two together, so undo restores both in one step.
+     */
+    private void applyExplicitLimits(long startTime, long endTime, double minValue, double maxValue) {
+        acceptNewAxes(startTime, endTime, minValue, maxValue);
+        if (parentComponent instanceof PlotPanel plotPanel) {
+            plotPanel.setAutoYMode(false);
+        }
     }
 
     /**
@@ -979,8 +951,8 @@ public class PlotInteractionManager {
         }
         XAxisType xAxisType = currentViewport.getXAxisType();
 
-        JTextField xField = new JTextField(getCurrentXLimits(currentViewport), 32);
-        JTextField yField = new JTextField(getCurrentYLimits(currentViewport), 32);
+        JTextField xField = new JTextField(AxisLimitCodec.formatXLimits(currentViewport), 32);
+        JTextField yField = new JTextField(AxisLimitCodec.formatYLimits(currentViewport), 32);
 
         JPanel form = new JPanel(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
@@ -997,33 +969,22 @@ public class PlotInteractionManager {
         JButton okButton = new JButton("OK");
         okButton.addActionListener(ev -> {
             try {
-                String[] xLimits = splitLimitString(xField.getText());
-                String[] yLimits = splitLimitString(yField.getText());
-
-                long   startTime;
-                long   endTime;
-                double minVal;
-                double maxVal;
-                try {
-                    // bounds-safe owing to the pair check in readBoundsFromClipboard
-                    startTime = parseX(xLimits[0], xAxisType);
-                    endTime   = parseX(xLimits[1], xAxisType);
-                    minVal    = parseY(yLimits[0]);
-                    maxVal    = parseY(yLimits[1]);
-                } catch (IllegalArgumentException ex) {
-                    JOptionPane.showMessageDialog(
-                        parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
-                    return;
+                long[] x = AxisLimitCodec.parseXLimits(xField.getText(), xAxisType);
+                double[] y = AxisLimitCodec.parseYLimits(yField.getText());
+                ViewPort.validateBounds(x[0], x[1], y[0], y[1]);
+                // An edited Y field is an explicit Y range; an untouched one (the codec's
+                // formatting round-trips exactly) means the user only wanted X, which obeys
+                // auto-Y like any other X-only change.
+                boolean yEdited = y[0] != currentViewport.getMinValue() || y[1] != currentViewport.getMaxValue();
+                if (yEdited) {
+                    applyExplicitLimits(x[0], x[1], y[0], y[1]);
+                } else {
+                    applyXLimits(x[0], x[1]);
                 }
-                ViewPort.validateBounds(startTime, endTime, minVal, maxVal);
-                acceptNewAxes(startTime, endTime, minVal, maxVal);
-                dialog.dispose(); // Intentionally here so the user can retry
-            } catch (DateTimeParseException | NumberFormatException parseEx) {
-                JOptionPane.showMessageDialog(dialog, "Could not parse axis limits: " + parseEx.getMessage(),
-                    "Invalid input", JOptionPane.ERROR_MESSAGE);
-            } catch (IllegalArgumentException rangeEx) {
-                JOptionPane.showMessageDialog(dialog, rangeEx.getMessage(),
-                    "Invalid input", JOptionPane.ERROR_MESSAGE);
+                dialog.dispose();
+            } catch (IllegalArgumentException ex) {
+                // The dialog stays open so the user can correct the field.
+                showInvalidInput(dialog, ex.getMessage());
             }
         });
         JButton cancelButton = new JButton("Cancel");
@@ -1056,138 +1017,12 @@ public class PlotInteractionManager {
     }
 
     /**
-     * Parses a field's text into a viewport X value (a real timestamp for TIME, or one of the
-     * fake-timestamp encodings used for the other axis types — see {@link XAxisType}).
-     */
-    private Long parseX(String text, XAxisType xAxisType) throws IllegalArgumentException {
-        if (text == null || text.isBlank()) {
-            throw new IllegalArgumentException("X value cannot be blank.");
-        }
-        String trimmed = text.trim();
-        switch (xAxisType) {
-            case PERCENTILE:
-                String stripped = trimmed.endsWith("%") ? trimmed.substring(0, trimmed.length() - 1).trim() : trimmed;
-                try {
-                    return Math.round(Double.parseDouble(stripped) * 1_000_000.0);
-                } catch (Exception e) {
-                    throw new IllegalArgumentException("Not a valid percentile: \"" + trimmed + "\"");
-                }
-            case COUNT:
-                try {
-                    return Long.parseLong(trimmed);
-                } catch (Exception e) {
-                    throw new IllegalArgumentException("Not a valid integer count: \"" + trimmed + "\"");
-                }
-            case NUMERIC:
-                try {
-                    return Math.round(Double.parseDouble(trimmed) * PlotTypeTransformer.NUMERIC_SCALE);
-                } catch (Exception e) {
-                    throw new IllegalArgumentException("Not a valid number: \"" + trimmed + "\"");
-                }
-            case TIME:
-            default:
-                try {
-                    return TimeFormatUtil.parseFlexible(trimmed);
-                } catch (Exception e) {
-                    throw new IllegalArgumentException(
-                        "Not a valid date/time: \"" + trimmed
-                            + "\" (expected 2024-02-01 or 01-02-2024, optionally with HH:mm[:ss])");
-                }
-        }
-    }
-
-    /**
-     * Parses a field's text into a (double) Y value.
-     */
-    private Double parseY(String text) throws IllegalArgumentException {
-        if (text == null || text.isBlank()) {
-            throw new IllegalArgumentException("Y value cannot be blank.");
-        }
-        try {
-            return Double.parseDouble(text.trim());
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Not a valid number: \"" + text.trim() + "\"");
-        }
-    }
-
-    /**
-     * Formats a viewport X value for editing, in the units matching {@code xAxisType}
-     * (the inverse of {@link #parseX}).
-     */
-    private String formatXValue(long value, XAxisType xAxisType) {
-        return switch (xAxisType) {
-            case PERCENTILE -> formatDoubleForField(value / 1_000_000.0) + "%";
-            case COUNT -> String.valueOf(value);
-            case NUMERIC -> formatDoubleForField((double) value / PlotTypeTransformer.NUMERIC_SCALE);
-            default -> {
-                // Date-only for midnight-aligned timestamps, full ISO datetime otherwise.
-                //                          ms per day          s per day
-                long stepSeconds = (value % 86_400_000L == 0) ? 86_400L : 1L;
-                yield TimeFormatUtil.formatForStepSize(value, stepSeconds);
-            }
-        };
-    }
-
-    /**
-     * Formats a double for editing without scientific notation or spurious ".0" noise.
-     */
-    private String formatDoubleForField(double value) {
-        if (!Double.isInfinite(value) && !Double.isNaN(value) && value == Math.rint(value)
-                && Math.abs(value) < 1e15) {
-            return String.valueOf((long) value);
-        }
-        return String.valueOf(value);
-    }
-
-    /**
-     * Helper for consistent formatting of limits.
-     */
-    private String formatLimits(String left, String right) {
-        return left + ", " + right;
-    }
-
-    /**
-     * Helper to consistently format x axis limits.
-     */
-    private String formatXLimits(long min, long max, XAxisType xAxisType) {
-        return formatLimits(formatXValue(min, xAxisType), formatXValue(max, xAxisType));
-    }
-
-    /**
-     * Helper to consistently format y axis limits.
-     */
-    private String formatYLimits(double min, double max) {
-        return formatLimits(formatDoubleForField(min), formatDoubleForField(max));
-    }
-
-    /**
-     * Get the current X limits as a formatted string.
-     * Precondition: {@code viewPort} is not null.
-     */
-    private String getCurrentXLimits(ViewPort viewPort) {
-        XAxisType xAxisType = viewPort.getXAxisType();
-        long min = viewPort.getStartTimeMs();
-        long max = viewPort.getEndTimeMs();
-        return formatXLimits(min, max, xAxisType);
-    }
-
-    /**
-     * Get the current Y limits as a formatted string.
-     * Precondition: {@code viewPort} is not null.
-     */
-    private String getCurrentYLimits(ViewPort viewPort) {
-        double min = viewPort.getMinValue();
-        double max = viewPort.getMaxValue();
-        return formatYLimits(min, max);
-    }
-
-    /**
      * Moves the viewport to the given axis limits, keeping plot area, Y-axis scale, and
      * X-axis type unchanged. All four limits are required and are applied as given; callers
      * are responsible for parsing and for checking them with
      * {@link ViewPort#validateBounds} first.
      */
-    private void acceptNewAxes(Long startTime, Long endTime, Double minValue, Double maxValue) {
+    private void acceptNewAxes(long startTime, long endTime, double minValue, double maxValue) {
         var currentViewport = this.viewportSupplier.get();
         if (currentViewport == null) {
             return;

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -2,6 +2,8 @@ package com.kalix.ide.flowviz;
 
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.rendering.ViewPort;
+import com.kalix.ide.flowviz.rendering.XAxisType;
+import com.kalix.ide.flowviz.transform.PlotTypeTransformer;
 import com.kalix.ide.flowviz.transform.YAxisScale;
 import com.kalix.ide.io.TimeSeriesCsvExporter;
 import com.kalix.ide.io.SourceResCsvExporter;
@@ -9,22 +11,32 @@ import com.kalix.ide.io.SourceResCsvFormat;
 import com.kalix.ide.io.PixieWriter;
 import com.kalix.ide.filedialog.FileDialogFilter;
 import com.kalix.ide.filedialog.KalixFileDialog;
+import com.kalix.ide.utils.TimeFormatUtil;
 
 import javax.swing.ButtonGroup;
+import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import java.awt.BasicStroke;
-import java.awt.Color;
+import java.awt.BorderLayout;
 import java.awt.Cursor;
+import java.awt.Dialog;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.Graphics2D;
+import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
@@ -32,6 +44,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.io.File;
 import java.io.IOException;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -675,10 +688,15 @@ public class PlotInteractionManager {
 
         contextMenu.addSeparator();
 
+        JMenuItem setAxes = new JMenuItem("Set axis limits");
+        setAxes.addActionListener(e1 -> showSetAxesDialog());
+        contextMenu.add(setAxes);
+
+        contextMenu.addSeparator();
+
         // Y-axis scale submenu
         yAxisScaleMenu = new JMenu("Y-axis scale");
         ButtonGroup yAxisScaleGroup = new ButtonGroup();
-
         for (YAxisScale scale : YAxisScale.values()) {
             JRadioButtonMenuItem scaleItem = new JRadioButtonMenuItem(scale.getDisplayName());
             scaleItem.addActionListener(e -> {
@@ -753,6 +771,195 @@ public class PlotInteractionManager {
             @Override
             public void popupMenuCanceled(PopupMenuEvent e) {}
         });
+    }
+
+    /**
+     * Shows a modal dialog with the current axis limits, pre-filled and editable as text.
+     * A blank field leaves that limit unchanged (see {@link #acceptNewAxes}); X fields are
+     * parsed according to the viewport's {@link XAxisType} (dates for TIME, percentages for
+     * PERCENTILE, etc.) so the field always shows and accepts values in the axis' own units.
+     */
+    private void showSetAxesDialog() {
+        ViewPort currentViewport = viewportSupplier.get();
+        if (currentViewport == null) {
+            return;
+        }
+        XAxisType xAxisType = currentViewport.getXAxisType();
+
+        JTextField xMinField = new JTextField(formatXValue(currentViewport.getStartTimeMs(), xAxisType), 16);
+        JTextField xMaxField = new JTextField(formatXValue(currentViewport.getEndTimeMs(), xAxisType), 16);
+        JTextField yMinField = new JTextField(formatDoubleForField(currentViewport.getMinValue()), 16);
+        JTextField yMaxField = new JTextField(formatDoubleForField(currentViewport.getMaxValue()), 16);
+
+        JPanel form = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4, 4, 4, 4);
+        gbc.anchor = GridBagConstraints.WEST;
+        addAxisFieldRow(form, gbc, 0, "X min:", xMinField);
+        addAxisFieldRow(form, gbc, 1, "X max:", xMaxField);
+        addAxisFieldRow(form, gbc, 2, "Y min:", yMinField);
+        addAxisFieldRow(form, gbc, 3, "Y max:", yMaxField);
+
+        JDialog dialog = new JDialog(SwingUtilities.getWindowAncestor(parentComponent),
+            "Set Axis Limits", Dialog.ModalityType.APPLICATION_MODAL);
+        dialog.setLayout(new BorderLayout());
+        dialog.add(form, BorderLayout.CENTER);
+
+        JButton okButton = new JButton("OK");
+        okButton.addActionListener(ev -> {
+            try {
+                Long   startTime = parseX(xMinField.getText(), xAxisType);
+                Long   endTime   = parseX(xMaxField.getText(), xAxisType);
+                Double minValue  = parseY(yMinField.getText());
+                Double maxValue  = parseY(yMaxField.getText());
+
+                if (startTime >= endTime) {
+                    throw new IllegalArgumentException("X min must be less than X max.");
+                }
+                if (minValue >= maxValue) {
+                    throw new IllegalArgumentException("Y min must be less than Y max.");
+                }
+
+                acceptNewAxes(startTime, endTime, minValue, maxValue);
+                dialog.dispose();
+            } catch (DateTimeParseException | NumberFormatException parseEx) {
+                JOptionPane.showMessageDialog(dialog, "Could not parse axis limits: " + parseEx.getMessage(),
+                    "Invalid input", JOptionPane.ERROR_MESSAGE);
+            } catch (IllegalArgumentException rangeEx) {
+                JOptionPane.showMessageDialog(dialog, rangeEx.getMessage(),
+                    "Invalid input", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+        JButton cancelButton = new JButton("Cancel");
+        cancelButton.addActionListener(ev -> dialog.dispose());
+
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.add(okButton);
+        buttonPanel.add(cancelButton);
+        dialog.add(buttonPanel, BorderLayout.SOUTH);
+        dialog.getRootPane().setDefaultButton(okButton);
+
+        dialog.pack();
+        dialog.setLocationRelativeTo(parentComponent);
+        dialog.setVisible(true);
+    }
+
+    /**
+     * Adds a label + text field pair as one row of a {@link GridBagLayout} form.
+     */
+    private void addAxisFieldRow(JPanel form, GridBagConstraints gbc, int row, String label, JTextField field) {
+        gbc.gridx = 0;
+        gbc.gridy = row;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        form.add(new JLabel(label), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        form.add(field, gbc);
+    }
+
+    /**
+     * Parses a field's text into a viewport X value (a real timestamp for TIME, or one of the
+     * fake-timestamp encodings used for the other axis types — see {@link XAxisType}).
+     */
+    private Long parseX(String text, XAxisType xAxisType) throws IllegalArgumentException {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("X value cannot be blank.");
+        }
+        String trimmed = text.trim();
+        switch (xAxisType) {
+            case PERCENTILE:
+                String stripped = trimmed.endsWith("%") ? trimmed.substring(0, trimmed.length() - 1).trim() : trimmed;
+                try {
+                    return Math.round(Double.parseDouble(stripped) * 1_000_000.0);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Not a valid percentile: \"" + trimmed + "\"");
+                }
+            case COUNT:
+                try {
+                    return Long.parseLong(trimmed);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Not a valid integer count: \"" + trimmed + "\"");
+                }
+            case NUMERIC:
+                try {
+                    return Math.round(Double.parseDouble(trimmed) * PlotTypeTransformer.NUMERIC_SCALE);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Not a valid number: \"" + trimmed + "\"");
+                }
+            case TIME:
+            default:
+                try {
+                    return TimeFormatUtil.parseFlexible(trimmed);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException(
+                        "Not a valid date/time: \"" + trimmed + "\" (expected yyyy-MM-dd or yyyy-MM-dd HH:mm:ss)");
+                }
+        }
+    }
+
+    /**
+     * Parses a field's text into a (double) Y value.
+     */
+    private Double parseY(String text) throws IllegalArgumentException {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Y value cannot be blank.");
+        }
+        try {
+            return Double.parseDouble(text.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Not a valid number: \"" + text.trim() + "\"");
+        }
+    }
+
+    /**
+     * Formats a viewport X value for editing, in the units matching {@code xAxisType}
+     * (the inverse of {@link #parseX}).
+     */
+    private String formatXValue(long value, XAxisType xAxisType) {
+        return switch (xAxisType) {
+            case PERCENTILE -> formatDoubleForField(value / 1_000_000.0) + "%";
+            case COUNT -> String.valueOf(value);
+            case NUMERIC -> formatDoubleForField((double) value / PlotTypeTransformer.NUMERIC_SCALE);
+            default -> {
+                // Date-only for midnight-aligned timestamps, full ISO datetime otherwise.
+                //                          ms per day          s per day
+                long stepSeconds = (value % 86_400_000L == 0) ? 86_400L : 1L;
+                yield TimeFormatUtil.formatForStepSize(value, stepSeconds);
+            }
+        };
+    }
+
+    /**
+     * Formats a double for editing without scientific notation or spurious ".0" noise.
+     */
+    private String formatDoubleForField(double value) {
+        if (!Double.isInfinite(value) && !Double.isNaN(value) && value == Math.rint(value)
+                && Math.abs(value) < 1e15) {
+            return String.valueOf((long) value);
+        }
+        return String.valueOf(value);
+    }
+
+    /**
+     * Moves the viewport to the given axis limits, keeping plot area, Y-axis scale, and
+     * X-axis type unchanged. Limits must already be resolved (no "leave unchanged" fallback
+     * here) — see {@link #showSetAxesDialog}, which resolves blank fields against the current
+     * viewport before calling this.
+     */
+    private void acceptNewAxes(Long startTime, Long endTime, Double minValue, Double maxValue) {
+        var currentViewport = this.viewportSupplier.get();
+        if (currentViewport == null) {
+            return;
+        }
+        Rectangle plotArea = plotAreaSupplier.get();
+        ViewPort newViewport = new ViewPort(startTime, endTime, minValue, maxValue,
+                                            // vvv Window itself does not move or change scale/type vvv
+                                            plotArea.x, plotArea.y, plotArea.width, plotArea.height,
+                                            currentViewport.getYAxisScale(), currentViewport.getXAxisType());
+        viewportUpdater.accept(newViewport);
+        parentComponent.repaint();
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -39,7 +39,11 @@ import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
@@ -693,10 +697,11 @@ public class PlotInteractionManager {
         setAxes.addActionListener(e1 -> showSetAxesDialog());
         contextMenu.add(setAxes);
 
-        // TODO copy and paste X axis scale
-        // NOTE: likely dependent on X axis TYPE e.g. exceedance %
-        // Copy should simply get the string out (format?)
-        // Paste should attempt to paste from clipboard, throw error if invalid format or unparseable etc.
+        // Copy/paste go through formatXValue/parseX -- the same pair the Set-axis-limits
+        // dialog uses -- so the clipboard always carries the axis' own units. X bounds are
+        // real timestamps only on a TIME axis; on the others they are encoded values
+        // (percentile x 1e6, numeric x NUMERIC_SCALE) that formatting as a date would
+        // render as meaningless 1970 instants.
         JMenuItem copyXAxis = new JMenuItem("Copy X axis");
         copyXAxis.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
@@ -704,50 +709,35 @@ public class PlotInteractionManager {
                 return;
             }
             XAxisType xAxisType = currentViewport.getXAxisType();
-            var startTimeMs = currentViewport.getStartTimeMs();
-            var endTimeMs   = currentViewport.getEndTimeMs();
-            var startTimeFormatted = TimeFormatUtil.format(startTimeMs);
-            var endTimeFormatted   = TimeFormatUtil.format(endTimeMs);
-            copyBoundsToClipboard(startTimeFormatted, endTimeFormatted);
+            copyBoundsToClipboard(
+                formatXValue(currentViewport.getStartTimeMs(), xAxisType),
+                formatXValue(currentViewport.getEndTimeMs(), xAxisType)
+            );
         });
         contextMenu.add(copyXAxis);
         JMenuItem pasteXAxis = new JMenuItem("Paste X axis");
         pasteXAxis.addActionListener(e -> {
-            java.awt.datatransfer.Clipboard clipboard = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
-            String clipboardString;
-            try {
-                clipboardString = (String) clipboard.getData(DataFlavor.stringFlavor);
-            } catch (java.awt.datatransfer.UnsupportedFlavorException | java.io.IOException ex) {
-                JOptionPane.showMessageDialog(parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            ViewPort currentViewport = viewportSupplier.get();
+            if (currentViewport == null) {
                 return;
             }
-
-            var parts = clipboardString.split("\\s*,\\s*");
-            var l = parts.length;
-            if (l != 2) {
-                JOptionPane.showMessageDialog(
-                    parentComponent,
-                    String.format("Expected two comma-separated dates but received \"%s\"", clipboardString),
-                    "Error", JOptionPane.ERROR_MESSAGE
-                );
+            String[] parts = readBoundsFromClipboard("values");
+            if (parts == null) {
                 return;
             }
 
             long startTime;
             long endTime;
             try {
-                // bounds-safe owing to above check
-                startTime = TimeFormatUtil.parseFlexible(parts[0].trim());
-                endTime = TimeFormatUtil.parseFlexible(parts[1].trim());
-            } catch (DateTimeParseException ex) {
+                // bounds-safe owing to the pair check in readBoundsFromClipboard
+                XAxisType xAxisType = currentViewport.getXAxisType();
+                startTime = parseX(parts[0], xAxisType);
+                endTime = parseX(parts[1], xAxisType);
+            } catch (IllegalArgumentException ex) {
                 JOptionPane.showMessageDialog(
-                    parentComponent,
-                    "Error parsing datetime: " + ex.getMessage(),
-                    "Error", JOptionPane.ERROR_MESSAGE
-                );
+                    parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
                 return;
             }
-            ViewPort currentViewport = viewportSupplier.get();
             acceptNewAxes(
                 startTime, endTime,
                 currentViewport.getMinValue(), currentViewport.getMaxValue()
@@ -768,41 +758,26 @@ public class PlotInteractionManager {
         contextMenu.add(copyYAxis);
         JMenuItem pasteYAxis = new JMenuItem("Paste Y axis");
         pasteYAxis.addActionListener(e -> {
-            java.awt.datatransfer.Clipboard clipboard = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
-            String clipboardString;
-            try {
-                clipboardString = (String) clipboard.getData(DataFlavor.stringFlavor);
-            } catch (java.awt.datatransfer.UnsupportedFlavorException | java.io.IOException ex) {
-                JOptionPane.showMessageDialog(parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            ViewPort currentViewport = viewportSupplier.get();
+            if (currentViewport == null) {
                 return;
             }
-
-            var parts = clipboardString.split("\\s*,\\s*");
-            var l = parts.length;
-            if (l != 2) {
-                JOptionPane.showMessageDialog(
-                    parentComponent,
-                    String.format("Expected two comma-separated numbers but received \"%s\"", clipboardString),
-                    "Error", JOptionPane.ERROR_MESSAGE
-                );
+            String[] parts = readBoundsFromClipboard("numbers");
+            if (parts == null) {
                 return;
             }
 
             double minVal;
             double maxVal;
             try {
-                // bounds-safe owing to above check
-                minVal = Double.parseDouble(parts[0].trim());
-                maxVal = Double.parseDouble(parts[1].trim());
-            } catch (NumberFormatException ex) {
+                // bounds-safe owing to the pair check in readBoundsFromClipboard
+                minVal = parseY(parts[0]);
+                maxVal = parseY(parts[1]);
+            } catch (IllegalArgumentException ex) {
                 JOptionPane.showMessageDialog(
-                    parentComponent,
-                    "Error parsing number: " + ex.getMessage(),
-                    "Error", JOptionPane.ERROR_MESSAGE
-                );
+                    parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
                 return;
             }
-            ViewPort currentViewport = viewportSupplier.get();
             acceptNewAxes(
                 currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(),
                 minVal, maxVal
@@ -892,20 +867,48 @@ public class PlotInteractionManager {
     }
 
     /**
-     * Builds a {@code String} that
-     * @param startTimeFormatted
-     * @param endTimeFormatted
+     * Puts an axis' bounds on the system clipboard as {@code "lower, upper"} -- the format
+     * {@link #readBoundsFromClipboard} reads back, and one a user can equally well type by
+     * hand or paste in from elsewhere.
+     *
+     * @param lowerFormatted the axis minimum, already formatted in the axis' own units
+     * @param upperFormatted the axis maximum, likewise
      */
-    private static void copyBoundsToClipboard(String startTimeFormatted, String endTimeFormatted) {
-        StringBuilder b = new StringBuilder();
-        b.append(startTimeFormatted);
-        b.append(", ");
-        b.append(endTimeFormatted);
-        String s = b.toString();
-        // https://stackoverflow.com/questions/3591945/copying-to-the-clipboard-in-java
-        java.awt.datatransfer.StringSelection selection = new java.awt.datatransfer.StringSelection(s);
-        java.awt.datatransfer.Clipboard clipboard = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+    private static void copyBoundsToClipboard(String lowerFormatted, String upperFormatted) {
+        StringSelection selection = new StringSelection(lowerFormatted + ", " + upperFormatted);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(selection, selection);
+    }
+
+    /**
+     * Reads a {@code "lower, upper"} pair off the clipboard, the inverse of
+     * {@link #copyBoundsToClipboard}. Returns the two trimmed halves, or {@code null} when
+     * the clipboard is unreadable or does not hold exactly two comma-separated values --
+     * having reported that to the user, so callers need only bail out.
+     *
+     * @param expected what the halves should look like, for the error message ("values",
+     *                 "numbers") -- the units differ per axis and per X-axis type
+     */
+    private String[] readBoundsFromClipboard(String expected) {
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        String clipboardString;
+        try {
+            clipboardString = (String) clipboard.getData(DataFlavor.stringFlavor);
+        } catch (UnsupportedFlavorException | IOException ex) {
+            JOptionPane.showMessageDialog(parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+            return null;
+        }
+
+        String[] parts = clipboardString.split("\\s*,\\s*");
+        if (parts.length != 2) {
+            JOptionPane.showMessageDialog(
+                parentComponent,
+                String.format("Expected two comma-separated %s but received \"%s\"", expected, clipboardString),
+                "Error", JOptionPane.ERROR_MESSAGE
+            );
+            return null;
+        }
+        return new String[]{parts[0].trim(), parts[1].trim()};
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -39,6 +39,7 @@ import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.datatransfer.DataFlavor;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
@@ -692,6 +693,123 @@ public class PlotInteractionManager {
         setAxes.addActionListener(e1 -> showSetAxesDialog());
         contextMenu.add(setAxes);
 
+        // TODO copy and paste X axis scale
+        // NOTE: likely dependent on X axis TYPE e.g. exceedance %
+        // Copy should simply get the string out (format?)
+        // Paste should attempt to paste from clipboard, throw error if invalid format or unparseable etc.
+        JMenuItem copyXAxis = new JMenuItem("Copy X axis");
+        copyXAxis.addActionListener(e -> {
+            ViewPort currentViewport = viewportSupplier.get();
+            if (currentViewport == null) {
+                return;
+            }
+            XAxisType xAxisType = currentViewport.getXAxisType();
+            var startTimeMs = currentViewport.getStartTimeMs();
+            var endTimeMs   = currentViewport.getEndTimeMs();
+            var startTimeFormatted = TimeFormatUtil.format(startTimeMs);
+            var endTimeFormatted   = TimeFormatUtil.format(endTimeMs);
+            copyBoundsToClipboard(startTimeFormatted, endTimeFormatted);
+        });
+        contextMenu.add(copyXAxis);
+        JMenuItem pasteXAxis = new JMenuItem("Paste X axis");
+        pasteXAxis.addActionListener(e -> {
+            java.awt.datatransfer.Clipboard clipboard = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+            String clipboardString;
+            try {
+                clipboardString = (String) clipboard.getData(DataFlavor.stringFlavor);
+            } catch (java.awt.datatransfer.UnsupportedFlavorException | java.io.IOException ex) {
+                JOptionPane.showMessageDialog(parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+
+            var parts = clipboardString.split("\\s*,\\s*");
+            var l = parts.length;
+            if (l != 2) {
+                JOptionPane.showMessageDialog(
+                    parentComponent,
+                    String.format("Expected two comma-separated dates but received \"%s\"", clipboardString),
+                    "Error", JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
+
+            long startTime;
+            long endTime;
+            try {
+                // bounds-safe owing to above check
+                startTime = TimeFormatUtil.parseFlexible(parts[0].trim());
+                endTime = TimeFormatUtil.parseFlexible(parts[1].trim());
+            } catch (DateTimeParseException ex) {
+                JOptionPane.showMessageDialog(
+                    parentComponent,
+                    "Error parsing datetime: " + ex.getMessage(),
+                    "Error", JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
+            ViewPort currentViewport = viewportSupplier.get();
+            acceptNewAxes(
+                startTime, endTime,
+                currentViewport.getMinValue(), currentViewport.getMaxValue()
+            );
+        });
+        contextMenu.add(pasteXAxis);
+
+        JMenuItem copyYAxis = new JMenuItem("Copy Y axis");
+        copyYAxis.addActionListener(e -> {
+            ViewPort currentViewport = viewportSupplier.get();
+            if (currentViewport == null) {
+                return;
+            }
+            var minVal = currentViewport.getMinValue();
+            var maxVal = currentViewport.getMaxValue();
+            copyBoundsToClipboard(String.valueOf(minVal), String.valueOf(maxVal));
+        });
+        contextMenu.add(copyYAxis);
+        JMenuItem pasteYAxis = new JMenuItem("Paste Y axis");
+        pasteYAxis.addActionListener(e -> {
+            java.awt.datatransfer.Clipboard clipboard = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+            String clipboardString;
+            try {
+                clipboardString = (String) clipboard.getData(DataFlavor.stringFlavor);
+            } catch (java.awt.datatransfer.UnsupportedFlavorException | java.io.IOException ex) {
+                JOptionPane.showMessageDialog(parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+
+            var parts = clipboardString.split("\\s*,\\s*");
+            var l = parts.length;
+            if (l != 2) {
+                JOptionPane.showMessageDialog(
+                    parentComponent,
+                    String.format("Expected two comma-separated numbers but received \"%s\"", clipboardString),
+                    "Error", JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
+
+            double minVal;
+            double maxVal;
+            try {
+                // bounds-safe owing to above check
+                minVal = Double.parseDouble(parts[0].trim());
+                maxVal = Double.parseDouble(parts[1].trim());
+            } catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(
+                    parentComponent,
+                    "Error parsing number: " + ex.getMessage(),
+                    "Error", JOptionPane.ERROR_MESSAGE
+                );
+                return;
+            }
+            ViewPort currentViewport = viewportSupplier.get();
+            acceptNewAxes(
+                currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(),
+                minVal, maxVal
+            );
+        });
+        contextMenu.add(pasteYAxis);
+
         contextMenu.addSeparator();
 
         // Y-axis scale submenu
@@ -771,6 +889,23 @@ public class PlotInteractionManager {
             @Override
             public void popupMenuCanceled(PopupMenuEvent e) {}
         });
+    }
+
+    /**
+     * Builds a {@code String} that
+     * @param startTimeFormatted
+     * @param endTimeFormatted
+     */
+    private static void copyBoundsToClipboard(String startTimeFormatted, String endTimeFormatted) {
+        StringBuilder b = new StringBuilder();
+        b.append(startTimeFormatted);
+        b.append(", ");
+        b.append(endTimeFormatted);
+        String s = b.toString();
+        // https://stackoverflow.com/questions/3591945/copying-to-the-clipboard-in-java
+        java.awt.datatransfer.StringSelection selection = new java.awt.datatransfer.StringSelection(s);
+        java.awt.datatransfer.Clipboard clipboard = java.awt.Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(selection, selection);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -727,16 +727,16 @@ public class PlotInteractionManager {
 
         contextMenu.addSeparator();
 
-        JMenuItem setAxes = new JMenuItem("Set axis limits");
-        setAxes.addActionListener(e1 -> showSetAxesDialog());
-        contextMenu.add(setAxes);
+        // Clipboard block before the view/state items (context-menu-style 1: block 3
+        // precedes block 7). "Set axis limits..." carries an ellipsis because it opens a
+        // dialog -- per 2.4 -- where the copy/paste items act immediately and do not.
+        JMenuItem copyXAxis = new JMenuItem("Copy X axis");
 
         // Copy/paste go through formatXValue/parseX -- the same pair the Set-axis-limits
         // dialog uses -- so the clipboard always carries the axis' own units. X bounds are
         // real timestamps only on a TIME axis; on the others they are encoded values
         // (percentile x 1e6, numeric x NUMERIC_SCALE) that formatting as a date would
         // render as meaningless 1970 instants.
-        JMenuItem copyXAxis = new JMenuItem("Copy X axis");
         copyXAxis.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
             if (currentViewport == null) {
@@ -824,6 +824,10 @@ public class PlotInteractionManager {
         contextMenu.add(pasteYAxis);
 
         contextMenu.addSeparator();
+
+        JMenuItem setAxes = new JMenuItem("Set axis limits…");
+        setAxes.addActionListener(e1 -> showSetAxesDialog());
+        contextMenu.add(setAxes);
 
         // Y-axis scale submenu
         yAxisScaleMenu = new JMenu("Y-axis scale");

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -13,6 +13,7 @@ import com.kalix.ide.io.PixieWriter;
 import com.kalix.ide.filedialog.FileDialogFilter;
 import com.kalix.ide.filedialog.KalixFileDialog;
 
+import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
@@ -26,6 +27,7 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
@@ -43,6 +45,7 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
@@ -79,6 +82,8 @@ public class PlotInteractionManager {
     private boolean isDragging = false;
     private JPopupMenu contextMenu;
     private JCheckBoxMenuItem autoYMenuItem;
+    private JMenuItem pasteXAxisItem;
+    private JMenuItem pasteYAxisItem;
     private JCheckBoxMenuItem connectGapsMenuItem;
     private JCheckBoxMenuItem orphanMarkersMenuItem;
     private JMenu yAxisScaleMenu;
@@ -696,17 +701,37 @@ public class PlotInteractionManager {
      * zoom to fit, axis limits, axis copy/paste, save data -- acts on plotted series, so on
      * an empty tab the menu is a list of no-ops and error dialogs.
      *
-     * <p>The visible-series list is the evidence, not the viewport: {@code PlotPanel}
-     * synthesises a placeholder viewport ("now +/- 1 hour") while painting an empty panel,
-     * so a non-null viewport says nothing about whether data is on screen. The viewport is
-     * still checked because the handlers dereference it.</p>
+     * <p>The evidence is data in the display set for a visible series, not the viewport
+     * and not the selection: {@code PlotPanel} synthesises a placeholder viewport
+     * ("now +/- 1 hour") while painting an empty panel, and a series is added to the
+     * visible list the moment it is ticked, before its fetch completes (or fails). The
+     * display set only holds series whose data has arrived, which is the same test
+     * {@link #saveData()} applies. The viewport is still checked because the handlers
+     * dereference it.</p>
      */
     private boolean hasPlot() {
-        if (viewportSupplier == null || visibleSeriesSupplier == null) {
+        if (viewportSupplier == null || visibleSeriesSupplier == null || dataSetSupplier == null) {
             return false;
         }
+        DataSet dataSet = dataSetSupplier.get();
         List<SeriesRef> visibleSeries = visibleSeriesSupplier.get();
-        return viewportSupplier.get() != null && visibleSeries != null && !visibleSeries.isEmpty();
+        return viewportSupplier.get() != null
+            && dataSet != null && !dataSet.isEmpty()
+            && visibleSeries != null && !visibleSeries.isEmpty();
+    }
+
+    /**
+     * Whether the clipboard currently holds text the paste items could read. Per
+     * context-menu-style 4, Paste with an empty clipboard is shown disabled rather than
+     * hidden: the user should know the command exists. A clipboard held by another
+     * application counts as empty.
+     */
+    private static boolean hasClipboardText() {
+        try {
+            return Toolkit.getDefaultToolkit().getSystemClipboard().isDataFlavorAvailable(DataFlavor.stringFlavor);
+        } catch (IllegalStateException ex) {
+            return false;
+        }
     }
 
     /**
@@ -743,8 +768,8 @@ public class PlotInteractionManager {
             }
         });
         contextMenu.add(copyXAxis);
-        JMenuItem pasteXAxis = new JMenuItem("Paste X axis");
-        pasteXAxis.addActionListener(e -> {
+        pasteXAxisItem = new JMenuItem("Paste X axis");
+        pasteXAxisItem.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
             String text = readClipboardText();
             if (currentViewport == null || text == null) {
@@ -760,7 +785,7 @@ public class PlotInteractionManager {
             }
             applyXLimits(x[0], x[1]);
         });
-        contextMenu.add(pasteXAxis);
+        contextMenu.add(pasteXAxisItem);
 
         JMenuItem copyYAxis = new JMenuItem("Copy Y axis");
         copyYAxis.addActionListener(e -> {
@@ -770,8 +795,8 @@ public class PlotInteractionManager {
             }
         });
         contextMenu.add(copyYAxis);
-        JMenuItem pasteYAxis = new JMenuItem("Paste Y axis");
-        pasteYAxis.addActionListener(e -> {
+        pasteYAxisItem = new JMenuItem("Paste Y axis");
+        pasteYAxisItem.addActionListener(e -> {
             ViewPort currentViewport = viewportSupplier.get();
             String text = readClipboardText();
             if (currentViewport == null || text == null) {
@@ -787,7 +812,7 @@ public class PlotInteractionManager {
             }
             applyExplicitLimits(currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(), y[0], y[1]);
         });
-        contextMenu.add(pasteYAxis);
+        contextMenu.add(pasteYAxisItem);
 
         contextMenu.addSeparator();
 
@@ -846,6 +871,10 @@ public class PlotInteractionManager {
         contextMenu.addPopupMenuListener(new PopupMenuListener() {
             @Override
             public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                boolean clipboardHasText = hasClipboardText();
+                pasteXAxisItem.setEnabled(clipboardHasText);
+                pasteYAxisItem.setEnabled(clipboardHasText);
+
                 // Sync the checkbox state with the current PlotPanel state
                 if (parentComponent instanceof PlotPanel plotPanel) {
                     // Get the current auto-Y state from the PlotPanel
@@ -963,6 +992,7 @@ public class PlotInteractionManager {
 
         JDialog dialog = new JDialog(SwingUtilities.getWindowAncestor(parentComponent),
             "Set Axis Limits", Dialog.ModalityType.APPLICATION_MODAL);
+        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setLayout(new BorderLayout());
         dialog.add(form, BorderLayout.CENTER);
 
@@ -994,7 +1024,17 @@ public class PlotInteractionManager {
         buttonPanel.add(okButton);
         buttonPanel.add(cancelButton);
         dialog.add(buttonPanel, BorderLayout.SOUTH);
+
+        // Esc cancels; Enter accepts via the default button (the KalixFileDialog idiom).
         dialog.getRootPane().setDefaultButton(okButton);
+        dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+            .put(KeyStroke.getKeyStroke("ESCAPE"), "cancel");
+        dialog.getRootPane().getActionMap().put("cancel", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dialog.dispose();
+            }
+        });
 
         dialog.pack();
         dialog.setLocationRelativeTo(parentComponent);

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -1,6 +1,7 @@
 package com.kalix.ide.flowviz;
 
 import com.kalix.ide.flowviz.data.DataSet;
+import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.flowviz.rendering.ViewPort;
 import com.kalix.ide.flowviz.rendering.XAxisType;
 import com.kalix.ide.flowviz.transform.PlotTypeTransformer;
@@ -210,7 +211,7 @@ public class PlotInteractionManager {
                 // on press on macOS/Linux but on release on Windows, and macOS
                 // Ctrl+click is a popup gesture without being the right button.
                 if (e.isPopupTrigger() && plotArea.contains(e.getPoint())) {
-                    contextMenu.show(parentComponent, e.getX(), e.getY());
+                    showContextMenuIfPlotted(e);
                 } else if (SwingUtilities.isLeftMouseButton(e) && e.isShiftDown() && plotArea.contains(e.getPoint())) {
                     // Shift+click: start zoom rectangle selection
                     isZoomSelecting = true;
@@ -238,7 +239,10 @@ public class PlotInteractionManager {
             @Override
             public void mouseReleased(MouseEvent e) {
                 if (e.isPopupTrigger() && plotAreaSupplier.get().contains(e.getPoint())) {
-                    contextMenu.show(parentComponent, e.getX(), e.getY());
+                    // Return regardless of whether the menu showed: the gesture was a popup
+                    // trigger either way, and on macOS Ctrl+click it is also a left-button
+                    // release, which would otherwise fall through into the drag/zoom paths.
+                    showContextMenuIfPlotted(e);
                     return;
                 }
                 if (SwingUtilities.isLeftMouseButton(e) && isZoomSelecting) {
@@ -669,6 +673,36 @@ public class PlotInteractionManager {
         }
 
         return new double[]{minValue, maxValue};
+    }
+
+    /**
+     * Shows the context menu at the event position, but only when there is an actual plot
+     * under the cursor. Callers have already established that the gesture was a popup
+     * trigger inside the plot area.
+     */
+    private void showContextMenuIfPlotted(MouseEvent e) {
+        if (!hasPlot()) {
+            return;
+        }
+        contextMenu.show(parentComponent, e.getX(), e.getY());
+    }
+
+    /**
+     * Whether this panel is actually plotting something. Every item on the context menu --
+     * zoom to fit, axis limits, axis copy/paste, save data -- acts on plotted series, so on
+     * an empty tab the menu is a list of no-ops and error dialogs.
+     *
+     * <p>The visible-series list is the evidence, not the viewport: {@code PlotPanel}
+     * synthesises a placeholder viewport ("now +/- 1 hour") while painting an empty panel,
+     * so a non-null viewport says nothing about whether data is on screen. The viewport is
+     * still checked because the handlers dereference it.</p>
+     */
+    private boolean hasPlot() {
+        if (viewportSupplier == null || visibleSeriesSupplier == null) {
+            return false;
+        }
+        List<SeriesRef> visibleSeries = visibleSeriesSupplier.get();
+        return viewportSupplier.get() != null && visibleSeries != null && !visibleSeries.isEmpty();
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -742,11 +742,7 @@ public class PlotInteractionManager {
             if (currentViewport == null) {
                 return;
             }
-            XAxisType xAxisType = currentViewport.getXAxisType();
-            copyBoundsToClipboard(
-                formatXValue(currentViewport.getStartTimeMs(), xAxisType),
-                formatXValue(currentViewport.getEndTimeMs(), xAxisType)
-            );
+            copyStringToClipboard(getCurrentXLimits(currentViewport));
         });
         contextMenu.add(copyXAxis);
         JMenuItem pasteXAxis = new JMenuItem("Paste X axis");
@@ -787,9 +783,7 @@ public class PlotInteractionManager {
             if (currentViewport == null) {
                 return;
             }
-            var minVal = currentViewport.getMinValue();
-            var maxVal = currentViewport.getMaxValue();
-            copyBoundsToClipboard(String.valueOf(minVal), String.valueOf(maxVal));
+            copyStringToClipboard(getCurrentYLimits(currentViewport));
         });
         contextMenu.add(copyYAxis);
         JMenuItem pasteYAxis = new JMenuItem("Paste Y axis");
@@ -909,22 +903,17 @@ public class PlotInteractionManager {
     }
 
     /**
-     * Puts an axis' bounds on the system clipboard as {@code "lower, upper"} -- the format
-     * {@link #readBoundsFromClipboard} reads back, and one a user can equally well type by
-     * hand or paste in from elsewhere.
-     *
-     * @param lowerFormatted the axis minimum, already formatted in the axis' own units
-     * @param upperFormatted the axis maximum, likewise
+     * Puts a string on the system clipboard
      */
-    private static void copyBoundsToClipboard(String lowerFormatted, String upperFormatted) {
-        StringSelection selection = new StringSelection(lowerFormatted + ", " + upperFormatted);
+    private static void copyStringToClipboard(String formatted) {
+        StringSelection selection = new StringSelection(formatted);
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(selection, selection);
     }
 
     /**
      * Reads a {@code "lower, upper"} pair off the clipboard, the inverse of
-     * {@link #copyBoundsToClipboard}. Returns the two trimmed halves, or {@code null} when
+     * {@link #copyStringToClipboard}. Returns the two trimmed halves, or {@code null} when
      * the clipboard is unreadable or does not hold exactly two comma-separated values --
      * having reported that to the user, so callers need only bail out.
      *
@@ -941,8 +930,10 @@ public class PlotInteractionManager {
             return null;
         }
 
-        String[] parts = clipboardString.split("\\s*,\\s*");
-        if (parts.length != 2) {
+        try {
+            return splitLimitString(clipboardString);
+        }
+        catch (IllegalArgumentException ex) {
             JOptionPane.showMessageDialog(
                 parentComponent,
                 String.format("Expected two comma-separated %s but received \"%s\"", expected, clipboardString),
@@ -950,7 +941,23 @@ public class PlotInteractionManager {
             );
             return null;
         }
-        return new String[]{parts[0].trim(), parts[1].trim()};
+    }
+
+    /**
+     * Splits a {@code "lower, upper"} string into its two trimmed halves.
+     *
+     * @param parseString the raw field text to split
+     * @return the two trimmed halves, {@code {lower, upper}}
+     * @throws IllegalArgumentException if {@code parseString} does not hold exactly two
+     *                                   comma-separated values
+     */
+    private String[] splitLimitString(String parseString) {
+        String[] parts = parseString.split("\\s*,\\s*");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException(
+                String.format("Expected two comma-separated values but received \"%s\"", parseString));
+        }
+        return new String[]{ parts[0].trim(), parts[1].trim() };
     }
 
     /**
@@ -967,19 +974,15 @@ public class PlotInteractionManager {
         }
         XAxisType xAxisType = currentViewport.getXAxisType();
 
-        JTextField xMinField = new JTextField(formatXValue(currentViewport.getStartTimeMs(), xAxisType), 16);
-        JTextField xMaxField = new JTextField(formatXValue(currentViewport.getEndTimeMs(), xAxisType), 16);
-        JTextField yMinField = new JTextField(formatDoubleForField(currentViewport.getMinValue()), 16);
-        JTextField yMaxField = new JTextField(formatDoubleForField(currentViewport.getMaxValue()), 16);
+        JTextField xField = new JTextField(getCurrentXLimits(currentViewport), 32);
+        JTextField yField = new JTextField(getCurrentYLimits(currentViewport), 32);
 
         JPanel form = new JPanel(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.insets = new Insets(4, 4, 4, 4);
         gbc.anchor = GridBagConstraints.WEST;
-        addAxisFieldRow(form, gbc, 0, "X min:", xMinField);
-        addAxisFieldRow(form, gbc, 1, "X max:", xMaxField);
-        addAxisFieldRow(form, gbc, 2, "Y min:", yMinField);
-        addAxisFieldRow(form, gbc, 3, "Y max:", yMaxField);
+        addAxisFieldRow(form, gbc, 0, "X limits:", xField);
+        addAxisFieldRow(form, gbc, 1, "Y limits:", yField);
 
         JDialog dialog = new JDialog(SwingUtilities.getWindowAncestor(parentComponent),
             "Set Axis Limits", Dialog.ModalityType.APPLICATION_MODAL);
@@ -989,15 +992,27 @@ public class PlotInteractionManager {
         JButton okButton = new JButton("OK");
         okButton.addActionListener(ev -> {
             try {
-                Long   startTime = parseX(xMinField.getText(), xAxisType);
-                Long   endTime   = parseX(xMaxField.getText(), xAxisType);
-                Double minValue  = parseY(yMinField.getText());
-                Double maxValue  = parseY(yMaxField.getText());
+                String[] xLimits = splitLimitString(xField.getText());
+                String[] yLimits = splitLimitString(yField.getText());
 
-                ViewPort.validateBounds(startTime, endTime, minValue, maxValue);
-
-                acceptNewAxes(startTime, endTime, minValue, maxValue);
-                dialog.dispose();
+                long   startTime;
+                long   endTime;
+                double minVal;
+                double maxVal;
+                try {
+                    // bounds-safe owing to the pair check in readBoundsFromClipboard
+                    startTime = parseX(xLimits[0], xAxisType);
+                    endTime   = parseX(xLimits[1], xAxisType);
+                    minVal    = parseY(yLimits[0]);
+                    maxVal    = parseY(yLimits[1]);
+                } catch (IllegalArgumentException ex) {
+                    JOptionPane.showMessageDialog(
+                        parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                    return;
+                }
+                ViewPort.validateBounds(startTime, endTime, minVal, maxVal);
+                acceptNewAxes(startTime, endTime, minVal, maxVal);
+                dialog.dispose(); // Intentionally here so the user can retry
             } catch (DateTimeParseException | NumberFormatException parseEx) {
                 JOptionPane.showMessageDialog(dialog, "Could not parse axis limits: " + parseEx.getMessage(),
                     "Invalid input", JOptionPane.ERROR_MESSAGE);
@@ -1117,6 +1132,48 @@ public class PlotInteractionManager {
             return String.valueOf((long) value);
         }
         return String.valueOf(value);
+    }
+
+    /**
+     * Helper for consistent formatting of limits.
+     */
+    private String formatLimits(String left, String right) {
+        return left + ", " + right;
+    }
+
+    /**
+     * Helper to consistently format x axis limits.
+     */
+    private String formatXLimits(long min, long max, XAxisType xAxisType) {
+        return formatLimits(formatXValue(min, xAxisType), formatXValue(max, xAxisType));
+    }
+
+    /**
+     * Helper to consistently format y axis limits.
+     */
+    private String formatYLimits(double min, double max) {
+        return formatLimits(formatDoubleForField(min), formatDoubleForField(max));
+    }
+
+    /**
+     * Get the current X limits as a formatted string.
+     * Precondition: {@code viewPort} is not null.
+     */
+    private String getCurrentXLimits(ViewPort viewPort) {
+        XAxisType xAxisType = viewPort.getXAxisType();
+        long min = viewPort.getStartTimeMs();
+        long max = viewPort.getEndTimeMs();
+        return formatXLimits(min, max, xAxisType);
+    }
+
+    /**
+     * Get the current Y limits as a formatted string.
+     * Precondition: {@code viewPort} is not null.
+     */
+    private String getCurrentYLimits(ViewPort viewPort) {
+        double min = viewPort.getMinValue();
+        double max = viewPort.getMaxValue();
+        return formatYLimits(min, max);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -740,23 +740,25 @@ public class PlotInteractionManager {
     private void setupContextMenu() {
         contextMenu = new JPopupMenu();
 
+        // Primary block (context-menu-style 1, block 1): the default action, which on a plot
+        // is what double-click does (see the mouse listener). The skeleton's table lists
+        // "Zoom to fit" under block 7 for panels where it is merely a view command; here
+        // it is the primary one, so it leads.
         JMenuItem zoomToFitItem = new JMenuItem("Zoom to fit");
         zoomToFitItem.addActionListener(e -> zoomToFit());
         contextMenu.add(zoomToFitItem);
 
-        autoYMenuItem = new JCheckBoxMenuItem("Auto-scale Y axis");
-        autoYMenuItem.addActionListener(e -> {
-            if (parentComponent instanceof PlotPanel plotPanel) {
-                plotPanel.setAutoYMode(autoYMenuItem.isSelected());
-            }
-        });
-        contextMenu.add(autoYMenuItem);
+        contextMenu.addSeparator();
+
+        // Context-specific block (block 2): the plot's own handoff to a file.
+        JMenuItem saveDataItem = new JMenuItem("Save data…");
+        saveDataItem.addActionListener(e -> saveData());
+        contextMenu.add(saveDataItem);
 
         contextMenu.addSeparator();
 
-        // Clipboard block before the view/state items (context-menu-style 1: block 3
-        // precedes block 7). "Set axis limits..." carries an ellipsis because it opens a
-        // dialog -- per 2.4 -- where the copy/paste items act immediately and do not.
+        // Clipboard block (block 3). The copy/paste items act immediately and carry no
+        // ellipsis (2.4).
         JMenuItem copyXAxis = new JMenuItem("Copy X axis");
 
         // Copy/paste go through AxisLimitCodec -- the same codec the Set-axis-limits
@@ -816,9 +818,20 @@ public class PlotInteractionManager {
 
         contextMenu.addSeparator();
 
+        // View/state block (block 7): everything that changes how the data is shown, never
+        // the data. "Set axis limits…" carries an ellipsis because it opens a dialog (2.4);
+        // the submenus are category nouns with value children (6).
         JMenuItem setAxes = new JMenuItem("Set axis limits…");
         setAxes.addActionListener(e1 -> showSetAxesDialog());
         contextMenu.add(setAxes);
+
+        autoYMenuItem = new JCheckBoxMenuItem("Auto-scale Y axis");
+        autoYMenuItem.addActionListener(e -> {
+            if (parentComponent instanceof PlotPanel plotPanel) {
+                plotPanel.setAutoYMode(autoYMenuItem.isSelected());
+            }
+        });
+        contextMenu.add(autoYMenuItem);
 
         // Y-axis scale submenu
         yAxisScaleMenu = new JMenu("Y-axis scale");
@@ -834,8 +847,6 @@ public class PlotInteractionManager {
             yAxisScaleMenu.add(scaleItem);
         }
         contextMenu.add(yAxisScaleMenu);
-
-        contextMenu.addSeparator();
 
         // Missing Data submenu. "Draw across gaps" and "Mark orphan points" are mutually
         // exclusive — drawing a continuous line removes the gaps that orphan points would mark —
@@ -860,12 +871,6 @@ public class PlotInteractionManager {
         missingDataMenu.add(orphanMarkersMenuItem);
 
         contextMenu.add(missingDataMenu);
-
-        contextMenu.addSeparator();
-
-        JMenuItem saveDataItem = new JMenuItem("Save data…");
-        saveDataItem.addActionListener(e -> saveData());
-        contextMenu.add(saveDataItem);
 
         // Add popup menu listener to update checkbox/radio button states when menu is shown
         contextMenu.addPopupMenuListener(new PopupMenuListener() {
@@ -991,7 +996,7 @@ public class PlotInteractionManager {
         addAxisFieldRow(form, gbc, 1, "Y limits:", yField);
 
         JDialog dialog = new JDialog(SwingUtilities.getWindowAncestor(parentComponent),
-            "Set Axis Limits", Dialog.ModalityType.APPLICATION_MODAL);
+            "Set axis limits", Dialog.ModalityType.APPLICATION_MODAL);  // sentence case (2.1)
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setLayout(new BorderLayout());
         dialog.add(form, BorderLayout.CENTER);

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -767,6 +767,8 @@ public class PlotInteractionManager {
                 XAxisType xAxisType = currentViewport.getXAxisType();
                 startTime = parseX(parts[0], xAxisType);
                 endTime = parseX(parts[1], xAxisType);
+                ViewPort.validateBounds(startTime, endTime,
+                    currentViewport.getMinValue(), currentViewport.getMaxValue());
             } catch (IllegalArgumentException ex) {
                 JOptionPane.showMessageDialog(
                     parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
@@ -807,6 +809,8 @@ public class PlotInteractionManager {
                 // bounds-safe owing to the pair check in readBoundsFromClipboard
                 minVal = parseY(parts[0]);
                 maxVal = parseY(parts[1]);
+                ViewPort.validateBounds(currentViewport.getStartTimeMs(), currentViewport.getEndTimeMs(),
+                    minVal, maxVal);
             } catch (IllegalArgumentException ex) {
                 JOptionPane.showMessageDialog(
                     parentComponent, ex.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
@@ -947,7 +951,8 @@ public class PlotInteractionManager {
 
     /**
      * Shows a modal dialog with the current axis limits, pre-filled and editable as text.
-     * A blank field leaves that limit unchanged (see {@link #acceptNewAxes}); X fields are
+     * All four fields are required -- they arrive pre-filled with the current limits, so
+     * leaving one alone is how a limit is kept, and a blank field is an error. X fields are
      * parsed according to the viewport's {@link XAxisType} (dates for TIME, percentages for
      * PERCENTILE, etc.) so the field always shows and accepts values in the axis' own units.
      */
@@ -985,12 +990,7 @@ public class PlotInteractionManager {
                 Double minValue  = parseY(yMinField.getText());
                 Double maxValue  = parseY(yMaxField.getText());
 
-                if (startTime >= endTime) {
-                    throw new IllegalArgumentException("X min must be less than X max.");
-                }
-                if (minValue >= maxValue) {
-                    throw new IllegalArgumentException("Y min must be less than Y max.");
-                }
+                ViewPort.validateBounds(startTime, endTime, minValue, maxValue);
 
                 acceptNewAxes(startTime, endTime, minValue, maxValue);
                 dialog.dispose();
@@ -1116,9 +1116,9 @@ public class PlotInteractionManager {
 
     /**
      * Moves the viewport to the given axis limits, keeping plot area, Y-axis scale, and
-     * X-axis type unchanged. Limits must already be resolved (no "leave unchanged" fallback
-     * here) — see {@link #showSetAxesDialog}, which resolves blank fields against the current
-     * viewport before calling this.
+     * X-axis type unchanged. All four limits are required and are applied as given; callers
+     * are responsible for parsing and for checking them with
+     * {@link ViewPort#validateBounds} first.
      */
     private void acceptNewAxes(Long startTime, Long endTime, Double minValue, Double maxValue) {
         var currentViewport = this.viewportSupplier.get();

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -216,6 +216,16 @@ public class PlotPanel extends JPanel {
         }
     }
 
+    /**
+     * Releases display-scoped resources only. This fires on every hierarchy detach,
+     * including the remove/insert cycle a tab reorder or reset performs, and everything
+     * torn down here is re-established on {@link #addNotify()} or on next use. Callbacks
+     * installed by the owning toolbar ({@code onHistoryChanged}, {@code onAutoYModeChanged})
+     * are deliberately <em>not</em> cleared: they belong to the owner, which detaches
+     * them when it closes the tab, and clearing them here would sever a re-parented
+     * panel from its own toolbar. (Stopping the coalesce timer drops one pending history
+     * push if a tab is dragged within 500 ms of a zoom — known and harmless.)
+     */
     @Override
     public void removeNotify() {
         PlotPaletteManager.getInstance().removeChangeListener(paletteChangeListener);
@@ -225,7 +235,6 @@ public class PlotPanel extends JPanel {
         }
         viewportCoalesceTimer.stop();
         coordinateDisplayManager.dispose();
-        onHistoryChanged = null;
         super.removeNotify();
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -137,6 +137,7 @@ public class PlotPanel extends JPanel {
     private final PlotStateHistory stateHistory = new PlotStateHistory();
     private boolean restoringState = false;  // Suppresses pushState() during restore
     private Runnable onHistoryChanged;       // Callback for toolbar button enable/disable
+    private Runnable onAutoYModeChanged;     // Callback for the toolbar auto-Y toggle
 
     // Repaints this panel whenever the active palette is edited or switched, or a
     // series is moved to a different palette slot, so a palette-backed resolver's
@@ -190,6 +191,7 @@ public class PlotPanel extends JPanel {
 
         // Setup plot type supplier for format-aware export
         plotInteractionManager.setPlotTypeSupplier(() -> plotType);
+        plotInteractionManager.setAutoYModeSupplier(() -> autoYMode);
 
         // Resolver for projecting ref-keyed series to column headers on CSV export.
         plotInteractionManager.setLabelResolverSupplier(() -> labelResolver);
@@ -587,12 +589,32 @@ public class PlotPanel extends JPanel {
         repaint();
     }
     
+    /**
+     * Sets auto-Y mode: whether X-only navigation (wheel zoom, pan, pasted X limits)
+     * keeps the Y range fitted to the visible data. This is the single owner of the
+     * mode; the interaction manager reads it through a supplier and the toolbar follows
+     * it through {@link #setOnAutoYModeChanged}. Enabling fits Y immediately, so every
+     * entry point (toolbar, context menu) behaves the same and records one history entry.
+     */
     public void setAutoYMode(boolean autoYMode) {
+        if (this.autoYMode == autoYMode) return;
         this.autoYMode = autoYMode;
-        if (plotInteractionManager != null) {
-            plotInteractionManager.setAutoYMode(autoYMode);
+        if (autoYMode) {
+            fitYAxis();
         }
         pushState();
+        if (onAutoYModeChanged != null) {
+            onAutoYModeChanged.run();
+        }
+    }
+
+    /**
+     * Sets a callback invoked whenever {@link #setAutoYMode} changes the mode, so a
+     * toolbar toggle can follow changes made from the context menu or by explicit axis
+     * limits. Not invoked on undo/redo, which the toolbar syncs from the restored state.
+     */
+    public void setOnAutoYModeChanged(Runnable callback) {
+        this.onAutoYModeChanged = callback;
     }
 
     public void saveData() {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisLimitCodec.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisLimitCodec.java
@@ -22,11 +22,12 @@ import java.util.concurrent.TimeUnit;
  * viewport is not a hydrological concern.</p>
  *
  * <p>Every failure is an {@link IllegalArgumentException} carrying the message shown to
- * the user, so callers need a single catch. This is also the one gate against
- * non-finite input: {@code Double.parseDouble} accepts {@code "NaN"} and
+ * the user, so callers need a single catch. This is also the one gate against input the
+ * encodings cannot hold: {@code Double.parseDouble} accepts {@code "NaN"} and
  * {@code "Infinity"}, and {@code Math.round} would silently turn those into {@code 0}
- * and {@code Long.MAX_VALUE}. {@link ViewPort#validateBounds} then only has to check the
- * ordering of each pair.</p>
+ * and {@code Long.MAX_VALUE}, as it would any finite value whose scaled form overflows
+ * a long. {@link ViewPort#validateBounds} then only has to check the ordering of each
+ * pair.</p>
  */
 public final class AxisLimitCodec {
 
@@ -105,8 +106,8 @@ public final class AxisLimitCodec {
         return switch (xAxisType) {
             case PERCENTILE -> {
                 String number = trimmed.endsWith("%") ? trimmed.substring(0, trimmed.length() - 1).trim() : trimmed;
-                double percentile = parseFinite(number, "Not a valid percentile: \"" + trimmed + "\"");
-                yield Math.round(percentile * PlotTypeTransformer.PERCENTILE_SCALE);
+                yield encodeScaled(number, PlotTypeTransformer.PERCENTILE_SCALE,
+                    "Not a valid percentile: \"" + trimmed + "\"");
             }
             case COUNT -> {
                 try {
@@ -115,10 +116,8 @@ public final class AxisLimitCodec {
                     throw new IllegalArgumentException("Not a valid integer count: \"" + trimmed + "\"");
                 }
             }
-            case NUMERIC -> {
-                double value = parseFinite(trimmed, "Not a valid number: \"" + trimmed + "\"");
-                yield Math.round(value * PlotTypeTransformer.NUMERIC_SCALE);
-            }
+            case NUMERIC -> encodeScaled(trimmed, PlotTypeTransformer.NUMERIC_SCALE,
+                "Not a valid number: \"" + trimmed + "\"");
             case TIME -> {
                 try {
                     yield TimeFormatUtil.parseFlexible(trimmed);
@@ -179,6 +178,19 @@ public final class AxisLimitCodec {
             throw new IllegalArgumentException(errorMessage);
         }
         return value;
+    }
+
+    /**
+     * Parses a number and encodes it as {@code value * scale}, rejecting anything the
+     * long encoding cannot hold: {@code Math.round} saturates at {@code Long.MAX_VALUE}
+     * rather than failing, which would install a silently wrong bound.
+     */
+    private static long encodeScaled(String number, long scale, String errorMessage) {
+        double scaled = parseFinite(number, errorMessage) * scale;
+        if (!Double.isFinite(scaled) || Math.abs(scaled) >= 0x1p63) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        return Math.round(scaled);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisLimitCodec.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisLimitCodec.java
@@ -1,0 +1,196 @@
+package com.kalix.ide.flowviz.rendering;
+
+import com.kalix.ide.flowviz.transform.PlotTypeTransformer;
+import com.kalix.ide.utils.TimeFormatUtil;
+
+import java.time.format.DateTimeParseException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Text &lt;-&gt; value codec for axis limits, in the axis' own units: the pure half of the
+ * "Copy/Paste X axis", "Copy/Paste Y axis" and "Set axis limits…" commands.
+ *
+ * <p>X bounds are viewport longs: real epoch millis on a {@link XAxisType#TIME} axis, and
+ * fake-timestamp encodings on the others (percentile &times;
+ * {@link PlotTypeTransformer#PERCENTILE_SCALE}, value &times;
+ * {@link PlotTypeTransformer#NUMERIC_SCALE}, raw counts). Formatting a percentile or
+ * numeric bound as a date would render it as a meaningless 1970 instant, so every
+ * {@code format} here is the exact inverse of its {@code parse} for the given axis type,
+ * and a copied pair pastes back unchanged. One documented exception: TIME bounds are
+ * exchanged at second resolution, so two bounds within the same second collapse to one
+ * instant and {@link ViewPort#validateBounds} rejects them on paste. A sub-second
+ * viewport is not a hydrological concern.</p>
+ *
+ * <p>Every failure is an {@link IllegalArgumentException} carrying the message shown to
+ * the user, so callers need a single catch. This is also the one gate against
+ * non-finite input: {@code Double.parseDouble} accepts {@code "NaN"} and
+ * {@code "Infinity"}, and {@code Math.round} would silently turn those into {@code 0}
+ * and {@code Long.MAX_VALUE}. {@link ViewPort#validateBounds} then only has to check the
+ * ordering of each pair.</p>
+ */
+public final class AxisLimitCodec {
+
+    private AxisLimitCodec() {}
+
+    private static final long MS_PER_DAY = TimeUnit.DAYS.toMillis(1);
+    private static final long SECONDS_PER_DAY = TimeUnit.DAYS.toSeconds(1);
+    private static final String PAIR_SEPARATOR = ", ";
+
+    // ---- pairs ----
+
+    /** The current X limits of {@code viewport} as {@code "lower, upper"} in the axis' units. */
+    public static String formatXLimits(ViewPort viewport) {
+        XAxisType xAxisType = viewport.getXAxisType();
+        return formatPair(formatX(viewport.getStartTimeMs(), xAxisType), formatX(viewport.getEndTimeMs(), xAxisType));
+    }
+
+    /** The current Y limits of {@code viewport} as {@code "lower, upper"}. */
+    public static String formatYLimits(ViewPort viewport) {
+        return formatPair(formatY(viewport.getMinValue()), formatY(viewport.getMaxValue()));
+    }
+
+    /**
+     * Parses {@code "lower, upper"} into two viewport X values for {@code xAxisType}.
+     *
+     * @throws IllegalArgumentException if the text is not two comma-separated values, or
+     *                                  either value is not valid for the axis type
+     */
+    public static long[] parseXLimits(String text, XAxisType xAxisType) {
+        String[] parts = splitPair(text);
+        return new long[]{ parseX(parts[0], xAxisType), parseX(parts[1], xAxisType) };
+    }
+
+    /**
+     * Parses {@code "lower, upper"} into two Y values.
+     *
+     * @throws IllegalArgumentException if the text is not two comma-separated values, or
+     *                                  either value is not a finite number
+     */
+    public static double[] parseYLimits(String text) {
+        String[] parts = splitPair(text);
+        return new double[]{ parseY(parts[0]), parseY(parts[1]) };
+    }
+
+    /** Joins two formatted bounds the way {@link #splitPair} splits them. */
+    public static String formatPair(String lower, String upper) {
+        return lower + PAIR_SEPARATOR + upper;
+    }
+
+    /**
+     * Splits {@code "lower, upper"} into its two trimmed halves.
+     *
+     * @throws IllegalArgumentException if {@code text} does not hold exactly two
+     *                                  comma-separated values
+     */
+    public static String[] splitPair(String text) {
+        String[] parts = text == null ? new String[0] : text.split("\\s*,\\s*");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException(
+                String.format("Expected two comma-separated values but received \"%s\"", text));
+        }
+        return new String[]{ parts[0].trim(), parts[1].trim() };
+    }
+
+    // ---- single values ----
+
+    /**
+     * Parses one X bound in the units of {@code xAxisType}: a date/time (see
+     * {@link TimeFormatUtil#parseFlexible}) for TIME, a percentage with optional
+     * {@code %} for PERCENTILE, an integer for COUNT, a number for NUMERIC.
+     *
+     * @throws IllegalArgumentException if the text is blank or not valid for the axis type
+     */
+    public static long parseX(String text, XAxisType xAxisType) {
+        String trimmed = requireText(text, "X");
+        return switch (xAxisType) {
+            case PERCENTILE -> {
+                String number = trimmed.endsWith("%") ? trimmed.substring(0, trimmed.length() - 1).trim() : trimmed;
+                double percentile = parseFinite(number, "Not a valid percentile: \"" + trimmed + "\"");
+                yield Math.round(percentile * PlotTypeTransformer.PERCENTILE_SCALE);
+            }
+            case COUNT -> {
+                try {
+                    yield Long.parseLong(trimmed);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Not a valid integer count: \"" + trimmed + "\"");
+                }
+            }
+            case NUMERIC -> {
+                double value = parseFinite(trimmed, "Not a valid number: \"" + trimmed + "\"");
+                yield Math.round(value * PlotTypeTransformer.NUMERIC_SCALE);
+            }
+            case TIME -> {
+                try {
+                    yield TimeFormatUtil.parseFlexible(trimmed);
+                } catch (DateTimeParseException e) {
+                    throw new IllegalArgumentException("Not a valid date/time: \"" + trimmed
+                        + "\" (expected 2024-02-01 or 01-02-2024, optionally with HH:mm[:ss])");
+                }
+            }
+        };
+    }
+
+    /**
+     * Formats one X bound in the units of {@code xAxisType}; the inverse of
+     * {@link #parseX}. TIME bounds format as a bare date when midnight-aligned and as a
+     * full ISO datetime otherwise, both of which {@link TimeFormatUtil#parseFlexible} reads.
+     */
+    public static String formatX(long value, XAxisType xAxisType) {
+        return switch (xAxisType) {
+            case PERCENTILE -> formatNumber((double) value / PlotTypeTransformer.PERCENTILE_SCALE) + "%";
+            case COUNT -> String.valueOf(value);
+            case NUMERIC -> formatNumber((double) value / PlotTypeTransformer.NUMERIC_SCALE);
+            case TIME -> TimeFormatUtil.formatForStepSize(value, value % MS_PER_DAY == 0 ? SECONDS_PER_DAY : 1L);
+        };
+    }
+
+    /**
+     * Parses one Y bound.
+     *
+     * @throws IllegalArgumentException if the text is blank or not a finite number
+     */
+    public static double parseY(String text) {
+        String trimmed = requireText(text, "Y");
+        return parseFinite(trimmed, "Not a valid number: \"" + trimmed + "\"");
+    }
+
+    /** Formats one Y bound; the inverse of {@link #parseY}. */
+    public static String formatY(double value) {
+        return formatNumber(value);
+    }
+
+    // ---- helpers ----
+
+    private static String requireText(String text, String axis) {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException(axis + " value cannot be blank.");
+        }
+        return text.trim();
+    }
+
+    private static double parseFinite(String number, String errorMessage) {
+        double value;
+        try {
+            value = Double.parseDouble(number);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        if (!Double.isFinite(value)) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+        return value;
+    }
+
+    /**
+     * Formats a double for editing without scientific notation or a spurious {@code .0}
+     * on whole numbers. Both branches print something {@code Double.parseDouble} reads
+     * back to the same value, which the Set-axis-limits dialog relies on to tell an
+     * untouched Y field from an edited one.
+     */
+    private static String formatNumber(double value) {
+        if (Double.isFinite(value) && value == Math.rint(value) && Math.abs(value) < 1e15) {
+            return String.valueOf((long) value);
+        }
+        return String.valueOf(value);
+    }
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
@@ -10,6 +10,8 @@ import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.kalix.ide.flowviz.transform.PlotTypeTransformer.PERCENTILE_SCALE;
+
 /**
  * Handles rendering of grid lines, axis ticks, and axis labels for time series plots.
  * Works in conjunction with TemporalAxisCalculator to provide synchronized
@@ -89,8 +91,8 @@ public class AxisRenderer {
         List<Long> ticks = new ArrayList<>();
 
         // Convert fake timestamps back to percentiles
-        double startPercentile = viewport.getStartTimeMs() / 1_000_000.0;
-        double endPercentile = viewport.getEndTimeMs() / 1_000_000.0;
+        double startPercentile = (double) viewport.getStartTimeMs() / PERCENTILE_SCALE;
+        double endPercentile = (double) viewport.getEndTimeMs() / PERCENTILE_SCALE;
         double range = endPercentile - startPercentile;
 
         // Choose tick interval based on zoom level
@@ -112,7 +114,7 @@ public class AxisRenderer {
         while (currentPercentile <= endPercentile + tickInterval / 2) {
             if (currentPercentile >= 0 && currentPercentile <= 100) {
                 // Convert percentile to fake timestamp
-                long fakeTimestamp = (long)(currentPercentile * 1_000_000);
+                long fakeTimestamp = (long) (currentPercentile * PERCENTILE_SCALE);
                 ticks.add(fakeTimestamp);
             }
             currentPercentile += tickInterval;
@@ -404,7 +406,7 @@ public class AxisRenderer {
      * Formats a fake timestamp as a percentile label.
      */
     private String formatPercentile(long fakeTimestamp) {
-        double percentile = fakeTimestamp / 1_000_000.0;
+        double percentile = (double) fakeTimestamp / PERCENTILE_SCALE;
 
         // Format with appropriate precision
         if (percentile == Math.floor(percentile)) {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/ViewPort.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/ViewPort.java
@@ -3,15 +3,23 @@ package com.kalix.ide.flowviz.rendering;
 import com.kalix.ide.flowviz.transform.YAxisScale;
 
 public class ViewPort {
+    /// Minimum visible time (x-axis min)
     private final long startTimeMs;
+    /// Maximum visible time (x-axis max)
     private final long endTimeMs;
+    /// Minimum visible value (y-axis min)
     private final double minValue;
+    /// Maximum visible value (y-axis max)
     private final double maxValue;
 
     // Plot area dimensions
+    /// Left edge of the plot area in screen pixels
     private final int plotX;
+    /// Top edge of the plot area in screen pixels
     private final int plotY;
+    /// Width of the plot area in screen pixels
     private final int plotWidth;
+    /// Height of the plot area in screen pixels
     private final int plotHeight;
 
     // Axis transformations

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/ViewPort.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/ViewPort.java
@@ -40,6 +40,38 @@ public class ViewPort {
         this.xAxisType = xAxisType != null ? xAxisType : XAxisType.TIME;
     }
     
+    /**
+     * Checks that a proposed set of axis limits describes a viewport a user could actually
+     * read: X strictly increasing, Y strictly increasing, and Y finite. Throws
+     * {@link IllegalArgumentException} with a message fit to show in a dialog.
+     *
+     * <p>Deliberately a separate check rather than a constructor guard. Degenerate
+     * viewports are a legitimate <em>internal</em> state -- {@link #timeToScreenX} handles
+     * {@code endTimeMs == startTimeMs} by design, and zoom/pan arithmetic can collapse a
+     * range at extreme magnification -- so rejecting them at construction would turn an
+     * interaction into a crash. What must be policed is the boundary where a user supplies
+     * limits directly: the Set-axis-limits dialog and the axis paste commands, which can
+     * otherwise install an inverted or zero-width viewport that feeds a divide-by-zero into
+     * the axis transforms.</p>
+     *
+     * <p>The finite check matters because {@code Double.parseDouble} happily accepts
+     * {@code "NaN"} and {@code "Infinity"}, and NaN compares false against everything --
+     * so a NaN limit would slip past the ordering test unchallenged.</p>
+     *
+     * @throws IllegalArgumentException if the limits are inverted, empty, or non-finite
+     */
+    public static void validateBounds(long startTimeMs, long endTimeMs, double minValue, double maxValue) {
+        if (startTimeMs >= endTimeMs) {
+            throw new IllegalArgumentException("X min must be less than X max.");
+        }
+        if (!Double.isFinite(minValue) || !Double.isFinite(maxValue)) {
+            throw new IllegalArgumentException("Y limits must be finite numbers.");
+        }
+        if (minValue >= maxValue) {
+            throw new IllegalArgumentException("Y min must be less than Y max.");
+        }
+    }
+
     // Transform coordinates between data space and screen space
     public int timeToScreenX(long timeMs) {
         if (endTimeMs == startTimeMs) return plotX;

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotTypeTransformer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotTypeTransformer.java
@@ -32,6 +32,13 @@ public class PlotTypeTransformer {
     public static final long NUMERIC_SCALE = 1_000_000L;
 
     /**
+     * Scale factor for encoding exceedance percentiles (0-100) as fake timestamps.
+     * Six decimal places, like {@link #NUMERIC_SCALE}; the two are separate constants
+     * because they encode different quantities and need not stay equal.
+     */
+    public static final long PERCENTILE_SCALE = 1_000_000L;
+
+    /**
      * Transforms a dataset according to the specified plot type.
      *
      * @param input The aggregated dataset
@@ -261,8 +268,8 @@ public class PlotTypeTransformer {
                 // Cunnane formula: p = (rank - 0.4) / (n + 0.2)
                 double percentile = ((rank - 0.4) / (validCount + 0.2)) * 100.0;
 
-                // Store as fake timestamp (multiply by 1,000,000)
-                percentileTimestamps[rank - 1] = (long) (percentile * 1_000_000);
+                // Store as fake timestamp
+                percentileTimestamps[rank - 1] = (long) (percentile * PERCENTILE_SCALE);
                 exceedanceValues[rank - 1] = sortedValues[validCount - rank];
             }
 

--- a/kalixide/src/main/java/com/kalix/ide/io/TimeSeriesCsvExporter.java
+++ b/kalixide/src/main/java/com/kalix/ide/io/TimeSeriesCsvExporter.java
@@ -210,7 +210,7 @@ public class TimeSeriesCsvExporter {
             // Format first column based on plot type
             if (isExceedance) {
                 // Convert fake timestamp to percentile
-                double percentile = timestamp / 1_000_000.0;
+                double percentile = (double) timestamp / com.kalix.ide.flowviz.transform.PlotTypeTransformer.PERCENTILE_SCALE;
                 row.append(String.format(java.util.Locale.ROOT, "%.2f", percentile));
             } else {
                 row.append(TimeFormatUtil.formatForStepSize(timestamp, stepSeconds));

--- a/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
+++ b/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
@@ -1,9 +1,11 @@
 package com.kalix.ide.utils;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Centralised timestamp formatting for timeseries display, axis labels, and exports.
@@ -30,6 +32,7 @@ public final class TimeFormatUtil {
 
     private static final DateTimeFormatter DATE_ONLY = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter ISO_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final DateTimeFormatter SPACE_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter MMDD_HHMM = DateTimeFormatter.ofPattern("MM-dd HH:mm");
     private static final DateTimeFormatter HH_MM = DateTimeFormatter.ofPattern("HH:mm");
     private static final DateTimeFormatter HH_MM_SS = DateTimeFormatter.ofPattern("HH:mm:ss");
@@ -81,6 +84,29 @@ public final class TimeFormatUtil {
      */
     public static String formatForTickInterval(long timestampMs, long intervalMs) {
         return formatForTickInterval(toUtc(timestampMs), intervalMs);
+    }
+
+    /**
+     * Parses user-entered text back into an epoch-millisecond timestamp (UTC), accepting
+     * whichever of the formats {@link #formatForStepSize} produces: {@code yyyy-MM-dd},
+     * {@code yyyy-MM-dd'T'HH:mm:ss}, or the same datetime with a space instead of {@code 'T'}.
+     *
+     * @throws DateTimeParseException if the text matches none of the accepted formats
+     */
+    public static long parseFlexible(String text) {
+        String trimmed = text.trim();
+        try {
+            return LocalDateTime.parse(trimmed, ISO_DATETIME).toInstant(ZoneOffset.UTC).toEpochMilli();
+        } catch (DateTimeParseException ignored) {
+            // Not full ISO datetime — try the next format.
+        }
+        try {
+            return LocalDateTime.parse(trimmed, SPACE_DATETIME).toInstant(ZoneOffset.UTC).toEpochMilli();
+        } catch (DateTimeParseException ignored) {
+            // Not space-separated datetime — try date-only. Let this last attempt's
+            // exception (if any) propagate, since there is no further format to fall back to.
+        }
+        return LocalDate.parse(trimmed, DATE_ONLY).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
     }
 
     private static LocalDateTime toUtc(long timestampMs) {

--- a/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
+++ b/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
@@ -33,32 +33,20 @@ public final class TimeFormatUtil {
     private static final long MS_PER_MINUTE = 60_000L;
 
     private static final DateTimeFormatter DATE_ONLY = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    /**
+     * Second-resolution ISO datetime. Deliberately not {@code DateTimeFormatter.ISO_DATE_TIME}:
+     * that appends a fractional-second part whenever the timestamp carries sub-second
+     * millis, and {@link #parseFlexible} -- the other half of the axis copy/paste round
+     * trip -- accepts no fraction. Viewport bounds pick up arbitrary millis from pan/zoom
+     * pixel arithmetic, so that combination broke the round trip on any plot the user had
+     * touched. Second is the finest resolution this class renders, so the truncation costs
+     * nothing visible.
+     */
     private static final DateTimeFormatter ISO_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
     private static final DateTimeFormatter MMDD_HHMM = DateTimeFormatter.ofPattern("MM-dd HH:mm");
     private static final DateTimeFormatter HH_MM = DateTimeFormatter.ofPattern("HH:mm");
     private static final DateTimeFormatter HH_MM_SS = DateTimeFormatter.ofPattern("HH:mm:ss");
-
-    /**
-     * Format a timestamp as an ISO datetime at second resolution.
-     *
-     * <p>Deliberately {@link #ISO_DATETIME} rather than {@code DateTimeFormatter.ISO_DATE_TIME}:
-     * the latter appends a fractional-second part whenever the timestamp carries sub-second
-     * millis, and {@link #parseFlexible} -- the other half of every copy/paste round trip --
-     * accepts no fraction. Viewport bounds pick up arbitrary millis from pan/zoom pixel
-     * arithmetic, so that combination broke the round trip on any plot the user had touched.
-     * Second is the finest resolution this class renders, so the truncation costs nothing
-     * visible.</p>
-     */
-    public static String format(LocalDateTime dateTime) {
-        return dateTime.format(ISO_DATETIME);
-    }
-
-    /**
-     * Convenience overload taking a millisecond-epoch timestamp; converts to UTC LocalDateTime.
-     */
-    public static String format(long timestampMs) {
-        return format(toUtc(timestampMs));
-    }
 
     /**
      * Format a timestamp for resolution-aware display. Daily-or-coarser series (step_size

--- a/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
+++ b/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
@@ -38,6 +38,20 @@ public final class TimeFormatUtil {
     private static final DateTimeFormatter HH_MM_SS = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     /**
+     * Format a timestamp as an ISO datetime at second resolution.
+     */
+    public static String format(LocalDateTime dateTime) {
+        return dateTime.format(ISO_DATETIME);
+    }
+
+    /**
+     * Convenience overload taking a millisecond-epoch timestamp; converts to UTC LocalDateTime.
+     */
+    public static String format(long timestampMs) {
+        return format(toUtc(timestampMs));
+    }
+
+    /**
      * Format a timestamp for resolution-aware display. Daily-or-coarser series (step_size
      * is a multiple of 86400s) format as {@code yyyy-MM-dd}; sub-daily series format as
      * full ISO datetime. A step_size of 0 (unknown) defaults to date-only.

--- a/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
+++ b/kalixide/src/main/java/com/kalix/ide/utils/TimeFormatUtil.java
@@ -1,8 +1,10 @@
 package com.kalix.ide.utils;
 
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -32,13 +34,20 @@ public final class TimeFormatUtil {
 
     private static final DateTimeFormatter DATE_ONLY = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter ISO_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-    private static final DateTimeFormatter SPACE_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter MMDD_HHMM = DateTimeFormatter.ofPattern("MM-dd HH:mm");
     private static final DateTimeFormatter HH_MM = DateTimeFormatter.ofPattern("HH:mm");
     private static final DateTimeFormatter HH_MM_SS = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     /**
      * Format a timestamp as an ISO datetime at second resolution.
+     *
+     * <p>Deliberately {@link #ISO_DATETIME} rather than {@code DateTimeFormatter.ISO_DATE_TIME}:
+     * the latter appends a fractional-second part whenever the timestamp carries sub-second
+     * millis, and {@link #parseFlexible} -- the other half of every copy/paste round trip --
+     * accepts no fraction. Viewport bounds pick up arbitrary millis from pan/zoom pixel
+     * arithmetic, so that combination broke the round trip on any plot the user had touched.
+     * Second is the finest resolution this class renders, so the truncation costs nothing
+     * visible.</p>
      */
     public static String format(LocalDateTime dateTime) {
         return dateTime.format(ISO_DATETIME);
@@ -101,26 +110,88 @@ public final class TimeFormatUtil {
     }
 
     /**
-     * Parses user-entered text back into an epoch-millisecond timestamp (UTC), accepting
-     * whichever of the formats {@link #formatForStepSize} produces: {@code yyyy-MM-dd},
-     * {@code yyyy-MM-dd'T'HH:mm:ss}, or the same datetime with a space instead of {@code 'T'}.
+     * Parses user-entered date/time text into an epoch-millisecond timestamp (UTC).
      *
-     * @throws DateTimeParseException if the text matches none of the accepted formats
+     * <p>Deliberately permissive about what a modeller types, while everything this class
+     * <em>writes</em> stays canonical {@code yyyy-MM-dd[THH:mm:ss]}. Accepted:</p>
+     * <ul>
+     *   <li><b>Year first</b> — {@code 2024-02-01}, {@code 2024-2-1} (day and month may be
+     *       written with or without a leading zero)</li>
+     *   <li><b>Day first</b> — {@code 01-02-2024}, {@code 1-2-2024}</li>
+     *   <li><b>Separators</b> — {@code -}, {@code /} or {@code .}, e.g. {@code 1/2/2024}</li>
+     *   <li><b>Optional time</b> — after a {@code T} or a space: {@code HH:mm} or
+     *       {@code HH:mm:ss}. Omitted means midnight.</li>
+     * </ul>
+     *
+     * <p>Which end carries the year is what picks the order, so the two are never ambiguous:
+     * a 4-digit year leads, or it trails, or the text is rejected. That is also why 2-digit
+     * years are <em>not</em> accepted — {@code 01/02/03} has no reading this method could
+     * defend, and guessing one silently would put a run on the wrong dates. Day-first is
+     * read as day-month-year, not month-day-year: the platform's audience writes DMY, and
+     * with both orders in play {@code 01/02/2024} has to mean one thing.</p>
+     *
+     * @throws DateTimeParseException if the text matches none of the accepted formats, or
+     *         names a date that does not exist (e.g. {@code 2024-02-31})
      */
     public static long parseFlexible(String text) {
-        String trimmed = text.trim();
-        try {
-            return LocalDateTime.parse(trimmed, ISO_DATETIME).toInstant(ZoneOffset.UTC).toEpochMilli();
-        } catch (DateTimeParseException ignored) {
-            // Not full ISO datetime — try the next format.
+        String trimmed = text == null ? "" : text.trim();
+        // 'T' is unambiguous as the date/time separator here: no accepted format spells a
+        // month or day with letters, so a T can only be the ISO one.
+        String[] halves = trimmed.split("[Tt\\s]+", 2);
+        LocalDate date = parseDatePart(halves[0], trimmed);
+        LocalTime time = halves.length > 1 ? parseTimePart(halves[1], trimmed) : LocalTime.MIDNIGHT;
+        return LocalDateTime.of(date, time).toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    /**
+     * Parses the date half: three numbers separated by {@code -}, {@code /} or {@code .},
+     * with the 4-digit year either leading (year-month-day) or trailing (day-month-year).
+     */
+    private static LocalDate parseDatePart(String datePart, String original) {
+        String[] fields = datePart.split("[-/.]");
+        if (fields.length != 3) {
+            throw parseFailure(original);
         }
         try {
-            return LocalDateTime.parse(trimmed, SPACE_DATETIME).toInstant(ZoneOffset.UTC).toEpochMilli();
-        } catch (DateTimeParseException ignored) {
-            // Not space-separated datetime — try date-only. Let this last attempt's
-            // exception (if any) propagate, since there is no further format to fall back to.
+            int first = Integer.parseInt(fields[0]);
+            int month = Integer.parseInt(fields[1]);
+            int last = Integer.parseInt(fields[2]);
+            if (fields[0].length() == 4) {
+                return LocalDate.of(first, month, last);
+            }
+            if (fields[2].length() == 4) {
+                return LocalDate.of(last, month, first);
+            }
+            // Neither end is a 4-digit year, so there is nothing to anchor the order on.
+            throw parseFailure(original);
+        } catch (NumberFormatException | DateTimeException e) {
+            throw parseFailure(original);
         }
-        return LocalDate.parse(trimmed, DATE_ONLY).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    /**
+     * Parses the optional time half: {@code HH:mm} or {@code HH:mm:ss}. Sub-second parts are
+     * rejected — nothing in this class writes them, and second is its finest resolution.
+     */
+    private static LocalTime parseTimePart(String timePart, String original) {
+        String[] fields = timePart.split(":");
+        if (fields.length < 2 || fields.length > 3) {
+            throw parseFailure(original);
+        }
+        try {
+            int hour = Integer.parseInt(fields[0]);
+            int minute = Integer.parseInt(fields[1]);
+            int second = fields.length == 3 ? Integer.parseInt(fields[2]) : 0;
+            return LocalTime.of(hour, minute, second);
+        } catch (NumberFormatException | DateTimeException e) {
+            throw parseFailure(original);
+        }
+    }
+
+    private static DateTimeParseException parseFailure(String text) {
+        return new DateTimeParseException(
+            "Expected a date like 2024-02-01 or 01-02-2024, optionally followed by HH:mm[:ss], "
+                + "but got \"" + text + "\"", text, 0);
     }
 
     private static LocalDateTime toUtc(long timestampMs) {

--- a/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/LastRunTracker.java
@@ -2,6 +2,7 @@ package com.kalix.ide.windows;
 
 import com.kalix.ide.components.JCheckboxTree;
 import com.kalix.ide.flowviz.data.LastSeries;
+import com.kalix.ide.flowviz.data.LastSource;
 import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.flowviz.data.TimeSeriesData;
 import com.kalix.ide.managers.TimeSeriesRequestManager;
@@ -168,8 +169,15 @@ class LastRunTracker {
             wasLastChecked = timeseriesSourceTree.isPathChecked(oldLastPath);
         }
 
-        // If Last was checked, block all checked-state events during the entire update
-        if (wasLastChecked) {
+        // The active tab may record "Last run" as a checked source without the tree
+        // showing it checked — that is exactly the state a default tab is in before the
+        // first run of the session, when there is no Last node to check yet. Honour the
+        // tab's recorded context so Last lights up the moment it exists.
+        boolean checkLast = wasLastChecked
+            || tabManager.getTargetTabCheckedSources().contains(new LastSource());
+
+        // If Last is to be checked, block all checked-state events during the entire update
+        if (checkLast) {
             fetchCoordinator.beginProgrammaticUpdate();
         }
         try {
@@ -199,8 +207,8 @@ class LastRunTracker {
                 treeModel.nodesWereInserted(lastRunNode, new int[]{0});
             }
 
-            // If Last was previously checked, rebuild the timeseries tree to show new outputs
-            if (wasLastChecked) {
+            // If Last is checked, rebuild the timeseries tree to show its outputs
+            if (checkLast) {
                 TreePath newLastPath = new TreePath(lastRunChildNode.getPath());
 
                 // Check the new Last node so its outputs are picked up below
@@ -218,7 +226,7 @@ class LastRunTracker {
                 window.reconcileCheckedSeriesWithTree(restoredSeries, tabSeries);
             }
         } finally {
-            if (wasLastChecked) {
+            if (checkLast) {
                 fetchCoordinator.endProgrammaticUpdate();
             }
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -237,11 +237,12 @@ class PlotToolbarBuilder {
             boolean enabled = autoYToggle.isSelected();
             plotPanel.setAutoYMode(enabled);
             PreferenceKeys.FLOWVIZ_AUTO_Y_MODE.set(enabled);
-            if (enabled) {
-                // Fit Y-axis to visible data in current X range (don't change X zoom)
-                plotPanel.fitYAxis();
-            }
         });
+
+        // Follow changes made elsewhere (context menu, explicit axis limits). Only the
+        // toolbar records the preference: those paths change this plot, not the default.
+        plotPanel.setOnAutoYModeChanged(() -> autoYToggle.setSelected(plotPanel.isAutoYMode()));
+
         toolbar.add(autoYToggle);
         return this;
     }

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -31,6 +31,10 @@ class PlotToolbarBuilder {
     static final Dimension WIDE_DROPDOWN_SIZE = new Dimension(150, 25);
     static final Dimension NARROW_DROPDOWN_SIZE = new Dimension(80, 25);
     static final int HORIZONTAL_SPACING = 5;
+    // Shared square footprint for every icon/toggle button on this toolbar, so save,
+    // undo/redo, palette, mask, auto-Y, coordinates and legend all line up identically
+    // rather than each sizing itself off its own icon/border combination.
+    static final Dimension BUTTON_SIZE = new Dimension(28, 28);
 
     /**
      * Aggregation period options for time series data (shared with
@@ -296,6 +300,9 @@ class PlotToolbarBuilder {
         JButton button = new JButton(FontIcon.of(icon, BUTTON_ICON_SIZE));
         button.setToolTipText(tooltip);
         button.setFocusable(false);
+        button.setPreferredSize(BUTTON_SIZE);
+        button.setMinimumSize(BUTTON_SIZE);
+        button.setMaximumSize(BUTTON_SIZE);
         button.addActionListener(e -> action.run());
         return button;
     }
@@ -306,6 +313,9 @@ class PlotToolbarBuilder {
         button.setToolTipText(tooltip);
         button.setFocusable(false);
         button.setSelected(initialState);
+        button.setPreferredSize(BUTTON_SIZE);
+        button.setMinimumSize(BUTTON_SIZE);
+        button.setMaximumSize(BUTTON_SIZE);
         return button;
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -1055,9 +1055,36 @@ public class RunManager extends JFrame {
      * {@link #onSourceTreeCheckedChanged} — i.e. whenever the checked set genuinely
      * changes — and nowhere else: recording must stay tied to check <em>changes</em>,
      * never to restore paths like {@link #onTabChanged}.
+     *
+     * <p>A tree snapshot only replaces what the tree can currently express. A recorded ref
+     * with no tree path yet — the default tab's {@link LastSource} before the first run
+     * completes — is neither confirmed nor denied by the tree, so it is carried forward
+     * untouched; the tree gains a node for it later and the next snapshot takes over.
+     * Sources that have genuinely gone are scrubbed by {@link #removeSourceFromAllTabs},
+     * not here.</p>
      */
     private void snapshotSourceChecksToTargetTab() {
-        tabManager.setTargetTabCheckedSources(currentCheckedSourceRefs());
+        Set<SourceRef> recorded = tabManager.getTargetTabCheckedSources();
+        Set<SourceRef> snapshot = currentCheckedSourceRefs();
+        // Build the new set fully before recording it: the recorded set is a live view of
+        // the very set the setter replaces.
+        for (SourceRef ref : recorded) {
+            if (pathForSourceRef(ref) == null) {
+                snapshot.add(ref);
+            }
+        }
+        tabManager.setTargetTabCheckedSources(snapshot);
+    }
+
+    /** The subset of {@code refs} the source tree can currently show a node for. */
+    private Set<SourceRef> representable(Set<SourceRef> refs) {
+        Set<SourceRef> result = new LinkedHashSet<>();
+        for (SourceRef ref : refs) {
+            if (pathForSourceRef(ref) != null) {
+                result.add(ref);
+            }
+        }
+        return result;
     }
 
     /**
@@ -1115,8 +1142,10 @@ public class RunManager extends JFrame {
         fetchCoordinator.beginProgrammaticUpdate();
         try {
             // Skip the rebuild when the contexts are identical: no outputs-tree churn
-            // when flicking between tabs that look at the same sources.
-            if (!tabSources.equals(currentCheckedSourceRefs())) {
+            // when flicking between tabs that look at the same sources. Compare only what
+            // the tree can show, or a ref with no node yet (see snapshotSourceChecksToTargetTab)
+            // would make the tab look different from the tree on every switch.
+            if (!representable(tabSources).equals(currentCheckedSourceRefs())) {
                 timeseriesSourceTree.setCheckedPaths(pathsForSourceRefs(tabSources));
                 updateOutputsTree();
             }

--- a/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/RunManager.java
@@ -414,9 +414,10 @@ public class RunManager extends JFrame {
         // Sync tree selection when user switches tabs
         tabManager.setOnTabChangedCallback(this::onTabChanged);
 
-        // Add default tabs (settings are applied by the tab manager)
-        tabManager.addPlotTab();
-        tabManager.addStatsTab();
+        // Add the default tab: one plot tab with "Last run" checked and nothing else.
+        // The same factory repopulates the strip when the final tab is closed, so a
+        // fresh window and a fully-cleared one look identical.
+        tabManager.addDefaultPlotTab();
     }
 
 
@@ -1103,7 +1104,7 @@ public class RunManager extends JFrame {
      * cross-contaminate; don't reintroduce one.)</p>
      */
     private void onTabChanged() {
-        // Adding the default tabs in createDetailsComponents() auto-selects the first tab,
+        // Adding the default tab in createDetailsComponents() auto-selects it,
         // firing this callback before initializeManagers() has constructed fetchCoordinator.
         // Nothing to sync during construction (the tree is empty), so bail out early.
         if (fetchCoordinator == null) return;

--- a/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/SeriesFetchCoordinator.java
@@ -128,7 +128,7 @@ class SeriesFetchCoordinator {
 
         TreePath[] checkedPaths = timeseriesTree.getCheckedPaths();
 
-        if (checkedPaths.length == 0) {
+        if (checkedPaths.length == 0 && !treeFilterManager.isFiltering()) {
             // Clear the target tab's series when nothing is checked
             tabManager.setTargetTabSelectedSeries(new LinkedHashSet<>());
             return;
@@ -142,7 +142,7 @@ class SeriesFetchCoordinator {
         }
 
         // If no valid leaves found, clear the target tab
-        if (allLeaves.isEmpty()) {
+        if (allLeaves.isEmpty() && !treeFilterManager.isFiltering()) {
             tabManager.setTargetTabSelectedSeries(new LinkedHashSet<>());
             return;
         }

--- a/kalixide/src/main/java/com/kalix/ide/windows/StatsToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/StatsToolbarBuilder.java
@@ -209,6 +209,9 @@ class StatsToolbarBuilder {
         JButton button = new JButton(FontIcon.of(icon, PlotToolbarBuilder.BUTTON_ICON_SIZE));
         button.setToolTipText(tooltip);
         button.setFocusable(false);
+        button.setPreferredSize(PlotToolbarBuilder.BUTTON_SIZE);
+        button.setMinimumSize(PlotToolbarBuilder.BUTTON_SIZE);
+        button.setMaximumSize(PlotToolbarBuilder.BUTTON_SIZE);
         button.addActionListener(e -> action.run());
         return button;
     }

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -710,34 +710,7 @@ public class VisualizationTabManager {
     private void setupTabContextMenu(JPanel tabPanel, TabInfo.TabType tabType, Component... labelComponents) {
         JPopupMenu contextMenu = new JPopupMenu();
 
-        // "New plot tab" menu item - always shown
-        JMenuItem addPlotItem = new JMenuItem("Duplicate plot");
-        addPlotItem.addActionListener(e -> {
-            // Find the TabInfo for this tab
-            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
-            if (tabIndex != -1 && tabIndex < tabs.size()) {
-                TabInfo sourceTab = tabs.get(tabIndex);
-
-                // Extract settings from source tab
-                TabSettings settings;
-                if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
-                    settings = TabSettings.fromPlotTab(sourceTab);
-                } else if (sourceTab.type == TabInfo.TabType.STATS) {
-                    settings = TabSettings.fromStatsTab(sourceTab);
-                } else {
-                    settings = TabSettings.getDefaults();
-                }
-
-                // Create new plot tab with copied settings
-                addPlotTabFromSettings(settings);
-            } else {
-                // Fallback: create with default settings
-                addPlotTab();
-            }
-        });
-        contextMenu.add(addPlotItem);
-
-        // "New stats tab" menu item - always shown
+        // "New stats tab" menu item - context-specific to this tab, always shown
         JMenuItem addStatsItem = new JMenuItem("Show stats");
         addStatsItem.addActionListener(e -> {
             // Find the TabInfo for this tab
@@ -764,14 +737,16 @@ public class VisualizationTabManager {
         });
         contextMenu.add(addStatsItem);
 
-        JPopupMenu.Separator renameSeparator = new JPopupMenu.Separator();
-        contextMenu.add(renameSeparator);
+        // Modify block (manifesto §1/§7.1): Rename before Duplicate, isolated from the
+        // context-specific items above and the destructive item below.
+        JPopupMenu.Separator modifySeparator = new JPopupMenu.Separator();
+        contextMenu.add(modifySeparator);
 
-        JMenuItem renameTab = new JMenuItem("Rename");
+        JMenuItem renameTab = new JMenuItem("Rename…");
         renameTab.addActionListener(e -> {
             int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
             if (tabIndex != -1 && tabIndex < tabs.size()) {
-                TabInfo sourceTab = tabs.get(tabIndex);  
+                TabInfo sourceTab = tabs.get(tabIndex);
                 String currentName = sourceTab.name;
                 String newName = (String) JOptionPane.showInputDialog(
                     tabbedPane,
@@ -789,6 +764,32 @@ public class VisualizationTabManager {
             }
         });
         contextMenu.add(renameTab);
+
+        JMenuItem addPlotItem = new JMenuItem("Duplicate plot");
+        addPlotItem.addActionListener(e -> {
+            // Find the TabInfo for this tab
+            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
+            if (tabIndex != -1 && tabIndex < tabs.size()) {
+                TabInfo sourceTab = tabs.get(tabIndex);
+
+                // Extract settings from source tab
+                TabSettings settings;
+                if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
+                    settings = TabSettings.fromPlotTab(sourceTab);
+                } else if (sourceTab.type == TabInfo.TabType.STATS) {
+                    settings = TabSettings.fromStatsTab(sourceTab);
+                } else {
+                    settings = TabSettings.getDefaults();
+                }
+
+                // Create new plot tab with copied settings
+                addPlotTabFromSettings(settings);
+            } else {
+                // Fallback: create with default settings
+                addPlotTab();
+            }
+        });
+        contextMenu.add(addPlotItem);
 
         // "Remove" menu item - only shown if there is more than one tab. The destructive action
         // is isolated in its own block (manifesto §1); the separator is toggled with the item so

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -502,7 +502,6 @@ public class VisualizationTabManager {
         return builder.build();
     }
 
-
     /**
      * Creates a toolbar for a stats tab.
      */
@@ -687,6 +686,7 @@ public class VisualizationTabManager {
 
         // Add context menu support
         setupTabContextMenu(tabPanel, tabType, iconLabel, nameLabel, labelPanel);
+        setupTabDoubleClickRename(tabPanel, iconLabel, nameLabel, labelPanel);
         tabInfo.registerNameLabel(nameLabel);
     }
 
@@ -710,7 +710,6 @@ public class VisualizationTabManager {
     private void setupTabContextMenu(JPanel tabPanel, TabInfo.TabType tabType, Component... labelComponents) {
         JPopupMenu contextMenu = new JPopupMenu();
         boolean isPlot = tabType == TabInfo.TabType.PLOT;
-
         // "New stats tab" menu item - same-type "Duplicate" on a stats tab, cross-type
         // "Show as" on a plot tab (manifesto §2.2: one verb per concept).
         JMenuItem addStatsItem = new JMenuItem(isPlot ? "Show stats" : "Duplicate stats");
@@ -777,24 +776,7 @@ public class VisualizationTabManager {
 
         JMenuItem renameTab = new JMenuItem("Rename…");
         renameTab.addActionListener(e -> {
-            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
-            if (tabIndex != -1 && tabIndex < tabs.size()) {
-                TabInfo sourceTab = tabs.get(tabIndex);
-                String currentName = sourceTab.name;
-                String newName = (String) JOptionPane.showInputDialog(
-                    tabbedPane,
-                    "Enter new name for tab '" + currentName + "':",
-                    "Rename tab",
-                    JOptionPane.PLAIN_MESSAGE,
-                    null,
-                    null,
-                    currentName
-                );
-                if (newName != null && !newName.isBlank()) {
-                    sourceTab.rename(newName);
-                    tabbedPane.setTitleAt(tabIndex, newName);
-                }
-            }
+            triggerTabRename(tabPanel);
         });
         contextMenu.add(renameTab);
 
@@ -854,6 +836,46 @@ public class VisualizationTabManager {
 
         for (Component labelComponent : labelComponents) {
             labelComponent.addMouseListener(popupListener);
+        }
+    }
+
+    /**
+     * Sets up double-click-to-rename on a tab. Mirrors {@link #setupTabContextMenu}: the
+     * listener is attached to every {@code labelComponents} entry (icon, name, wrapper
+     * panel) since mouse events dispatch to whichever of them is deepest under the cursor.
+     */
+    private void setupTabDoubleClickRename(JPanel tabPanel, Component... labelComponents) {
+        MouseAdapter doubleClickListener = new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2 && javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+                    triggerTabRename(tabPanel);
+                }
+            }
+        };
+        for (Component labelComponent : labelComponents) {
+            labelComponent.addMouseListener(doubleClickListener);
+        }
+    }
+
+    private void triggerTabRename(javax.swing.JPanel tabPanel) {
+        int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
+        if (tabIndex != -1 && tabIndex < tabs.size()) {
+            com.kalix.ide.windows.VisualizationTabManager.TabInfo sourceTab = tabs.get(tabIndex);
+            String currentName = sourceTab.name;
+            String newName = (String) javax.swing.JOptionPane.showInputDialog(
+                tabbedPane,
+                "Enter new name for tab '" + currentName + "':",
+                "Rename tab",
+                javax.swing.JOptionPane.PLAIN_MESSAGE,
+                null,
+                null,
+                currentName
+            );
+            if (newName != null && !newName.isBlank()) {
+                sourceTab.rename(newName);
+                tabbedPane.setTitleAt(tabIndex, newName);
+            }
         }
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -666,7 +666,7 @@ public class VisualizationTabManager {
         JPopupMenu contextMenu = new JPopupMenu();
 
         // "New plot tab" menu item - always shown
-        JMenuItem addPlotItem = new JMenuItem("New plot tab");
+        JMenuItem addPlotItem = new JMenuItem("Duplicate plot");
         addPlotItem.addActionListener(e -> {
             // Find the TabInfo for this tab
             int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
@@ -693,7 +693,7 @@ public class VisualizationTabManager {
         contextMenu.add(addPlotItem);
 
         // "New stats tab" menu item - always shown
-        JMenuItem addStatsItem = new JMenuItem("New stats tab");
+        JMenuItem addStatsItem = new JMenuItem("Show stats");
         addStatsItem.addActionListener(e -> {
             // Find the TabInfo for this tab
             int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -18,10 +18,12 @@ import com.formdev.flatlaf.FlatClientProperties;
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
 import org.kordamp.ikonli.swing.FontIcon;
 
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -100,6 +102,18 @@ public class VisualizationTabManager {
     private static class UIConstants {
         static final int TAB_ICON_SIZE = 14;
         static final int TAB_PANEL_PADDING = 2;
+        // Gap between the tab icon and its name label — collapsed to 0 when the name is
+        // empty so an unnamed tab doesn't show a dangling space after the icon.
+        static final int TAB_NAME_LABEL_GAP = 4;
+    }
+
+    /**
+     * Pads {@code nameLabel} on its leading edge so it sits clear of the tab icon, unless
+     * the name is empty — an unnamed tab then shows just the icon, with no trailing gap.
+     */
+    private static void updateNameLabelPadding(JLabel nameLabel) {
+        boolean hasName = nameLabel.getText() != null && !nameLabel.getText().isEmpty();
+        nameLabel.setBorder(BorderFactory.createEmptyBorder(0, hasName ? UIConstants.TAB_NAME_LABEL_GAP : 0, 0, 0));
     }
 
     /**
@@ -221,6 +235,7 @@ public class VisualizationTabManager {
         void rename(String name) {
             this.name = name;
             this.nameLabel.setText(name);
+            updateNameLabelPadding(this.nameLabel);
         }
 
         void registerNameLabel(JLabel nameLabel) {
@@ -659,6 +674,7 @@ public class VisualizationTabManager {
         tooltip = tabInfo.name;
 
         JLabel nameLabel = new JLabel(tabInfo.name);
+        updateNameLabelPadding(nameLabel);
         JLabel iconLabel = new JLabel(tabIcon);
         iconLabel.setToolTipText(tooltip);
 
@@ -750,6 +766,32 @@ public class VisualizationTabManager {
             }
         });
         contextMenu.add(addStatsItem);
+
+        JPopupMenu.Separator renameSeparator = new JPopupMenu.Separator();
+        contextMenu.add(renameSeparator);
+
+        JMenuItem renameTab = new JMenuItem("Rename");
+        renameTab.addActionListener(e -> {
+            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
+            if (tabIndex != -1 && tabIndex < tabs.size()) {
+                TabInfo sourceTab = tabs.get(tabIndex);  
+                String currentName = sourceTab.name;
+                String newName = (String) JOptionPane.showInputDialog(
+                    tabbedPane,
+                    "Enter new name for tab '" + currentName + "':",
+                    "Rename tab",
+                    JOptionPane.PLAIN_MESSAGE,
+                    null,
+                    null,
+                    currentName
+                );
+                if (newName != null && !newName.isBlank()) {
+                    sourceTab.rename(newName);
+                    tabbedPane.setTitleAt(tabIndex, newName);
+                }
+            }
+        });
+        contextMenu.add(renameTab);
 
         // "Remove" menu item - only shown if there is more than one tab. The destructive action
         // is isolated in its own block (manifesto §1); the separator is toggled with the item so

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -735,83 +735,67 @@ public class VisualizationTabManager {
      * {@code labelComponents} entry (icon, name, wrapper panel) since mouse events dispatch to
      * whichever of them is deepest under the cursor.
      */
+    /**
+     * The settings of the tab behind {@code tabPanel}, for seeding a new tab from it.
+     * Falls back to the defaults if the tab can no longer be found, which is what a
+     * plain "add tab" starts from too.
+     */
+    private TabSettings settingsOfTab(JPanel tabPanel) {
+        int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
+        if (tabIndex == -1 || tabIndex >= tabs.size()) {
+            return TabSettings.getDefaults();
+        }
+        TabInfo sourceTab = tabs.get(tabIndex);
+        if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
+            return TabSettings.fromPlotTab(sourceTab);
+        }
+        if (sourceTab.type == TabInfo.TabType.STATS) {
+            return TabSettings.fromStatsTab(sourceTab);
+        }
+        return TabSettings.getDefaults();
+    }
+
     private void setupTabContextMenu(JPanel tabPanel, TabInfo.TabType tabType, Component... labelComponents) {
         JPopupMenu contextMenu = new JPopupMenu();
         boolean isPlot = tabType == TabInfo.TabType.PLOT;
-        // "New stats tab" menu item - same-type "Duplicate" on a stats tab, cross-type
-        // "Show as" on a plot tab (manifesto §2.2: one verb per concept).
-        JMenuItem addStatsItem = new JMenuItem(isPlot ? "Show stats" : "Duplicate stats");
-        addStatsItem.addActionListener(e -> {
-            // Find the TabInfo for this tab
-            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
-            if (tabIndex != -1 && tabIndex < tabs.size()) {
-                TabInfo sourceTab = tabs.get(tabIndex);
 
-                // Extract settings from source tab
-                TabSettings settings;
-                if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
-                    settings = TabSettings.fromPlotTab(sourceTab);
-                } else if (sourceTab.type == TabInfo.TabType.STATS) {
-                    settings = TabSettings.fromStatsTab(sourceTab);
-                } else {
-                    settings = TabSettings.getDefaults();
-                }
+        // Primary block (context-menu-style §1 ①): the default action, which on a tab is
+        // what double-click does (setupTabDoubleClickRename). Ellipsis: opens a dialog (§2.4).
+        JMenuItem renameItem = new JMenuItem("Rename…");
+        renameItem.addActionListener(e -> triggerTabRename(tabPanel));
+        contextMenu.add(renameItem);
 
-                // Create new stats tab with copied settings
+        contextMenu.addSeparator();
+
+        // Create block (§1 ④), in the sanctioned verbless "New …" form (§2.2). The new tab
+        // is of the other type and starts from this tab's settings, as Duplicate does.
+        JMenuItem newOtherTypeItem = new JMenuItem(isPlot ? "New stats tab" : "New plot tab");
+        newOtherTypeItem.addActionListener(e -> {
+            TabSettings settings = settingsOfTab(tabPanel);
+            if (isPlot) {
                 addStatsTabFromSettings(settings);
             } else {
-                // Fallback: create with default settings
-                addStatsTab();
+                addPlotTabFromSettings(settings);
             }
         });
+        contextMenu.add(newOtherTypeItem);
 
-        // "New plot tab" menu item - same-type "Duplicate" on a plot tab, cross-type
-        // "Show as" on a stats tab.
-        JMenuItem addPlotItem = new JMenuItem(isPlot ? "Duplicate plot" : "Show as plot");
-        addPlotItem.addActionListener(e -> {
-            // Find the TabInfo for this tab
-            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
-            if (tabIndex != -1 && tabIndex < tabs.size()) {
-                TabInfo sourceTab = tabs.get(tabIndex);
+        contextMenu.addSeparator();
 
-                // Extract settings from source tab
-                TabSettings settings;
-                if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
-                    settings = TabSettings.fromPlotTab(sourceTab);
-                } else if (sourceTab.type == TabInfo.TabType.STATS) {
-                    settings = TabSettings.fromStatsTab(sourceTab);
-                } else {
-                    settings = TabSettings.getDefaults();
-                }
-
-                // Create new plot tab with copied settings
+        // Modify block (§1 ⑤). "Duplicate" names no type: the tab is the context (§2.3).
+        // Reset changes the tab's state rather than its existence, so it belongs here and
+        // not with Remove -- §1 ⑥ and §2.5 isolate Remove/Delete only -- even though a
+        // reset is not undoable.
+        JMenuItem duplicateItem = new JMenuItem("Duplicate");
+        duplicateItem.addActionListener(e -> {
+            TabSettings settings = settingsOfTab(tabPanel);
+            if (isPlot) {
                 addPlotTabFromSettings(settings);
             } else {
-                // Fallback: create with default settings
-                addPlotTab();
+                addStatsTabFromSettings(settings);
             }
         });
-
-        // Context-specific block (manifesto §1 ②): the cross-type "Show as" item — the one
-        // that does *not* match this tab's own type — goes first.
-        contextMenu.add(isPlot ? addStatsItem : addPlotItem);
-
-        // Modify block (manifesto §1/§7.1 ⑤): Rename before Duplicate, isolated from the
-        // context-specific item above and the destructive item below. "Duplicate" here is
-        // whichever item matches this tab's own type.
-        JPopupMenu.Separator modifySeparator = new JPopupMenu.Separator();
-        contextMenu.add(modifySeparator);
-
-        JMenuItem renameTab = new JMenuItem("Rename…");
-        renameTab.addActionListener(e -> {
-            triggerTabRename(tabPanel);
-        });
-        contextMenu.add(renameTab);
-
-        contextMenu.add(isPlot ? addPlotItem : addStatsItem);
-
-        // The destructive actions are isolated to their own block (manifesto §1).
-        contextMenu.add(new JPopupMenu.Separator());
+        contextMenu.add(duplicateItem);
 
         JMenuItem resetItem = new JMenuItem("Reset");
         resetItem.addActionListener(e -> {
@@ -822,6 +806,10 @@ public class VisualizationTabManager {
         });
         contextMenu.add(resetItem);
 
+        contextMenu.addSeparator();
+
+        // Destructive block (§1 ⑥), alone. "Remove", not "Delete": a tab is a view onto
+        // data that stays put (§2.5).
         JMenuItem removeItem = new JMenuItem("Remove");
         removeItem.addActionListener(e -> {
             int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -662,7 +662,7 @@ public class VisualizationTabManager {
     /**
      * Sets up context menu for tab right-click.
      */
-    private void setupTabContextMenu(JPanel tabPanel, JLabel label, TabInfo.TabType tabType) {
+    private void setupTabContextMenu(JPanel tabPanel, Component labelComponent, TabInfo.TabType tabType) {
         JPopupMenu contextMenu = new JPopupMenu();
 
         // "New plot tab" menu item - always shown
@@ -763,7 +763,7 @@ public class VisualizationTabManager {
             }
         };
 
-        label.addMouseListener(popupListener);
+        labelComponent.addMouseListener(popupListener);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -107,6 +107,9 @@ public class VisualizationTabManager {
      * Makes it explicit what settings are shareable and provides a clean interface for copying.
      */
     public static class TabSettings {
+        // Tab name copied from the source tab when duplicating (null = leave the new tab unnamed)
+        public String name = null;
+
         // Aggregation settings (common to both plot and stats tabs)
         public AggregationPeriod aggregationPeriod = AggregationPeriod.ORIGINAL;
         public AggregationMethod aggregationMethod = AggregationMethod.SUM;
@@ -137,6 +140,7 @@ public class VisualizationTabManager {
         public static TabSettings fromPlotTab(TabInfo tabInfo) {
             PlotPanel plotPanel = tabInfo.plotPanel;
             TabSettings settings = new TabSettings();
+            settings.name = tabInfo.name;
             settings.aggregationPeriod = plotPanel.getAggregationPeriod();
             settings.aggregationMethod = plotPanel.getAggregationMethod();
             settings.plotType = plotPanel.getPlotType();
@@ -157,6 +161,7 @@ public class VisualizationTabManager {
          */
         public static TabSettings fromStatsTab(TabInfo statsTabInfo) {
             TabSettings settings = new TabSettings();
+            settings.name = statsTabInfo.name;
             settings.aggregationPeriod = statsTabInfo.statsPeriod;
             settings.aggregationMethod = statsTabInfo.statsMethod;
             settings.selectedSeries = new LinkedHashSet<>(statsTabInfo.selectedSeries);
@@ -428,7 +433,8 @@ public class VisualizationTabManager {
         containerPanel.add(plotPanel, BorderLayout.CENTER);
 
         // Add tab with inherited series selection and source context
-        TabInfo tabInfo = new TabInfo(TabInfo.TabType.PLOT, "Plot", containerPanel, plotPanel, null);
+        TabInfo tabInfo = new TabInfo(
+            TabInfo.TabType.PLOT, settings.name != null ? settings.name : "", containerPanel, plotPanel, null);
         tabInfo.selectedSeries.addAll(inheritedSeries);
         tabInfo.checkedSources.addAll(inheritedSources(settings));
         tabs.add(tabInfo);
@@ -588,7 +594,8 @@ public class VisualizationTabManager {
         JPanel containerPanel = new JPanel(new BorderLayout());
 
         // Create tab info so we can reference it in toolbar builder
-        TabInfo tabInfo = new TabInfo(TabInfo.TabType.STATS, "Statistics", containerPanel, null, model);
+        TabInfo tabInfo = new TabInfo(
+            TabInfo.TabType.STATS, settings.name != null ? settings.name : "", containerPanel, null, model);
 
         // Apply aggregation settings from TabSettings
         tabInfo.statsPeriod = settings.aggregationPeriod;

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -709,9 +709,11 @@ public class VisualizationTabManager {
      */
     private void setupTabContextMenu(JPanel tabPanel, TabInfo.TabType tabType, Component... labelComponents) {
         JPopupMenu contextMenu = new JPopupMenu();
+        boolean isPlot = tabType == TabInfo.TabType.PLOT;
 
-        // "New stats tab" menu item - context-specific to this tab, always shown
-        JMenuItem addStatsItem = new JMenuItem("Show stats");
+        // "New stats tab" menu item - same-type "Duplicate" on a stats tab, cross-type
+        // "Show as" on a plot tab (manifesto §2.2: one verb per concept).
+        JMenuItem addStatsItem = new JMenuItem(isPlot ? "Show stats" : "Duplicate stats");
         addStatsItem.addActionListener(e -> {
             // Find the TabInfo for this tab
             int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
@@ -735,10 +737,41 @@ public class VisualizationTabManager {
                 addStatsTab();
             }
         });
-        contextMenu.add(addStatsItem);
 
-        // Modify block (manifesto §1/§7.1): Rename before Duplicate, isolated from the
-        // context-specific items above and the destructive item below.
+        // "New plot tab" menu item - same-type "Duplicate" on a plot tab, cross-type
+        // "Show as" on a stats tab.
+        JMenuItem addPlotItem = new JMenuItem(isPlot ? "Duplicate plot" : "Show as plot");
+        addPlotItem.addActionListener(e -> {
+            // Find the TabInfo for this tab
+            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
+            if (tabIndex != -1 && tabIndex < tabs.size()) {
+                TabInfo sourceTab = tabs.get(tabIndex);
+
+                // Extract settings from source tab
+                TabSettings settings;
+                if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
+                    settings = TabSettings.fromPlotTab(sourceTab);
+                } else if (sourceTab.type == TabInfo.TabType.STATS) {
+                    settings = TabSettings.fromStatsTab(sourceTab);
+                } else {
+                    settings = TabSettings.getDefaults();
+                }
+
+                // Create new plot tab with copied settings
+                addPlotTabFromSettings(settings);
+            } else {
+                // Fallback: create with default settings
+                addPlotTab();
+            }
+        });
+
+        // Context-specific block (manifesto §1 ②): the cross-type "Show as" item — the one
+        // that does *not* match this tab's own type — goes first.
+        contextMenu.add(isPlot ? addStatsItem : addPlotItem);
+
+        // Modify block (manifesto §1/§7.1 ⑤): Rename before Duplicate, isolated from the
+        // context-specific item above and the destructive item below. "Duplicate" here is
+        // whichever item matches this tab's own type.
         JPopupMenu.Separator modifySeparator = new JPopupMenu.Separator();
         contextMenu.add(modifySeparator);
 
@@ -765,31 +798,7 @@ public class VisualizationTabManager {
         });
         contextMenu.add(renameTab);
 
-        JMenuItem addPlotItem = new JMenuItem("Duplicate plot");
-        addPlotItem.addActionListener(e -> {
-            // Find the TabInfo for this tab
-            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
-            if (tabIndex != -1 && tabIndex < tabs.size()) {
-                TabInfo sourceTab = tabs.get(tabIndex);
-
-                // Extract settings from source tab
-                TabSettings settings;
-                if (sourceTab.type == TabInfo.TabType.PLOT && sourceTab.plotPanel != null) {
-                    settings = TabSettings.fromPlotTab(sourceTab);
-                } else if (sourceTab.type == TabInfo.TabType.STATS) {
-                    settings = TabSettings.fromStatsTab(sourceTab);
-                } else {
-                    settings = TabSettings.getDefaults();
-                }
-
-                // Create new plot tab with copied settings
-                addPlotTabFromSettings(settings);
-            } else {
-                // Fallback: create with default settings
-                addPlotTab();
-            }
-        });
-        contextMenu.add(addPlotItem);
+        contextMenu.add(isPlot ? addPlotItem : addStatsItem);
 
         // "Remove" menu item - only shown if there is more than one tab. The destructive action
         // is isolated in its own block (manifesto §1); the separator is toggled with the item so

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -646,23 +646,27 @@ public class VisualizationTabManager {
         setupTabDragAndDrop(label);
 
         // Add context menu support
-        setupTabContextMenu(tabPanel, label, tabType);
+        setupTabContextMenu(tabPanel, tabType, label);
     }
 
     /**
-     * Enables ghost-style drag-to-reorder for this tab. The label is the drag handle (custom tab
-     * components swallow the strip's mouse events); the shared reorderer paints the dragged-tab
-     * ghost and the theme-coloured insertion line, commits the move on drop via {@link #reorderTab},
-     * and selects the tab on a plain click.
+     * Enables ghost-style drag-to-reorder for this tab. The handles are the drag targets (custom
+     * tab components swallow the strip's mouse events); the shared reorderer paints the
+     * dragged-tab ghost and the theme-coloured insertion line, commits the move on drop via
+     * {@link #reorderTab}, and selects the tab on a plain click.
      */
-    private void setupTabDragAndDrop(Component handle) {
-        tabReorderer.attachToHandle(handle);
+    private void setupTabDragAndDrop(Component... handles) {
+        for (Component handle : handles) {
+            tabReorderer.attachToHandle(handle);
+        }
     }
 
     /**
-     * Sets up context menu for tab right-click.
+     * Sets up context menu for tab right-click. Built once and shared across every
+     * {@code labelComponents} entry (icon, name, wrapper panel) since mouse events dispatch to
+     * whichever of them is deepest under the cursor.
      */
-    private void setupTabContextMenu(JPanel tabPanel, Component labelComponent, TabInfo.TabType tabType) {
+    private void setupTabContextMenu(JPanel tabPanel, TabInfo.TabType tabType, Component... labelComponents) {
         JPopupMenu contextMenu = new JPopupMenu();
 
         // "New plot tab" menu item - always shown
@@ -763,7 +767,9 @@ public class VisualizationTabManager {
             }
         };
 
-        labelComponent.addMouseListener(popupListener);
+        for (Component labelComponent : labelComponents) {
+            labelComponent.addMouseListener(popupListener);
+        }
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -947,13 +947,7 @@ public class VisualizationTabManager {
      * Closes a tab at the given index.
      */
     private void closeTab(int index) {
-        // Clean up listeners before removing
-        TabInfo tab = tabs.get(index);
-        if (tab.type == TabInfo.TabType.PLOT && tab.plotPanel != null) {
-            tab.plotPanel.setOnHistoryChanged(null);
-            tab.plotPanel.getLegendManager().setOnCollapsedChanged(null);
-        }
-
+        detachTabCallbacks(tabs.get(index));
         tabs.remove(index);
         tabbedPane.removeTabAt(index);
 
@@ -961,6 +955,19 @@ public class VisualizationTabManager {
         // brand-new default tab rather than on a blank panel with no way forward.
         if (tabs.isEmpty()) {
             addDefaultPlotTab();
+        }
+    }
+
+    /**
+     * Detaches the toolbar callbacks a plot tab's toolbar installed on its panel. This
+     * is the owner's side of the contract with {@code PlotPanel.removeNotify()}, which
+     * leaves those callbacks alone so a re-parented tab keeps working; they are released
+     * here, when the tab is genuinely discarded (close, reset).
+     */
+    private void detachTabCallbacks(TabInfo tab) {
+        if (tab.type == TabInfo.TabType.PLOT && tab.plotPanel != null) {
+            tab.plotPanel.setOnHistoryChanged(null);
+            tab.plotPanel.getLegendManager().setOnCollapsedChanged(null);
         }
     }
 
@@ -978,11 +985,7 @@ public class VisualizationTabManager {
         TabInfo oldTab = tabs.get(index);
         TabInfo.TabType type = oldTab.type;
 
-        // Clean up listeners before removing (mirrors closeTab).
-        if (oldTab.type == TabInfo.TabType.PLOT && oldTab.plotPanel != null) {
-            oldTab.plotPanel.setOnHistoryChanged(null);
-            oldTab.plotPanel.getLegendManager().setOnCollapsedChanged(null);
-        }
+        detachTabCallbacks(oldTab);
         tabs.remove(index);
         tabbedPane.removeTabAt(index);
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -259,6 +259,11 @@ public class VisualizationTabManager {
         this.tabbedPane.setTabPlacement(JTabbedPane.TOP);
         this.tabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
         this.tabReorderer = new TabDragReorderer(tabbedPane, this::reorderTab);
+        tabbedPane.putClientProperty("JTabbedPane.tabClosable", Boolean.TRUE);
+        tabbedPane.putClientProperty(
+            "JTabbedPane.tabCloseCallback",
+            (java.util.function.IntConsumer) this::closeTab
+        );
 
         // "New plot" affordance, pinned to the trailing edge of the tab strip rather
         // than added as a real tab: `tabs` is index-aligned with the tabbedPane, and a

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -665,18 +665,15 @@ public class VisualizationTabManager {
 
         // Create icon based on tab type
         FontIcon tabIcon;
-        String tooltip;
         if (tabType == TabInfo.TabType.PLOT) {
             tabIcon = FontIcon.of(FontAwesomeSolid.CHART_LINE, UIConstants.TAB_ICON_SIZE);
         } else {
             tabIcon = FontIcon.of(FontAwesomeSolid.CALCULATOR, UIConstants.TAB_ICON_SIZE);
         }
-        tooltip = tabInfo.name;
 
         JLabel nameLabel = new JLabel(tabInfo.name);
         updateNameLabelPadding(nameLabel);
         JLabel iconLabel = new JLabel(tabIcon);
-        iconLabel.setToolTipText(tooltip);
 
         labelPanel.add(iconLabel);
         labelPanel.add(nameLabel);

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -877,25 +877,42 @@ public class VisualizationTabManager {
         }
     }
 
-    private void triggerTabRename(javax.swing.JPanel tabPanel) {
+    /**
+     * Prompts for a new name for the tab whose handle is {@code tabPanel}, from the context
+     * menu or a double-click on the handle.
+     *
+     * <p>Cancelling leaves the name alone; submitting an empty box <em>clears</em> it. Unnamed
+     * is a legitimate state — it is what every new tab starts as, and {@link #setupTabIcon}
+     * and {@link #updateNameLabelPadding} render it as an icon-only handle — so clearing has
+     * to be reachable, or a tab named once could never be un-named.</p>
+     */
+    private void triggerTabRename(JPanel tabPanel) {
         int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
-        if (tabIndex != -1 && tabIndex < tabs.size()) {
-            com.kalix.ide.windows.VisualizationTabManager.TabInfo sourceTab = tabs.get(tabIndex);
-            String currentName = sourceTab.name;
-            String newName = (String) javax.swing.JOptionPane.showInputDialog(
-                tabbedPane,
-                "Enter new name for tab '" + currentName + "':",
-                "Rename tab",
-                javax.swing.JOptionPane.PLAIN_MESSAGE,
-                null,
-                null,
-                currentName
-            );
-            if (newName != null && !newName.isBlank()) {
-                sourceTab.rename(newName);
-                tabbedPane.setTitleAt(tabIndex, newName);
-            }
+        if (tabIndex == -1 || tabIndex >= tabs.size()) {
+            return;
         }
+        TabInfo sourceTab = tabs.get(tabIndex);
+        String currentName = sourceTab.name;
+        String prompt = currentName == null || currentName.isEmpty()
+            ? "Enter a name for this tab:"
+            : "Enter new name for tab '" + currentName + "':";
+
+        String newName = (String) JOptionPane.showInputDialog(
+            tabbedPane,
+            prompt,
+            "Rename tab",
+            JOptionPane.PLAIN_MESSAGE,
+            null,
+            null,
+            currentName
+        );
+        if (newName == null) {
+            return;
+        }
+
+        String trimmed = newName.trim();
+        sourceTab.rename(trimmed);
+        tabbedPane.setTitleAt(tabIndex, trimmed);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -800,11 +800,19 @@ public class VisualizationTabManager {
 
         contextMenu.add(isPlot ? addPlotItem : addStatsItem);
 
-        // "Remove" menu item - only shown if there is more than one tab. The destructive action
-        // is isolated in its own block (manifesto §1); the separator is toggled with the item so
-        // it never dangles when "Remove" is hidden.
+        // The destructive actions are isolated to their own block (manifesto §1); the
+        // separator is toggled with the item so it never dangles when "Remove" is hidden.
         JPopupMenu.Separator removeSeparator = new JPopupMenu.Separator();
         contextMenu.add(removeSeparator);
+
+        JMenuItem resetItem = new JMenuItem("Reset");
+        resetItem.addActionListener(e -> {
+            int tabIndex = tabbedPane.indexOfTabComponent(tabPanel);
+            if (tabIndex != -1) {
+                resetTabAt(tabIndex);
+            }
+        });
+        contextMenu.add(resetItem);
 
         JMenuItem removeItem = new JMenuItem("Remove");
         removeItem.addActionListener(e -> {
@@ -895,6 +903,47 @@ public class VisualizationTabManager {
 
         tabs.remove(index);
         tabbedPane.removeTabAt(index);
+    }
+
+    /**
+     * Resets the tab at {@code index} to a brand-new tab of the same type: default
+     * settings from preferences, no series selected, no checked sources — dropping all
+     * data selection and plot/stats configuration. Implemented as remove-then-recreate
+     * rather than clearing the existing tab's fields in place, so "reset" can never drift
+     * from what a genuinely new tab looks like.
+     */
+    private void resetTabAt(int index) {
+        if (index < 0 || index >= tabs.size()) {
+            return;
+        }
+        TabInfo oldTab = tabs.get(index);
+        TabInfo.TabType type = oldTab.type;
+
+        // Clean up listeners before removing (mirrors closeTab).
+        if (oldTab.type == TabInfo.TabType.PLOT && oldTab.plotPanel != null) {
+            oldTab.plotPanel.setOnHistoryChanged(null);
+            oldTab.plotPanel.getLegendManager().setOnCollapsedChanged(null);
+        }
+        tabs.remove(index);
+        tabbedPane.removeTabAt(index);
+
+        // Brand-new, unnamed tab with nothing selected and nothing inherited — always
+        // appended at the end by addPlotTabFromSettings/addStatsTabFromSettings, then
+        // moved back into the slot the old tab occupied so tab order is undisturbed.
+        TabSettings settings = TabSettings.getDefaults();
+        settings.selectedSeries = new LinkedHashSet<>();
+        settings.checkedSources = new LinkedHashSet<>();
+
+        if (type == TabInfo.TabType.PLOT) {
+            addPlotTabFromSettings(settings);
+        } else {
+            addStatsTabFromSettings(settings);
+        }
+
+        int newIndex = tabbedPane.getTabCount() - 1;
+        if (newIndex != index) {
+            reorderTab(newIndex, index);
+        }
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -4,6 +4,7 @@ import com.kalix.ide.components.TabDragReorderer;
 import com.kalix.ide.flowviz.PlotPanel;
 import com.kalix.ide.flowviz.data.DataSet;
 import com.kalix.ide.flowviz.data.LabelResolver;
+import com.kalix.ide.flowviz.data.LastSource;
 import com.kalix.ide.flowviz.data.SeriesRef;
 import com.kalix.ide.flowviz.data.SourceRef;
 import com.kalix.ide.flowviz.data.TimeSeriesData;
@@ -392,6 +393,28 @@ public class VisualizationTabManager {
     public PlotPanel addEmptyPlotTab() {
         TabSettings settings = TabSettings.getDefaults();
         settings.selectedSeries = new LinkedHashSet<>();
+        return addPlotTabFromSettings(settings);
+    }
+
+    /**
+     * Adds the <em>default</em> tab: a plot tab with the "Last run" source checked and
+     * nothing else — no other source, no series selected, settings straight from
+     * preferences.
+     *
+     * <p>This is what the visualization strip starts life as, and what it falls back to
+     * when the final tab is closed (see {@link #closeTab}), so the two paths can never
+     * drift apart. "Last run" is checked because it is the source a modeller almost
+     * always wants next; it is recorded as a {@link LastSource} ref rather than a tree
+     * path, so the tab picks the node up whenever it appears — including the first run
+     * of the session, which happens long after this tab is built.</p>
+     *
+     * @return The created PlotPanel
+     */
+    public PlotPanel addDefaultPlotTab() {
+        TabSettings settings = TabSettings.getDefaults();
+        settings.selectedSeries = new LinkedHashSet<>();
+        settings.checkedSources = new LinkedHashSet<>();
+        settings.checkedSources.add(new LastSource());
         return addPlotTabFromSettings(settings);
     }
 
@@ -787,10 +810,8 @@ public class VisualizationTabManager {
 
         contextMenu.add(isPlot ? addPlotItem : addStatsItem);
 
-        // The destructive actions are isolated to their own block (manifesto §1); the
-        // separator is toggled with the item so it never dangles when "Remove" is hidden.
-        JPopupMenu.Separator removeSeparator = new JPopupMenu.Separator();
-        contextMenu.add(removeSeparator);
+        // The destructive actions are isolated to their own block (manifesto §1).
+        contextMenu.add(new JPopupMenu.Separator());
 
         JMenuItem resetItem = new JMenuItem("Reset");
         resetItem.addActionListener(e -> {
@@ -810,7 +831,8 @@ public class VisualizationTabManager {
         });
         contextMenu.add(removeItem);
 
-        // Add popup listener to show menu and update "Remove" visibility
+        // Add popup listener to show the menu. "Remove" needs no guard: closing the
+        // final tab repopulates the strip with a default tab rather than emptying it.
         MouseAdapter popupListener = new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
@@ -827,14 +849,6 @@ public class VisualizationTabManager {
             }
 
             private void showContextMenu(MouseEvent e) {
-                // Count total tabs
-                int totalCount = tabs.size();
-
-                // Only show remove (and its separator) if there is more than one tab
-                boolean canRemove = totalCount > 1;
-                removeSeparator.setVisible(canRemove);
-                removeItem.setVisible(canRemove);
-
                 contextMenu.show(e.getComponent(), e.getX(), e.getY());
             }
         };
@@ -916,11 +930,6 @@ public class VisualizationTabManager {
      * Closes a tab at the given index.
      */
     private void closeTab(int index) {
-        // Safety check: don't close if it's the last tab
-        if (tabbedPane.getTabCount() <= 1) {
-            return;
-        }
-
         // Clean up listeners before removing
         TabInfo tab = tabs.get(index);
         if (tab.type == TabInfo.TabType.PLOT && tab.plotPanel != null) {
@@ -930,6 +939,12 @@ public class VisualizationTabManager {
 
         tabs.remove(index);
         tabbedPane.removeTabAt(index);
+
+        // The strip is never left empty: closing the final tab lands the user back on a
+        // brand-new default tab rather than on a blank panel with no way forward.
+        if (tabs.isEmpty()) {
+            addDefaultPlotTab();
+        }
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -640,9 +640,13 @@ public class VisualizationTabManager {
      */
     private void setupTabIcon(int index, TabInfo tabInfo) {
         TabInfo.TabType tabType = tabInfo.type;
+
+        // Create tab panel with the icon and name label
         JPanel tabPanel = new JPanel(new FlowLayout(FlowLayout.LEFT,
             UIConstants.TAB_PANEL_PADDING, UIConstants.TAB_PANEL_PADDING));
         tabPanel.setOpaque(false);
+        JPanel labelPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, UIConstants.TAB_PANEL_PADDING, 0));
+        labelPanel.setOpaque(false);
 
         // Create icon based on tab type
         FontIcon tabIcon;
@@ -654,18 +658,23 @@ public class VisualizationTabManager {
         }
         tooltip = tabInfo.name;
 
-        JLabel label = new JLabel(tabIcon);
-        label.setToolTipText(tooltip);
+        JLabel nameLabel = new JLabel(tabInfo.name);
+        JLabel iconLabel = new JLabel(tabIcon);
+        iconLabel.setToolTipText(tooltip);
 
-        tabPanel.add(label);
+        labelPanel.add(iconLabel);
+        labelPanel.add(nameLabel);
+
+        tabPanel.add(labelPanel);
 
         tabbedPane.setTabComponentAt(index, tabPanel);
 
         // Add drag-and-drop support for tab reordering
-        setupTabDragAndDrop(label);
+        setupTabDragAndDrop(iconLabel, nameLabel, labelPanel);
 
         // Add context menu support
-        setupTabContextMenu(tabPanel, tabType, label);
+        setupTabContextMenu(tabPanel, tabType, iconLabel, nameLabel, labelPanel);
+        tabInfo.registerNameLabel(nameLabel);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -184,7 +184,6 @@ public class VisualizationTabManager {
         enum TabType { PLOT, STATS }
 
         final TabType type;
-        final String name;
         final JComponent component;
         final PlotPanel plotPanel; // null for stats tabs
         final StatsTableModel statsModel; // null for plot tabs
@@ -201,12 +200,26 @@ public class VisualizationTabManager {
         AggregationPeriod statsPeriod = AggregationPeriod.ORIGINAL;
         AggregationMethod statsMethod = AggregationMethod.SUM;
 
+        // Tab user-supplied identifier
+        String name;
+        // remember the label for renaming
+        JLabel nameLabel;
+
         TabInfo(TabType type, String name, JComponent component, PlotPanel plotPanel, StatsTableModel statsModel) {
             this.type = type;
             this.name = name;
             this.component = component;
             this.plotPanel = plotPanel;
             this.statsModel = statsModel;
+        }
+
+        void rename(String name) {
+            this.name = name;
+            this.nameLabel.setText(name);
+        }
+
+        void registerNameLabel(JLabel nameLabel) {
+            this.nameLabel = nameLabel;
         }
     }
 
@@ -421,8 +434,8 @@ public class VisualizationTabManager {
         tabs.add(tabInfo);
 
         int index = tabbedPane.getTabCount();
-        tabbedPane.addTab("", containerPanel);
-        setupTabIcon(index, TabInfo.TabType.PLOT);
+        tabbedPane.addTab(tabInfo.name, containerPanel);
+        setupTabIcon(index, tabInfo);
 
         // Select the new tab (only when duplicating, not for initial default tabs)
         if (settings.selectedSeries != null) {
@@ -604,8 +617,8 @@ public class VisualizationTabManager {
         containerPanel.add(scrollPane, BorderLayout.CENTER);
 
         int index = tabbedPane.getTabCount();
-        tabbedPane.addTab("", containerPanel);
-        setupTabIcon(index, TabInfo.TabType.STATS);
+        tabbedPane.addTab(tabInfo.name, containerPanel);
+        setupTabIcon(index, tabInfo);
 
         // Select the new tab (only when duplicating, not for initial default tabs)
         if (settings.selectedSeries != null) {
@@ -618,8 +631,8 @@ public class VisualizationTabManager {
     /**
      * Sets up a tab with an icon and interaction handlers.
      */
-    private void setupTabIcon(int index, TabInfo.TabType tabType) {
-        // Create tab panel with just the icon
+    private void setupTabIcon(int index, TabInfo tabInfo) {
+        TabInfo.TabType tabType = tabInfo.type;
         JPanel tabPanel = new JPanel(new FlowLayout(FlowLayout.LEFT,
             UIConstants.TAB_PANEL_PADDING, UIConstants.TAB_PANEL_PADDING));
         tabPanel.setOpaque(false);
@@ -629,11 +642,10 @@ public class VisualizationTabManager {
         String tooltip;
         if (tabType == TabInfo.TabType.PLOT) {
             tabIcon = FontIcon.of(FontAwesomeSolid.CHART_LINE, UIConstants.TAB_ICON_SIZE);
-            tooltip = "Plot";
         } else {
             tabIcon = FontIcon.of(FontAwesomeSolid.CALCULATOR, UIConstants.TAB_ICON_SIZE);
-            tooltip = "Statistics";
         }
+        tooltip = tabInfo.name;
 
         JLabel label = new JLabel(tabIcon);
         label.setToolTipText(tooltip);

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -731,11 +731,6 @@ public class VisualizationTabManager {
     }
 
     /**
-     * Sets up context menu for tab right-click. Built once and shared across every
-     * {@code labelComponents} entry (icon, name, wrapper panel) since mouse events dispatch to
-     * whichever of them is deepest under the cursor.
-     */
-    /**
      * The settings of the tab behind {@code tabPanel}, for seeding a new tab from it.
      * Falls back to the defaults if the tab can no longer be found, which is what a
      * plain "add tab" starts from too.
@@ -755,6 +750,11 @@ public class VisualizationTabManager {
         return TabSettings.getDefaults();
     }
 
+    /**
+     * Sets up context menu for tab right-click. Built once and shared across every
+     * {@code labelComponents} entry (icon, name, wrapper panel) since mouse events dispatch to
+     * whichever of them is deepest under the cursor.
+     */
     private void setupTabContextMenu(JPanel tabPanel, TabInfo.TabType tabType, Component... labelComponents) {
         JPopupMenu contextMenu = new JPopupMenu();
         boolean isPlot = tabType == TabInfo.TabType.PLOT;
@@ -783,9 +783,9 @@ public class VisualizationTabManager {
         contextMenu.addSeparator();
 
         // Modify block (§1 ⑤). "Duplicate" names no type: the tab is the context (§2.3).
-        // Reset changes the tab's state rather than its existence, so it belongs here and
-        // not with Remove -- §1 ⑥ and §2.5 isolate Remove/Delete only -- even though a
-        // reset is not undoable.
+        // Reset changes the tab's state rather than its existence, so it is a modify
+        // action, not a destructive one, even though it is not undoable; the destructive
+        // block that §1 ⑥ and §8 isolate is Remove alone.
         JMenuItem duplicateItem = new JMenuItem("Duplicate");
         duplicateItem.addActionListener(e -> {
             TabSettings settings = settingsOfTab(tabPanel);

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -967,6 +967,7 @@ public class VisualizationTabManager {
     private void detachTabCallbacks(TabInfo tab) {
         if (tab.type == TabInfo.TabType.PLOT && tab.plotPanel != null) {
             tab.plotPanel.setOnHistoryChanged(null);
+            tab.plotPanel.setOnAutoYModeChanged(null);
             tab.plotPanel.getLegendManager().setOnCollapsedChanged(null);
         }
     }

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -655,8 +655,8 @@ public class VisualizationTabManager {
      * ghost and the theme-coloured insertion line, commits the move on drop via {@link #reorderTab},
      * and selects the tab on a plain click.
      */
-    private void setupTabDragAndDrop(JLabel label) {
-        tabReorderer.attachToHandle(label);
+    private void setupTabDragAndDrop(Component handle) {
+        tabReorderer.attachToHandle(handle);
     }
 
     /**

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisLimitCodecTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisLimitCodecTest.java
@@ -115,6 +115,22 @@ class AxisLimitCodecTest {
         }
     }
 
+    /**
+     * Math.round saturates at Long.MAX_VALUE instead of failing, so a finite value whose
+     * scaled form overflows a long would otherwise install a silently wrong bound.
+     */
+    @Test
+    void scaledEncodingsRejectValuesTheLongCannotHold() {
+        assertEquals("Not a valid number: \"1e13\"", assertThrows(IllegalArgumentException.class,
+            () -> AxisLimitCodec.parseX("1e13", XAxisType.NUMERIC)).getMessage());
+        assertEquals("Not a valid percentile: \"1e300%\"", assertThrows(IllegalArgumentException.class,
+            () -> AxisLimitCodec.parseX("1e300%", XAxisType.PERCENTILE)).getMessage());
+        assertEquals("Not a valid number: \"-1e13\"", assertThrows(IllegalArgumentException.class,
+            () -> AxisLimitCodec.parseX("-1e13", XAxisType.NUMERIC)).getMessage());
+        // Just inside the range still encodes.
+        assertEquals(9_000_000_000_000_000_000L, AxisLimitCodec.parseX("9e12", XAxisType.NUMERIC));
+    }
+
     // ---- COUNT ----
 
     @Test

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisLimitCodecTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisLimitCodecTest.java
@@ -1,0 +1,206 @@
+package com.kalix.ide.flowviz.rendering;
+
+import com.kalix.ide.flowviz.transform.PlotTypeTransformer;
+import com.kalix.ide.flowviz.transform.YAxisScale;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers {@link AxisLimitCodec}, the text &lt;-&gt; value codec behind the axis copy/paste
+ * commands and the Set-axis-limits dialog. The load-bearing property is that
+ * {@code parse(format(v)) == v} for every axis type, since that is what makes a copied
+ * pair paste back unchanged.
+ */
+class AxisLimitCodecTest {
+
+    private static final long MIDNIGHT = utc(2024, 1, 15, 0, 0, 0);
+    private static final long AFTERNOON = utc(2024, 1, 15, 14, 30, 0);
+
+    private static long utc(int y, int mo, int d, int h, int mi, int s) {
+        return LocalDateTime.of(y, mo, d, h, mi, s).toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    // ---- TIME ----
+
+    @Test
+    void timeFormatsMidnightAsDateOnly() {
+        assertEquals("2024-01-15", AxisLimitCodec.formatX(MIDNIGHT, XAxisType.TIME));
+    }
+
+    @Test
+    void timeFormatsOtherInstantsAsIsoDatetime() {
+        assertEquals("2024-01-15T14:30:00", AxisLimitCodec.formatX(AFTERNOON, XAxisType.TIME));
+    }
+
+    @Test
+    void timeRoundTripsAtBothResolutions() {
+        for (long value : new long[]{ MIDNIGHT, AFTERNOON }) {
+            assertEquals(value, AxisLimitCodec.parseX(AxisLimitCodec.formatX(value, XAxisType.TIME), XAxisType.TIME));
+        }
+    }
+
+    /**
+     * Pan and zoom leave viewport bounds on arbitrary millisecond values; the codec
+     * exchanges TIME bounds at second resolution, so the fraction is dropped rather than
+     * emitted in a form the parser refuses.
+     */
+    @Test
+    void timeSubSecondBoundFormatsAtSecondResolutionAndReparses() {
+        long withMillis = AFTERNOON + 123L;
+        String text = AxisLimitCodec.formatX(withMillis, XAxisType.TIME);
+        assertEquals("2024-01-15T14:30:00", text);
+        assertEquals(AFTERNOON, AxisLimitCodec.parseX(text, XAxisType.TIME));
+    }
+
+    @Test
+    void timeAcceptsDayFirstAndUnpaddedDates() {
+        assertEquals(MIDNIGHT, AxisLimitCodec.parseX("15/1/2024", XAxisType.TIME));
+        assertEquals(AFTERNOON, AxisLimitCodec.parseX("15-01-2024 14:30", XAxisType.TIME));
+    }
+
+    @Test
+    void timeRejectsUnparseableTextWithGuidance() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> AxisLimitCodec.parseX("yesterday", XAxisType.TIME));
+        assertEquals("Not a valid date/time: \"yesterday\" (expected 2024-02-01 or 01-02-2024, "
+            + "optionally with HH:mm[:ss])", ex.getMessage());
+    }
+
+    // ---- PERCENTILE ----
+
+    @Test
+    void percentileFormatsWithPercentSignAndRoundTrips() {
+        long encoded = Math.round(12.5 * PlotTypeTransformer.PERCENTILE_SCALE);
+        assertEquals("12.5%", AxisLimitCodec.formatX(encoded, XAxisType.PERCENTILE));
+        assertEquals(encoded, AxisLimitCodec.parseX("12.5%", XAxisType.PERCENTILE));
+        assertEquals(encoded, AxisLimitCodec.parseX("12.5", XAxisType.PERCENTILE));
+        assertEquals(encoded, AxisLimitCodec.parseX(" 12.5 % ", XAxisType.PERCENTILE));
+    }
+
+    @Test
+    void percentileWholeNumbersFormatWithoutDecimalNoise() {
+        assertEquals("50%", AxisLimitCodec.formatX(50 * PlotTypeTransformer.PERCENTILE_SCALE, XAxisType.PERCENTILE));
+    }
+
+    @Test
+    void percentileRejectsNonFiniteInput() {
+        for (String text : new String[]{ "NaN", "Infinity", "-Infinity", "NaN%" }) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> AxisLimitCodec.parseX(text, XAxisType.PERCENTILE), text);
+            assertEquals("Not a valid percentile: \"" + text + "\"", ex.getMessage());
+        }
+    }
+
+    // ---- NUMERIC ----
+
+    @Test
+    void numericRoundTripsThroughNumericScale() {
+        long encoded = Math.round(1234.5678 * PlotTypeTransformer.NUMERIC_SCALE);
+        assertEquals("1234.5678", AxisLimitCodec.formatX(encoded, XAxisType.NUMERIC));
+        assertEquals(encoded, AxisLimitCodec.parseX("1234.5678", XAxisType.NUMERIC));
+    }
+
+    @Test
+    void numericRejectsNonFiniteInput() {
+        for (String text : new String[]{ "NaN", "Infinity" }) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> AxisLimitCodec.parseX(text, XAxisType.NUMERIC), text);
+            assertEquals("Not a valid number: \"" + text + "\"", ex.getMessage());
+        }
+    }
+
+    // ---- COUNT ----
+
+    @Test
+    void countRoundTripsAsPlainInteger() {
+        assertEquals("42", AxisLimitCodec.formatX(42L, XAxisType.COUNT));
+        assertEquals(42L, AxisLimitCodec.parseX("42", XAxisType.COUNT));
+    }
+
+    @Test
+    void countRejectsFractions() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> AxisLimitCodec.parseX("4.2", XAxisType.COUNT));
+        assertEquals("Not a valid integer count: \"4.2\"", ex.getMessage());
+    }
+
+    // ---- blank X ----
+
+    @Test
+    void blankXIsRejectedForEveryAxisType() {
+        for (XAxisType type : XAxisType.values()) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> AxisLimitCodec.parseX("   ", type), type.name());
+            assertEquals("X value cannot be blank.", ex.getMessage());
+        }
+    }
+
+    // ---- Y ----
+
+    @Test
+    void yFormatsWholeNumbersWithoutDecimalNoise() {
+        assertEquals("0", AxisLimitCodec.formatY(0.0));
+        assertEquals("-300", AxisLimitCodec.formatY(-300.0));
+        assertEquals("0.25", AxisLimitCodec.formatY(0.25));
+    }
+
+    @Test
+    void yRoundTripsFullDoublePrecision() {
+        for (double value : new double[]{ 0.1 + 0.2, 1e-9, 123456789.123456789, 1e15, 1e300 }) {
+            assertEquals(value, AxisLimitCodec.parseY(AxisLimitCodec.formatY(value)));
+        }
+    }
+
+    @Test
+    void yRejectsNonFiniteBlankAndText() {
+        assertEquals("Y value cannot be blank.",
+            assertThrows(IllegalArgumentException.class, () -> AxisLimitCodec.parseY("")).getMessage());
+        for (String text : new String[]{ "NaN", "Infinity", "ten" }) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> AxisLimitCodec.parseY(text), text);
+            assertEquals("Not a valid number: \"" + text + "\"", ex.getMessage());
+        }
+    }
+
+    // ---- pairs ----
+
+    @Test
+    void splitPairTrimsAroundTheComma() {
+        assertArrayEquals(new String[]{ "a", "b" }, AxisLimitCodec.splitPair("  a ,b  "));
+    }
+
+    @Test
+    void splitPairRejectsAnythingButTwoValues() {
+        for (String text : new String[]{ "", "a", "a, b, c" }) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> AxisLimitCodec.splitPair(text), text);
+            assertEquals("Expected two comma-separated values but received \"" + text + "\"", ex.getMessage());
+        }
+    }
+
+    @Test
+    void pairsRoundTripThroughFormatAndSplit() {
+        assertEquals("2024-01-15, 2024-01-15T14:30:00", AxisLimitCodec.formatPair(
+            AxisLimitCodec.formatX(MIDNIGHT, XAxisType.TIME), AxisLimitCodec.formatX(AFTERNOON, XAxisType.TIME)));
+        assertArrayEquals(new long[]{ MIDNIGHT, AFTERNOON },
+            AxisLimitCodec.parseXLimits("2024-01-15, 2024-01-15T14:30:00", XAxisType.TIME));
+        assertArrayEquals(new double[]{ -1.5, 2.0 }, AxisLimitCodec.parseYLimits("-1.5, 2"));
+    }
+
+    @Test
+    void viewportLimitsFormatInTheViewportsOwnAxisUnits() {
+        ViewPort time = new ViewPort(MIDNIGHT, AFTERNOON, 0.0, 12.5, 0, 0, 100, 100, YAxisScale.LINEAR, XAxisType.TIME);
+        assertEquals("2024-01-15, 2024-01-15T14:30:00", AxisLimitCodec.formatXLimits(time));
+        assertEquals("0, 12.5", AxisLimitCodec.formatYLimits(time));
+
+        ViewPort percentile = new ViewPort(0L, 100 * PlotTypeTransformer.PERCENTILE_SCALE, 0.0, 1.0,
+            0, 0, 100, 100, YAxisScale.LINEAR, XAxisType.PERCENTILE);
+        assertEquals("0%, 100%", AxisLimitCodec.formatXLimits(percentile));
+    }
+}

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/ViewPortBoundsTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/ViewPortBoundsTest.java
@@ -1,0 +1,60 @@
+package com.kalix.ide.flowviz.rendering;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers {@link ViewPort#validateBounds}, the guard on user-supplied axis limits (the
+ * Set-axis-limits dialog and the axis paste commands).
+ */
+class ViewPortBoundsTest {
+
+    private static final long T0 = 1_705_276_800_000L;   // 2024-01-15T00:00:00Z
+    private static final long T1 = T0 + 86_400_000L;     // one day later
+
+    @Test
+    void acceptsIncreasingLimits() {
+        assertDoesNotThrow(() -> ViewPort.validateBounds(T0, T1, 0.0, 10.0));
+    }
+
+    @Test
+    void rejectsInvertedXRange() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ViewPort.validateBounds(T1, T0, 0.0, 10.0));
+        assertEquals("X min must be less than X max.", ex.getMessage());
+    }
+
+    @Test
+    void rejectsZeroWidthXRange() {
+        assertThrows(IllegalArgumentException.class, () -> ViewPort.validateBounds(T0, T0, 0.0, 10.0));
+    }
+
+    @Test
+    void rejectsInvertedYRange() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> ViewPort.validateBounds(T0, T1, 10.0, 0.0));
+        assertEquals("Y min must be less than Y max.", ex.getMessage());
+    }
+
+    @Test
+    void rejectsZeroHeightYRange() {
+        assertThrows(IllegalArgumentException.class, () -> ViewPort.validateBounds(T0, T1, 5.0, 5.0));
+    }
+
+    /**
+     * "NaN" and "Infinity" both parse as doubles, and NaN compares false against
+     * everything — so without the finite check they would slip past the ordering test.
+     */
+    @Test
+    void rejectsNonFiniteYLimits() {
+        assertThrows(IllegalArgumentException.class,
+            () -> ViewPort.validateBounds(T0, T1, Double.NaN, 10.0));
+        assertThrows(IllegalArgumentException.class,
+            () -> ViewPort.validateBounds(T0, T1, 0.0, Double.NaN));
+        assertThrows(IllegalArgumentException.class,
+            () -> ViewPort.validateBounds(T0, T1, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+    }
+}

--- a/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
@@ -112,4 +112,77 @@ class TimeFormatUtilTest {
     void parseFlexibleRejectsUnrecognisedText() {
         assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("not a date"));
     }
+
+    // ---- parseFlexible: input formats (issue #223) ----
+
+    @Test
+    void parseFlexibleAcceptsUnpaddedYearFirst() {
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("2024-1-15"));
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("2024-01-15"));
+    }
+
+    @Test
+    void parseFlexibleAcceptsDayFirst() {
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("15-01-2024"));
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("15-1-2024"));
+    }
+
+    /** Day-first is day-month-year, never month-day-year. */
+    @Test
+    void parseFlexibleReadsDayFirstAsDayMonthYear() {
+        assertEquals(TimeFormatUtil.parseFlexible("2024-02-01"), TimeFormatUtil.parseFlexible("01-02-2024"));
+    }
+
+    @Test
+    void parseFlexibleAcceptsSlashAndDotSeparators() {
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("2024/01/15"));
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("15/1/2024"));
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("15.01.2024"));
+    }
+
+    @Test
+    void parseFlexibleAcceptsTimeWithoutSeconds() {
+        assertEquals(MS_2024_01_15_14_30, TimeFormatUtil.parseFlexible("2024-01-15 14:30"));
+        assertEquals(MS_2024_01_15_14_30, TimeFormatUtil.parseFlexible("15/1/2024T14:30:00"));
+    }
+
+    /**
+     * The example from the issue: a range typed with unpadded day numbers, as one half of
+     * "2024-02-1, 2025-02-1".
+     */
+    @Test
+    void parseFlexibleAcceptsIssueExample() {
+        assertEquals(TimeFormatUtil.parseFlexible("2024-02-01"), TimeFormatUtil.parseFlexible("2024-02-1"));
+    }
+
+    @Test
+    void parseFlexibleRejectsTwoDigitYear() {
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("01/02/03"));
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("15-01-24"));
+    }
+
+    @Test
+    void parseFlexibleRejectsImpossibleDate() {
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("2024-02-31"));
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("2024-13-01"));
+    }
+
+    @Test
+    void parseFlexibleRejectsImpossibleTime() {
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("2024-01-15 25:00"));
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("2024-01-15 14:61"));
+    }
+
+    @Test
+    void parseFlexibleRejectsPartialDate() {
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("2024-01"));
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("2024"));
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible(""));
+    }
+
+    @Test
+    void parseFlexibleRejectsSubSecondPrecision() {
+        assertThrows(DateTimeParseException.class,
+            () -> TimeFormatUtil.parseFlexible("2024-01-15T14:30:00.123"));
+    }
 }

--- a/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
@@ -91,6 +91,23 @@ class TimeFormatUtilTest {
         assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("  2024-01-15  "));
     }
 
+    // ---- format / parseFlexible round trip ----
+
+    @Test
+    void formatEmitsSecondResolution() {
+        assertEquals("2024-01-15T14:30:00", TimeFormatUtil.format(MS_2024_01_15_14_30));
+    }
+
+    /**
+     * The copy/paste axis round trip: pan and zoom leave viewport bounds on arbitrary
+     * millisecond values, so format() must still emit something parseFlexible accepts.
+     */
+    @Test
+    void formatOfSubSecondTimestampRoundTripsThroughParseFlexible() {
+        long withMillis = MS_2024_01_15_14_30 + 123L;
+        assertEquals(MS_2024_01_15_14_30, TimeFormatUtil.parseFlexible(TimeFormatUtil.format(withMillis)));
+    }
+
     @Test
     void parseFlexibleRejectsUnrecognisedText() {
         assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("not a date"));

--- a/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TimeFormatUtilTest {
 
@@ -65,5 +67,32 @@ class TimeFormatUtilTest {
     @Test
     void subMinuteTickIntervalIncludesSeconds() {
         assertEquals("14:30:00", TimeFormatUtil.formatForTickInterval(MS_2024_01_15_14_30, 1000L));
+    }
+
+    // ---- parseFlexible ----
+
+    @Test
+    void parseFlexibleAcceptsDateOnly() {
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("2024-01-15"));
+    }
+
+    @Test
+    void parseFlexibleAcceptsIsoDatetime() {
+        assertEquals(MS_2024_01_15_14_30, TimeFormatUtil.parseFlexible("2024-01-15T14:30:00"));
+    }
+
+    @Test
+    void parseFlexibleAcceptsSpaceSeparatedDatetime() {
+        assertEquals(MS_2024_01_15_14_30, TimeFormatUtil.parseFlexible("2024-01-15 14:30:00"));
+    }
+
+    @Test
+    void parseFlexibleTrimsWhitespace() {
+        assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("  2024-01-15  "));
+    }
+
+    @Test
+    void parseFlexibleRejectsUnrecognisedText() {
+        assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("not a date"));
     }
 }

--- a/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/utils/TimeFormatUtilTest.java
@@ -91,23 +91,6 @@ class TimeFormatUtilTest {
         assertEquals(MS_2024_01_15_MIDNIGHT, TimeFormatUtil.parseFlexible("  2024-01-15  "));
     }
 
-    // ---- format / parseFlexible round trip ----
-
-    @Test
-    void formatEmitsSecondResolution() {
-        assertEquals("2024-01-15T14:30:00", TimeFormatUtil.format(MS_2024_01_15_14_30));
-    }
-
-    /**
-     * The copy/paste axis round trip: pan and zoom leave viewport bounds on arbitrary
-     * millisecond values, so format() must still emit something parseFlexible accepts.
-     */
-    @Test
-    void formatOfSubSecondTimestampRoundTripsThroughParseFlexible() {
-        long withMillis = MS_2024_01_15_14_30 + 123L;
-        assertEquals(MS_2024_01_15_14_30, TimeFormatUtil.parseFlexible(TimeFormatUtil.format(withMillis)));
-    }
-
     @Test
     void parseFlexibleRejectsUnrecognisedText() {
         assertThrows(DateTimeParseException.class, () -> TimeFormatUtil.parseFlexible("not a date"));


### PR DESCRIPTION
This addresses part 1 of #348 (part 2 requires scoping/description), and #223. In particular...

Plotting tabs UX:
- [+] button pre-existing
- Tab naming implemented [5c1315b](https://github.com/chasegan/Kalix/pull/385/commits/5c1315b7218f0fded41e28708ccd4191be1b130c) through [ec3e48d](https://github.com/chasegan/Kalix/pull/385/commits/ec3e48dd4a98b51cea4801a761487c38b744ffce), with a convenience double-click to rename quickly [33b442b](https://github.com/chasegan/Kalix/pull/385/commits/33b442b49f2a9a07570dea8356afe8c0c971a0a4)
- Context menu "Duplicate plot/stats" and "Show stats/plot" (resp.) - [e909724](https://github.com/chasegan/Kalix/pull/385/commits/e9097247ee784edd5199886b8ac0718fe3f50dbd)
- "Reset" context menu item [cfed529](https://github.com/chasegan/Kalix/pull/385/commits/cfed529d7f30403e486478495d46c2d8e32c3bb1)

Date range filter:
- Copy/Paste X/Y on plot
- Set Axis Limits... command, offering full control of axis limits 

Additional UX improvements:
- Default tab on construction which automatically ticks "Last run" (saves the user a click). Also constructed when final tab is closed. [2270a21](https://github.com/chasegan/Kalix/pull/385/commits/2270a211765b03f8e9a95b6271f69278e81b0cba)
- Context menu on plot only shows when a plot exists (does not show when no data series selected)
- Make toolbar buttons uniform in size (previously, "Auto-Y range" was squished because the icon was narrow)
- Add close buttons on plot tabs [f12848d](https://github.com/chasegan/Kalix/pull/385/commits/f12848d9634434667c53b179fffbe27819779da1)


## Review follow-up (seven commits, 8a8d80a3..8f7ac9e8)

An orchestrated review of the branch produced 21 findings; a second pass after the fixes confirmed 19 closed and raised nothing contested. Manifesto clauses are cited in the code and commit messages.

- **Undo/Redo survived re-parenting** — `PlotPanel.removeNotify` no longer clears the history callback, so Reset and drag-reorder keep the buttons live (drag-reorder was already broken on main).
- **Auto-Y has one owner** — the interaction manager reads the mode through a supplier; the panel notifies the toolbar (same idiom as the legend toggle); enabling fits Y in one place. Explicit Y limits (Paste Y, edited Y in Set axis limits…) turn auto-Y off; Paste X obeys auto-Y like wheel and pan.
- **`AxisLimitCodec`** — the axis text⇄value logic is a pure, tested class next to `ViewPort` (22 tests). Non-finite and overflowing input is rejected on every axis. `PERCENTILE_SCALE` replaces seven bare literals. Unused `TimeFormatUtil.format()` removed.
- **Clipboard / dialog / gate** — Paste items are disabled on an empty clipboard (context-menu-style §4); the axis dialog disposes on close and binds Escape; the plot menu only shows when data is actually plotted.
- **Menus re-cut to the §1 skeleton** — plot: Zoom to fit (① double-click) | Save data… | clipboard | view/state. Tab: Rename… (① double-click) | New stats tab / New plot tab | Duplicate, Reset | Remove. Titles in sentence case (§2.1).
- **Default tab's "Last run" tick** — a tree snapshot only replaces refs the tree can currently show, so the tick survives until the first run completes.

### Deliberately not addressed here

- **Dialog-title case** is not covered by any manifesto; ~85 `JOptionPane` titles elsewhere are Title Case. This PR uses sentence case per the spirit of §2.1 (on-manifestos §8). Candidate one-line clause for context-menu-style.
- **JCheckboxTree double-click on childless category rows** ticks them, but single-click on the checkbox already does; the real fix is non-checkable rows (renderer/model), out of scope.
- **Pre-existing on main:** removing the Last run rewrites the active tab's recorded sources through the check listener (`LastRunTracker.onRunRemoved` runs outside a programmatic update), so that tab stops auto-ticking the next run. Deserves its own issue.
- The older `FlowVizWindow` keeps its own auto-Y mirror and button; unchanged.
