### PR TITLE
Plot legend - toolbar hides, and context menu reset

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -104,6 +104,7 @@ public class PlotInteractionManager {
     private Supplier<com.kalix.ide.flowviz.transform.PlotType> plotTypeSupplier;
     private Supplier<com.kalix.ide.flowviz.data.LabelResolver> labelResolverSupplier;
     private BooleanSupplier autoYModeSupplier;
+    private Runnable legendResetAction;
 
 
     /**
@@ -152,6 +153,13 @@ public class PlotInteractionManager {
         this.viewportUpdater = viewportUpdater;
         this.visibleSeriesSupplier = visibleSeriesSupplier;
         this.plotAreaSupplier = plotAreaSupplier;
+    }
+
+    /**
+     * Sets the action invoked by the context menu's "Reset legend" item.
+     */
+    public void setLegendResetAction(Runnable legendResetAction) {
+        this.legendResetAction = legendResetAction;
     }
 
     /**
@@ -872,6 +880,10 @@ public class PlotInteractionManager {
 
         contextMenu.add(missingDataMenu);
 
+        JMenuItem resetLegendItem = new JMenuItem("Reset legend");
+        resetLegendItem.addActionListener(e -> resetLegend());
+        contextMenu.add(resetLegendItem);
+
         // Add popup menu listener to update checkbox/radio button states when menu is shown
         contextMenu.addPopupMenuListener(new PopupMenuListener() {
             @Override
@@ -1127,6 +1139,15 @@ public class PlotInteractionManager {
             } else {
                 saveAsCsvFormat(file);
             }
+        }
+    }
+
+    /**
+     * Resets the legend to its default state: shown, expanded, and auto-positioned.
+     */
+    public void resetLegend() {
+        if (legendResetAction != null) {
+            legendResetAction.run();
         }
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -104,7 +104,6 @@ public class PlotInteractionManager {
     private Supplier<com.kalix.ide.flowviz.transform.PlotType> plotTypeSupplier;
     private Supplier<com.kalix.ide.flowviz.data.LabelResolver> labelResolverSupplier;
     private BooleanSupplier autoYModeSupplier;
-    private Runnable legendResetAction;
 
 
     /**
@@ -153,13 +152,6 @@ public class PlotInteractionManager {
         this.viewportUpdater = viewportUpdater;
         this.visibleSeriesSupplier = visibleSeriesSupplier;
         this.plotAreaSupplier = plotAreaSupplier;
-    }
-
-    /**
-     * Sets the action invoked by the context menu's "Reset legend" item.
-     */
-    public void setLegendResetAction(Runnable legendResetAction) {
-        this.legendResetAction = legendResetAction;
     }
 
     /**
@@ -880,9 +872,18 @@ public class PlotInteractionManager {
 
         contextMenu.add(missingDataMenu);
 
-        JMenuItem resetLegendItem = new JMenuItem("Reset legend");
-        resetLegendItem.addActionListener(e -> resetLegend());
-        contextMenu.add(resetLegendItem);
+        contextMenu.addSeparator();
+
+        // Still block 7, but a command rather than a setting (6), so it sits apart from the
+        // settings above. "Key" is what the legend calls itself on screen and on the
+        // toolbar, so the item says "Key" too (2.2: one name per concept).
+        JMenuItem resetKeyItem = new JMenuItem("Reset key");
+        resetKeyItem.addActionListener(e -> {
+            if (parentComponent instanceof PlotPanel plotPanel) {
+                plotPanel.resetLegend();
+            }
+        });
+        contextMenu.add(resetKeyItem);
 
         // Add popup menu listener to update checkbox/radio button states when menu is shown
         contextMenu.addPopupMenuListener(new PopupMenuListener() {
@@ -1139,15 +1140,6 @@ public class PlotInteractionManager {
             } else {
                 saveAsCsvFormat(file);
             }
-        }
-    }
-
-    /**
-     * Resets the legend to its default state: shown, expanded, and auto-positioned.
-     */
-    public void resetLegend() {
-        if (legendResetAction != null) {
-            legendResetAction.run();
         }
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotLegendManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotLegendManager.java
@@ -82,9 +82,8 @@ public class PlotLegendManager {
     private int y = -1;
     private DisplayMode displayMode = DisplayMode.FULL_NAME;
 
-    // Callback for enabled or collapsed state changes
+    // Callback for enabled state changes (the toolbar's Show Key button follows it)
     private Runnable onEnabledChanged = null;
-    private Runnable onCollapsedChanged = null;
 
     // Callback invoked when an entry's line sample is clicked, with the series and
     // the click point. Null when style picking is unavailable (non-palette plots).
@@ -747,9 +746,6 @@ public class PlotLegendManager {
     public void setCollapsed(boolean collapsed) {
         this.collapsed = collapsed;
         savePreferences();
-        if (onCollapsedChanged != null) {
-            onCollapsedChanged.run();
-        }
     }
 
     public boolean isCollapsed() {
@@ -760,10 +756,6 @@ public class PlotLegendManager {
         this.onEnabledChanged = callback;
     }
 
-    public void setOnCollapsedChanged(Runnable callback) {
-        this.onCollapsedChanged = callback;
-    }
-
     /**
      * Resets the legend to its default state: shown, expanded, and auto-positioned —
      * recovering it regardless of how it was hidden, collapsed, or dragged off-screen.
@@ -771,8 +763,12 @@ public class PlotLegendManager {
     public void reset() {
         x = -1;
         y = -1;
-        setCollapsed(false);
-        setEnabled(true);
+        collapsed = false;
+        enabled = true;
+        savePreferences();
+        if (onEnabledChanged != null) {
+            onEnabledChanged.run();
+        }
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotLegendManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotLegendManager.java
@@ -82,7 +82,8 @@ public class PlotLegendManager {
     private int y = -1;
     private DisplayMode displayMode = DisplayMode.FULL_NAME;
 
-    // Callback for collapsed state changes
+    // Callback for enabled or collapsed state changes
+    private Runnable onEnabledChanged = null;
     private Runnable onCollapsedChanged = null;
 
     // Callback invoked when an entry's line sample is clicked, with the series and
@@ -734,6 +735,9 @@ public class PlotLegendManager {
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
         savePreferences();
+        if (onEnabledChanged != null) {
+            onEnabledChanged.run();
+        }
     }
 
     public boolean isEnabled() {
@@ -750,6 +754,10 @@ public class PlotLegendManager {
 
     public boolean isCollapsed() {
         return collapsed;
+    }
+
+    public void setOnEnabledChanged(Runnable callback) {
+        this.onEnabledChanged = callback;
     }
 
     public void setOnCollapsedChanged(Runnable callback) {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotLegendManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotLegendManager.java
@@ -765,6 +765,17 @@ public class PlotLegendManager {
     }
 
     /**
+     * Resets the legend to its default state: shown, expanded, and auto-positioned —
+     * recovering it regardless of how it was hidden, collapsed, or dragged off-screen.
+     */
+    public void reset() {
+        x = -1;
+        y = -1;
+        setCollapsed(false);
+        setEnabled(true);
+    }
+
+    /**
      * Loads legend preferences.
      */
     public void loadPreferences() {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -21,8 +21,6 @@ import com.kalix.ide.flowviz.stats.MaskMode;
 import com.kalix.ide.flowviz.stats.TimeSeriesMasker;
 
 import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -33,7 +31,7 @@ import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.util.List;
 import java.util.function.Supplier;
-import com.kalix.ide.constants.UIConstants;
+
 import com.kalix.ide.preferences.PreferenceKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -21,6 +21,7 @@ import com.kalix.ide.flowviz.stats.MaskMode;
 import com.kalix.ide.flowviz.stats.TimeSeriesMasker;
 
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import java.awt.Cursor;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -31,7 +32,6 @@ import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.util.List;
 import java.util.function.Supplier;
-
 import com.kalix.ide.preferences.PreferenceKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -193,8 +193,6 @@ public class PlotPanel extends JPanel {
 
         // Resolver for projecting ref-keyed series to column headers on CSV export.
         plotInteractionManager.setLabelResolverSupplier(() -> labelResolver);
-
-        plotInteractionManager.setLegendResetAction(this::resetLegend);
 
         setupMouseListeners();
     }
@@ -430,11 +428,17 @@ public class PlotPanel extends JPanel {
     private void setupMouseListeners() {
         MouseAdapter plotMouseHandler = plotInteractionManager.createMouseHandler();
 
-        // Create composite mouse handler that routes events to legend first, then to plot
+        // Create composite mouse handler that routes events to legend first, then to plot.
+        // Only a plain left press belongs to the legend (drag, collapse). A popup trigger
+        // must reach the plot handler even over the legend, or on macOS (where the popup
+        // fires on press) a right-click over the key could never open the menu that holds
+        // "Reset key".
         MouseAdapter compositeHandler = new MouseAdapter() {
             @Override
             public void mousePressed(java.awt.event.MouseEvent e) {
-                if (legendManager != null && legendManager.handleMousePress(e.getX(), e.getY())) {
+                boolean plainLeftPress = SwingUtilities.isLeftMouseButton(e) && !e.isPopupTrigger();
+                if (plainLeftPress && legendManager != null
+                        && legendManager.handleMousePress(e.getX(), e.getY())) {
                     repaint();
                     return; // Event consumed by legend
                 }

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -637,6 +637,13 @@ public class PlotPanel extends JPanel {
         return coordinateDisplayManager != null && coordinateDisplayManager.isShowCoordinates();
     }
 
+    public void setLegendEnabled(boolean enabled) {
+        if (legendManager != null) {
+            legendManager.setEnabled(enabled);
+            repaint();
+        }
+    }
+
     public void setLegendCollapsed(boolean collapsed) {
         if (legendManager != null) {
             legendManager.setCollapsed(collapsed);
@@ -646,6 +653,10 @@ public class PlotPanel extends JPanel {
 
     public boolean isLegendCollapsed() {
         return legendManager != null && legendManager.isCollapsed();
+    }
+
+    public boolean isLegendEnabled() {
+        return legendManager != null && legendManager.isEnabled();
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -196,6 +196,8 @@ public class PlotPanel extends JPanel {
         // Resolver for projecting ref-keyed series to column headers on CSV export.
         plotInteractionManager.setLabelResolverSupplier(() -> labelResolver);
 
+        plotInteractionManager.setLegendResetAction(this::resetLegend);
+
         setupMouseListeners();
     }
 
@@ -657,6 +659,16 @@ public class PlotPanel extends JPanel {
 
     public boolean isLegendEnabled() {
         return legendManager != null && legendManager.isEnabled();
+    }
+
+    /**
+     * Resets the legend to its default state: shown, expanded, and auto-positioned.
+     */
+    public void resetLegend() {
+        if (legendManager != null) {
+            legendManager.reset();
+            repaint();
+        }
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -262,16 +262,15 @@ class PlotToolbarBuilder {
         JToggleButton button = createToggleButton(FontAwesomeSolid.KEY,
             "Show Key", initialState);
 
-        // Update collapsed state when button is clicked
+        // Update enabled state when button is clicked
         button.addActionListener(e -> {
-            plotPanel.setLegendCollapsed(!button.isSelected());
-            PreferenceKeys.PLOT_LEGEND_COLLAPSED.set(!button.isSelected());
+            plotPanel.setLegendEnabled(button.isSelected());
+            PreferenceKeys.PLOT_LEGEND_ENABLED.set(button.isSelected());
         });
 
-        // Set up callback to update button when collapsed state changes from other sources
-        plotPanel.getLegendManager().setOnCollapsedChanged(() -> {
-            boolean collapsed = plotPanel.isLegendCollapsed();
-            button.setSelected(!collapsed);
+        // Set up callback to update button when enabled state changes from other sources
+        plotPanel.getLegendManager().setOnEnabledChanged(() -> {
+            button.setSelected(plotPanel.isLegendEnabled());
         });
 
         toolbar.add(button);

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -263,10 +263,8 @@ class PlotToolbarBuilder {
             "Show Key", initialState);
 
         // Update enabled state when button is clicked
-        button.addActionListener(e -> {
-            plotPanel.setLegendEnabled(button.isSelected());
-            PreferenceKeys.PLOT_LEGEND_ENABLED.set(button.isSelected());
-        });
+        // The legend manager persists its own state, so no preference write here.
+        button.addActionListener(e -> plotPanel.setLegendEnabled(button.isSelected()));
 
         // Set up callback to update button when enabled state changes from other sources
         plotPanel.getLegendManager().setOnEnabledChanged(() -> {

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -135,6 +135,7 @@ public class VisualizationTabManager {
         public boolean autoYMode = true;
         public boolean showCoordinates = false;
         public boolean legendCollapsed = false;
+        public boolean legendEnabled = true;
         // Missing-data handling (context menu > Missing data). Mutually exclusive; both
         // false = default "break at gaps".
         public boolean connectAcrossGaps = false;
@@ -163,6 +164,7 @@ public class VisualizationTabManager {
             settings.autoYMode = plotPanel.isAutoYMode();
             settings.showCoordinates = plotPanel.isShowCoordinates();
             settings.legendCollapsed = plotPanel.isLegendCollapsed();
+            settings.legendEnabled = plotPanel.isLegendEnabled();
             settings.connectAcrossGaps = plotPanel.isConnectAcrossGaps();
             settings.showOrphanMarkers = plotPanel.isShowOrphanMarkers();
             settings.selectedSeries = new LinkedHashSet<>(tabInfo.selectedSeries);
@@ -192,6 +194,7 @@ public class VisualizationTabManager {
             settings.showCoordinates = PreferenceKeys.FLOWVIZ_SHOW_COORDINATES.get();
             settings.autoYMode = PreferenceKeys.FLOWVIZ_AUTO_Y_MODE.get();
             settings.legendCollapsed = PreferenceKeys.PLOT_LEGEND_COLLAPSED.get();
+            settings.legendEnabled = PreferenceKeys.PLOT_LEGEND_ENABLED.get();
             return settings;
         }
     }
@@ -463,6 +466,9 @@ public class VisualizationTabManager {
         if (settings.legendCollapsed) {
             plotPanel.setLegendCollapsed(true);
         }
+        if (!settings.legendEnabled) {
+            plotPanel.setLegendEnabled(false);
+        }
 
         // Populate legend with inherited series (colour resolved at render time)
         for (SeriesRef ref : inheritedSeries) {
@@ -526,7 +532,7 @@ public class VisualizationTabManager {
             .addSeparator()
             .addAutoYToggle(initialAutoY)
             .addCoordinatesToggle(initialShowCoordinates)
-            .addLegendToggle(!plotPanel.isLegendCollapsed());
+            .addLegendToggle(plotPanel.isLegendEnabled());
         return builder.build();
     }
 
@@ -956,7 +962,7 @@ public class VisualizationTabManager {
         if (tab.type == TabInfo.TabType.PLOT && tab.plotPanel != null) {
             tab.plotPanel.setOnHistoryChanged(null);
             tab.plotPanel.setOnAutoYModeChanged(null);
-            tab.plotPanel.getLegendManager().setOnCollapsedChanged(null);
+            tab.plotPanel.getLegendManager().setOnEnabledChanged(null);
         }
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -463,12 +463,10 @@ public class VisualizationTabManager {
         // net result matches the source tab.
         plotPanel.setConnectAcrossGaps(settings.connectAcrossGaps);
         plotPanel.setShowOrphanMarkers(settings.showOrphanMarkers);
-        if (settings.legendCollapsed) {
-            plotPanel.setLegendCollapsed(true);
-        }
-        if (!settings.legendEnabled) {
-            plotPanel.setLegendEnabled(false);
-        }
+        // Unconditional: the new legend manager starts from the global preference, which
+        // may disagree with this tab's settings in either direction.
+        plotPanel.setLegendCollapsed(settings.legendCollapsed);
+        plotPanel.setLegendEnabled(settings.legendEnabled);
 
         // Populate legend with inherited series (colour resolved at render time)
         for (SeriesRef ref : inheritedSeries) {


### PR DESCRIPTION
This PR addresses #383 by adding a reset context menu item, and also changes the toolbar button functionality to fully hide the legend.

# Implementation details
Legend reset: 
- Reset action hooked in via callback in PlotInteractionManager
- reset() defined in PlotLegendManager
- Hooked in with null guard and repaint in PlotPanel::resetLegend

Show key - collapse -> hide behaviour change:
- Functions mirroring collapsed callbacks etc added
- Rewired in PlotToolbarBuilder to modify the `enabled` property rather than `collapsed`. 
  - Adding a `hidden` property would replicate logic used with `enabled`.
- VisualizationTabManager remembers this setting

# Closing keywords

Closes #383 