### PR TITLE
Automatic data masking (#369)

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -938,17 +938,45 @@ public class PlotPanel extends JPanel {
     }
 
     /**
-     * Sets the plot type for this plot.
+     * Sets the plot type for this plot, keeping the current mask mode.
      * Triggers rebuild of display dataset to apply the transformation.
      */
     public void setPlotType(PlotType type) {
-        if (type == null || type == this.plotType) {
+        if (type == null) {
+            return;
+        }
+        setPlotTypeAndMaskMode(type, this.maskMode);
+    }
+
+    /**
+     * Sets plot type and mask mode together as one atomic action: both fields update, the
+     * display dataset rebuilds once (not twice), and exactly one entry is pushed to undo
+     * history. Pushing the two changes separately would leave a "phantom" intermediate state
+     * (new plot type, stale mask mode) that undo would visit but the user never actually saw
+     * — used by the plot-type dropdown, which changes both together (per
+     * {@link PlotType#isDataMaskDefault()}).
+     *
+     * <p>This is the primitive: {@link #setPlotType} and {@link #setMaskMode} delegate here,
+     * so the rebuild/fit/push tail lives in exactly one place. The mask concerned is the
+     * <em>overlapping-data</em> mask ({@link MaskMode}) only; further filter dimensions
+     * (e.g. a seasonal filter, issue #235) are deliberately outside this coupling and belong
+     * in orthogonal fields, not new MaskMode variants.</p>
+     */
+    public void setPlotTypeAndMaskMode(PlotType type, MaskMode maskMode) {
+        if (type == null || maskMode == null) {
+            return;
+        }
+        boolean plotTypeChanged = type != this.plotType;
+        if (!plotTypeChanged && maskMode == this.maskMode) {
             return;
         }
 
         PlotType oldPlotType = this.plotType;
         this.plotType = type;
-        lastReferenceSeries = null; // Reset reference tracking
+        if (plotTypeChanged) {
+            lastReferenceSeries = null; // Reset reference tracking
+        }
+        this.maskMode = maskMode;
 
         if (restoringState) {
             return; // restoreState rebuilds once at the end
@@ -956,57 +984,8 @@ public class PlotPanel extends JPanel {
 
         rebuildDisplayDataSet();
 
-        // Check if X-axis domain changed (switching to/from non-time X-axis types)
-        boolean xAxisDomainChanged = xAxisTypeFor(oldPlotType) != xAxisTypeFor(type);
-
-        // If X-axis domain changed, must recalculate entire viewport (can't preserve X zoom)
-        // Otherwise, follow same logic as aggregation changes
-        if (xAxisDomainChanged) {
-            zoomToFit();  // Full recalculation - X domain is completely different
-        } else if (autoYMode) {
-            fitYAxis();   // Preserve X zoom, fit Y to new data
-        } else {
-            zoomToFit();  // Zoom to fit both axes
-        }
-        pushState();
-    }
-
-    /**
-     * Sets plot type and mask mode together as one atomic action: both fields update, the
-     * display dataset rebuilds once (not twice), and exactly one entry is pushed to undo
-     * history. Calling {@link #setPlotType} and {@link #setMaskMode} back to back would each
-     * push their own snapshot, leaving a "phantom" intermediate state (new plot type, stale
-     * mask mode) that undo would visit but the user never actually saw — used by the plot-type
-     * dropdown, which changes both together (per {@link PlotType#isDataMaskDefault()}).
-     */
-    public void setPlotTypeAndMaskMode(PlotType type, MaskMode maskMode) {
-        if (type == null || maskMode == null) {
-            return;
-        }
-        boolean plotTypeChanged = type != this.plotType;
-        boolean maskModeChanged = maskMode != this.maskMode;
-        if (!plotTypeChanged && !maskModeChanged) {
-            return;
-        }
-
-        PlotType oldPlotType = this.plotType;
-
-        boolean wasRestoring = restoringState;
-        restoringState = true; // suppress setPlotType/setMaskMode's own rebuild/fit/pushState
-        try {
-            setPlotType(type);
-            setMaskMode(maskMode);
-        } finally {
-            restoringState = wasRestoring;
-        }
-
-        if (restoringState) {
-            return; // nested inside an outer restore, which rebuilds once at its own end
-        }
-
-        rebuildDisplayDataSet();
-
-        // Same domain-aware fit choice as setPlotType, since plot type may have changed here too.
+        // If the X-axis domain changed, the viewport must be fully recalculated (X zoom
+        // can't be preserved); otherwise follow the same logic as aggregation changes.
         boolean xAxisDomainChanged = xAxisTypeFor(oldPlotType) != xAxisTypeFor(type);
 
         if (xAxisDomainChanged) {
@@ -1041,23 +1020,10 @@ public class PlotPanel extends JPanel {
      * When ALL, only timestamps where all visible series have valid data are included.
      */
     public void setMaskMode(MaskMode mode) {
-        if (mode == null || mode == this.maskMode) {
+        if (mode == null) {
             return;
         }
-        this.maskMode = mode;
-
-        if (restoringState) {
-            return; // restoreState rebuilds once at the end
-        }
-
-        rebuildDisplayDataSet();
-
-        if (autoYMode) {
-            fitYAxis();
-        } else {
-            zoomToFit();
-        }
-        pushState();
+        setPlotTypeAndMaskMode(this.plotType, mode);
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -976,6 +976,58 @@ public class PlotPanel extends JPanel {
     }
 
     /**
+     * Sets plot type and mask mode together as one atomic action: both fields update, the
+     * display dataset rebuilds once (not twice), and exactly one entry is pushed to undo
+     * history. Calling {@link #setPlotType} and {@link #setMaskMode} back to back would each
+     * push their own snapshot, leaving a "phantom" intermediate state (new plot type, stale
+     * mask mode) that undo would visit but the user never actually saw — used by the plot-type
+     * dropdown, which changes both together (per {@link PlotType#isDataMaskDefault()}).
+     */
+    public void setPlotTypeAndMaskMode(PlotType type, MaskMode maskMode) {
+        if (type == null || maskMode == null) {
+            return;
+        }
+        boolean plotTypeChanged = type != this.plotType;
+        boolean maskModeChanged = maskMode != this.maskMode;
+        if (!plotTypeChanged && !maskModeChanged) {
+            return;
+        }
+
+        PlotType oldPlotType = this.plotType;
+
+        boolean wasRestoring = restoringState;
+        restoringState = true; // suppress setPlotType/setMaskMode's own rebuild/fit/pushState
+        try {
+            setPlotType(type);
+            setMaskMode(maskMode);
+        } finally {
+            restoringState = wasRestoring;
+        }
+
+        if (restoringState) {
+            return; // nested inside an outer restore, which rebuilds once at its own end
+        }
+
+        rebuildDisplayDataSet();
+
+        // Same domain-aware fit choice as setPlotType, since plot type may have changed here too.
+        XAxisType oldAxisType = oldPlotType == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
+            : oldPlotType == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
+        XAxisType newAxisType = type == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
+            : type == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
+        boolean xAxisDomainChanged = oldAxisType != newAxisType;
+
+        if (xAxisDomainChanged) {
+            zoomToFit();
+        } else if (autoYMode) {
+            fitYAxis();
+        } else {
+            zoomToFit();
+        }
+        pushState();
+    }
+
+    /**
      * Gets the current plot type.
      */
     public PlotType getPlotType() {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotPanel.java
@@ -957,11 +957,7 @@ public class PlotPanel extends JPanel {
         rebuildDisplayDataSet();
 
         // Check if X-axis domain changed (switching to/from non-time X-axis types)
-        XAxisType oldAxisType = oldPlotType == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
-            : oldPlotType == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
-        XAxisType newAxisType = type == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
-            : type == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
-        boolean xAxisDomainChanged = oldAxisType != newAxisType;
+        boolean xAxisDomainChanged = xAxisTypeFor(oldPlotType) != xAxisTypeFor(type);
 
         // If X-axis domain changed, must recalculate entire viewport (can't preserve X zoom)
         // Otherwise, follow same logic as aggregation changes
@@ -1011,11 +1007,7 @@ public class PlotPanel extends JPanel {
         rebuildDisplayDataSet();
 
         // Same domain-aware fit choice as setPlotType, since plot type may have changed here too.
-        XAxisType oldAxisType = oldPlotType == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
-            : oldPlotType == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
-        XAxisType newAxisType = type == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
-            : type == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
-        boolean xAxisDomainChanged = oldAxisType != newAxisType;
+        boolean xAxisDomainChanged = xAxisTypeFor(oldPlotType) != xAxisTypeFor(type);
 
         if (xAxisDomainChanged) {
             zoomToFit();
@@ -1025,6 +1017,16 @@ public class PlotPanel extends JPanel {
             zoomToFit();
         }
         pushState();
+    }
+
+    /**
+     * Maps a plot type to the X-axis domain it plots against, so callers can tell whether
+     * switching between two plot types changes that domain (and therefore can't preserve the
+     * existing X zoom). Shared by {@link #setPlotType} and {@link #setPlotTypeAndMaskMode}.
+     */
+    private static XAxisType xAxisTypeFor(PlotType type) {
+        return type == PlotType.EXCEEDANCE ? XAxisType.PERCENTILE
+            : type == PlotType.DOUBLE_MASS ? XAxisType.NUMERIC : XAxisType.TIME;
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/PlotTypeListCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/PlotTypeListCellRenderer.java
@@ -1,7 +1,6 @@
 package com.kalix.ide.flowviz.rendering;
 
 import com.kalix.ide.flowviz.transform.PlotType;
-import com.kalix.ide.icons.OverlayIcon;
 import com.kalix.ide.utils.ThemeUtils;
 
 import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/PlotTypeListCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/PlotTypeListCellRenderer.java
@@ -1,0 +1,94 @@
+package com.kalix.ide.flowviz.rendering;
+
+import com.kalix.ide.flowviz.transform.PlotType;
+import com.kalix.ide.icons.OverlayIcon;
+import com.kalix.ide.utils.ThemeUtils;
+
+import org.kordamp.ikonli.fontawesome6.FontAwesomeSolid;
+import org.kordamp.ikonli.swing.FontIcon;
+
+import javax.swing.BorderFactory;
+import javax.swing.Icon;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.ListCellRenderer;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+
+import static com.kalix.ide.windows.ToolbarConstants.BUTTON_ICON_SIZE;
+import static com.kalix.ide.windows.ToolbarConstants.HORIZONTAL_SPACING;
+
+/**
+ * Renders each {@link PlotType} combo-box item as its display name (left-aligned) plus a glyph
+ * (right-aligned) showing whether that plot type starts with overlapping-data masking on
+ * ({@link PlotType#isDataMaskDefault()}).
+ */
+public class PlotTypeListCellRenderer implements ListCellRenderer<PlotType> {
+
+    /** Same footprint as the real mask glyph, painted as nothing — see the class doc. */
+    private static final Icon BLANK_ICON = new Icon() {
+        @Override
+        public void paintIcon(Component c, java.awt.Graphics g, int x, int y) {
+            // Intentionally blank.
+        }
+
+        @Override
+        public int getIconWidth() {
+            return BUTTON_ICON_SIZE;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return BUTTON_ICON_SIZE;
+        }
+    };
+
+    @Override
+    public Component getListCellRendererComponent(
+        JList<? extends PlotType> list,
+        PlotType value,
+        int index,
+        boolean isSelected,
+        boolean cellHasFocus
+    ) {
+        Color background = isSelected ? list.getSelectionBackground() : list.getBackground();
+        Color foreground = isSelected ? list.getSelectionForeground() : list.getForeground();
+
+        JPanel panel = new JPanel(new BorderLayout(HORIZONTAL_SPACING, 0));
+        panel.setOpaque(true);
+        panel.setBackground(background);
+
+        JLabel textLabel = new JLabel(value == null ? "" : value.getDisplayName());
+        textLabel.setForeground(foreground);
+        textLabel.setBorder(BorderFactory.createEmptyBorder(2, HORIZONTAL_SPACING, 2, 0));
+        panel.add(textLabel, BorderLayout.WEST);
+
+        Icon icon;
+        if (value == null || index == -1) {
+            // Toolbar's own closed-state display (or the null-value case): no visible glyph,
+            // but still occupy the glyph's width — see the class doc.
+            icon = BLANK_ICON;
+        } else {
+            // Icon colour follows the row's own background (selected vs. not) rather than a
+            // fixed colour, so the glyph stays legible across both light and dark themes and
+            // across the highlighted/unhighlighted state within the same popup.
+            Color iconColor = ThemeUtils.iconColor(background);
+            icon = value.isDataMaskDefault()
+                ? FontIcon.of(FontAwesomeSolid.MASK, BUTTON_ICON_SIZE, iconColor)
+                : FontIcon.of(FontAwesomeSolid.BAN, BUTTON_ICON_SIZE, iconColor);
+        }
+        // Every icon (whichever glyph, or the blank placeholder) sits in the same padded box
+        // rather than flush against the row's edge, so rows stay visually uniform regardless
+        // of which glyph is showing (FontIcon already reports the same square footprint for
+        // every glyph - this is about breathing room, not the reported size). No left padding
+        // here: that gap already comes from the BorderLayout hgap between the two labels.
+        JLabel iconLabel = new JLabel(icon);
+        iconLabel.setBorder(BorderFactory.createEmptyBorder(2, 0, 2, HORIZONTAL_SPACING));
+        panel.add(iconLabel, BorderLayout.EAST);
+
+        return panel;
+    }
+}

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/PlotTypeListCellRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/PlotTypeListCellRenderer.java
@@ -24,6 +24,9 @@ import static com.kalix.ide.windows.ToolbarConstants.HORIZONTAL_SPACING;
  * Renders each {@link PlotType} combo-box item as its display name (left-aligned) plus a glyph
  * (right-aligned) showing whether that plot type starts with overlapping-data masking on
  * ({@link PlotType#isDataMaskDefault()}).
+ *
+ * <p>Rubber-stamp renderer: one cached component is reconfigured per call rather than
+ * allocated per call, matching the codebase's other list renderers.</p>
  */
 public class PlotTypeListCellRenderer implements ListCellRenderer<PlotType> {
 
@@ -45,6 +48,23 @@ public class PlotTypeListCellRenderer implements ListCellRenderer<PlotType> {
         }
     };
 
+    private final JPanel panel = new JPanel(new BorderLayout(HORIZONTAL_SPACING, 0));
+    private final JLabel textLabel = new JLabel();
+    private final JLabel iconLabel = new JLabel();
+
+    public PlotTypeListCellRenderer() {
+        panel.setOpaque(true);
+        textLabel.setBorder(BorderFactory.createEmptyBorder(2, HORIZONTAL_SPACING, 2, 0));
+        // Every icon (whichever glyph, or the blank placeholder) sits in the same padded box
+        // rather than flush against the row's edge, so rows stay visually uniform regardless
+        // of which glyph is showing (FontIcon already reports the same square footprint for
+        // every glyph - this is about breathing room, not the reported size). No left padding
+        // here: that gap already comes from the BorderLayout hgap between the two labels.
+        iconLabel.setBorder(BorderFactory.createEmptyBorder(2, 0, 2, HORIZONTAL_SPACING));
+        panel.add(textLabel, BorderLayout.WEST);
+        panel.add(iconLabel, BorderLayout.EAST);
+    }
+
     @Override
     public Component getListCellRendererComponent(
         JList<? extends PlotType> list,
@@ -56,14 +76,9 @@ public class PlotTypeListCellRenderer implements ListCellRenderer<PlotType> {
         Color background = isSelected ? list.getSelectionBackground() : list.getBackground();
         Color foreground = isSelected ? list.getSelectionForeground() : list.getForeground();
 
-        JPanel panel = new JPanel(new BorderLayout(HORIZONTAL_SPACING, 0));
-        panel.setOpaque(true);
         panel.setBackground(background);
-
-        JLabel textLabel = new JLabel(value == null ? "" : value.getDisplayName());
+        textLabel.setText(value == null ? "" : value.getDisplayName());
         textLabel.setForeground(foreground);
-        textLabel.setBorder(BorderFactory.createEmptyBorder(2, HORIZONTAL_SPACING, 2, 0));
-        panel.add(textLabel, BorderLayout.WEST);
 
         Icon icon;
         if (value == null || index == -1) {
@@ -79,14 +94,7 @@ public class PlotTypeListCellRenderer implements ListCellRenderer<PlotType> {
                 ? FontIcon.of(FontAwesomeSolid.MASK, BUTTON_ICON_SIZE, iconColor)
                 : FontIcon.of(FontAwesomeSolid.BAN, BUTTON_ICON_SIZE, iconColor);
         }
-        // Every icon (whichever glyph, or the blank placeholder) sits in the same padded box
-        // rather than flush against the row's edge, so rows stay visually uniform regardless
-        // of which glyph is showing (FontIcon already reports the same square footprint for
-        // every glyph - this is about breathing room, not the reported size). No left padding
-        // here: that gap already comes from the BorderLayout hgap between the two labels.
-        JLabel iconLabel = new JLabel(icon);
-        iconLabel.setBorder(BorderFactory.createEmptyBorder(2, 0, 2, HORIZONTAL_SPACING));
-        panel.add(iconLabel, BorderLayout.EAST);
+        iconLabel.setIcon(icon);
 
         return panel;
     }

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotType.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotType.java
@@ -69,16 +69,4 @@ public enum PlotType {
     public boolean requiresReferenceSeries() {
         return this == DIFFERENCE || this == CUMULATIVE_DIFFERENCE || this == DOUBLE_MASS;
     }
-
-    /**
-     * Parses display name to enum value.
-     */
-    public static PlotType fromDisplayName(String displayName) {
-        for (PlotType type : values()) {
-            if (type.displayName.equals(displayName)) {
-                return type;
-            }
-        }
-        return VALUES;
-    }
 }

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotType.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotType.java
@@ -6,32 +6,39 @@ package com.kalix.ide.flowviz.transform;
  */
 public enum PlotType {
     /** Original values - no transformation. */
-    VALUES("Values", "Value"),
+    VALUES("Values", "Value", false),
 
     /** Cumulative sum of values over time. */
-    CUMULATIVE("Cumulative Values", "Cumulative Value"),
+    CUMULATIVE("Cumulative Values", "Cumulative Value", true),
 
     /** Difference from reference series (first selected series). */
-    DIFFERENCE("Difference", "Difference from Reference"),
+    DIFFERENCE("Difference", "Difference from Reference", false),
 
     /** Cumulative difference from reference series. */
-    CUMULATIVE_DIFFERENCE("Cumulative Difference", "Cumulative Difference"),
+    CUMULATIVE_DIFFERENCE("Cumulative Difference", "Cumulative Difference", true),
 
     /** Exceedance probability distribution. */
-    EXCEEDANCE("Exceedance", "Exceedance Probability (%)"),
+    EXCEEDANCE("Exceedance", "Exceedance Probability (%)", true),
 
     /** Double mass curve: cumulative reference on X-axis vs cumulative series on Y-axis. */
-    DOUBLE_MASS("Double Mass", "Cumulative Value"),
+    DOUBLE_MASS("Double Mass", "Cumulative Value", true),
 
     /** Residual mass curve: cumulative deviation from mean over time. */
-    RESIDUAL_MASS("Residual Mass", "Residual Mass");
+    RESIDUAL_MASS("Residual Mass", "Residual Mass", true);
 
     private final String displayName;
     private final String yAxisLabel;
+    private final boolean dataMaskDefault;
 
-    PlotType(String displayName, String yAxisLabel) {
+    /**
+     * @param displayName UI label
+     * @param yAxisLabel Y-axis label appropriate for this plot type
+     * @param dataMaskDefault whether overlapping-data masking should start on for this plot type
+     */
+    PlotType(String displayName, String yAxisLabel, boolean dataMaskDefault) {
         this.displayName = displayName;
         this.yAxisLabel = yAxisLabel;
+        this.dataMaskDefault = dataMaskDefault;
     }
 
     /**
@@ -46,6 +53,13 @@ public enum PlotType {
      */
     public String getYAxisLabel() {
         return yAxisLabel;
+    }
+
+    /**
+     * Whether overlapping-data masking should default to on when this plot type is selected.
+     */
+    public boolean isDataMaskDefault() {
+        return dataMaskDefault;
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotType.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/transform/PlotType.java
@@ -56,7 +56,10 @@ public enum PlotType {
     }
 
     /**
-     * Whether overlapping-data masking should default to on when this plot type is selected.
+     * Whether overlapping-data masking should default to on when this plot type is selected
+     * from the toolbar dropdown (issue #369). This flag concerns the overlapping-data mask
+     * ({@code MaskMode}) only; other filter dimensions (e.g. a seasonal filter, issue #235)
+     * are deliberately independent of plot type and of this flag.
      */
     public boolean isDataMaskDefault() {
         return dataMaskDefault;

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -1,6 +1,7 @@
 package com.kalix.ide.windows;
 
 import com.kalix.ide.flowviz.PlotPanel;
+import com.kalix.ide.flowviz.rendering.PlotTypeListCellRenderer;
 import com.kalix.ide.flowviz.transform.AggregationMethod;
 import com.kalix.ide.flowviz.transform.AggregationPeriod;
 import com.kalix.ide.flowviz.transform.PlotType;
@@ -45,7 +46,7 @@ class PlotToolbarBuilder {
     // Store references to all state-reflecting controls
     private JComboBox<String> aggregationPeriodCombo;
     private JComboBox<String> aggregationMethodCombo;
-    private JComboBox<String> plotTypeCombo;
+    private JComboBox<PlotType> plotTypeCombo;
     private JComboBox<String> ySpaceCombo;
     private JToggleButton maskToggle;
     private JToggleButton autoYToggle;
@@ -167,16 +168,17 @@ class PlotToolbarBuilder {
         toolbar.add(new JLabel("Plot Type:"));
         toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
-        // Plot type dropdown
-        plotTypeCombo = createDropdown(PLOT_TYPE_OPTIONS,
-            ToolbarConstants.WIDE_DROPDOWN_SIZE, "Plot type");
+        // Plot type dropdown - custom construction to display
+        this.plotTypeCombo = new JComboBox<>(PlotType.values());
+        plotTypeCombo.setMaximumSize(ToolbarConstants.WIDE_DROPDOWN_SIZE);
+        plotTypeCombo.setToolTipText("Plot type");
+        plotTypeCombo.setRenderer(new PlotTypeListCellRenderer());
         // Set initial value from current PlotPanel state
-        plotTypeCombo.setSelectedItem(plotPanel.getPlotType().getDisplayName());
+        plotTypeCombo.setSelectedItem(plotPanel.getPlotType());
         plotTypeCombo.addActionListener(e -> {
-            String selected = (String) plotTypeCombo.getSelectedItem();
+            PlotType selected = (PlotType) plotTypeCombo.getSelectedItem();
             if (selected != null) {
-                PlotType type = PlotType.fromDisplayName(selected);
-                plotPanel.setPlotType(type);
+                plotPanel.setPlotType(selected);
             }
         });
         toolbar.add(plotTypeCombo);

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -2,6 +2,7 @@ package com.kalix.ide.windows;
 
 import com.kalix.ide.flowviz.PlotPanel;
 import com.kalix.ide.flowviz.rendering.PlotTypeListCellRenderer;
+import com.kalix.ide.flowviz.stats.MaskMode;
 import com.kalix.ide.flowviz.transform.AggregationMethod;
 import com.kalix.ide.flowviz.transform.AggregationPeriod;
 import com.kalix.ide.flowviz.transform.PlotType;
@@ -18,6 +19,9 @@ import javax.swing.JLabel;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import java.awt.Dimension;
+
+import static com.kalix.ide.flowviz.stats.MaskMode.ALL;
+import static com.kalix.ide.flowviz.stats.MaskMode.NONE;
 
 /**
  * Builder for a plot tab's toolbar (save, undo/redo, palette, aggregation, mask,
@@ -154,9 +158,7 @@ class PlotToolbarBuilder {
         maskToggle = createToggleButton(FontAwesomeSolid.MASK,
             "Overlapping Data Mask", false);
         maskToggle.addActionListener(e -> {
-            com.kalix.ide.flowviz.stats.MaskMode mode = maskToggle.isSelected()
-                ? com.kalix.ide.flowviz.stats.MaskMode.ALL
-                : com.kalix.ide.flowviz.stats.MaskMode.NONE;
+            MaskMode mode = maskToggle.isSelected() ? ALL : NONE;
             plotPanel.setMaskMode(mode);
         });
         toolbar.add(maskToggle);
@@ -178,7 +180,8 @@ class PlotToolbarBuilder {
         plotTypeCombo.addActionListener(e -> {
             PlotType selected = (PlotType) plotTypeCombo.getSelectedItem();
             if (selected != null) {
-                plotPanel.setPlotType(selected);
+                MaskMode maskMode = selected.isDataMaskDefault() ? ALL : NONE;
+                plotPanel.setPlotTypeAndMaskMode(selected, maskMode);
                 // sync with button
                 maskToggle.setSelected(selected.isDataMaskDefault());
             }

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -95,8 +95,9 @@ class PlotToolbarBuilder {
             }
         });
 
-        undoButton.setEnabled(false);
-        redoButton.setEnabled(false);
+        // Initialise from the panel: a duplicated tab has history before its toolbar exists.
+        undoButton.setEnabled(plotPanel.canUndo());
+        redoButton.setEnabled(plotPanel.canRedo());
 
         // Update button state whenever history changes
         plotPanel.setOnHistoryChanged(() -> {
@@ -155,8 +156,10 @@ class PlotToolbarBuilder {
     }
 
     PlotToolbarBuilder addMaskToggle() {
+        // Initialise from the panel rather than a constant: by toolbar-build time the panel
+        // may already carry a non-default mask (e.g. tab duplication copies history first).
         maskToggle = createToggleButton(FontAwesomeSolid.MASK,
-            "Overlapping Data Mask", false);
+            "Overlapping Data Mask", plotPanel.getMaskMode() == ALL);
         maskToggle.addActionListener(e -> {
             MaskMode mode = maskToggle.isSelected() ? ALL : NONE;
             plotPanel.setMaskMode(mode);
@@ -179,12 +182,15 @@ class PlotToolbarBuilder {
         plotTypeCombo.setSelectedItem(plotPanel.getPlotType());
         plotTypeCombo.addActionListener(e -> {
             PlotType selected = (PlotType) plotTypeCombo.getSelectedItem();
-            if (selected != null) {
-                MaskMode maskMode = selected.isDataMaskDefault() ? ALL : NONE;
-                plotPanel.setPlotTypeAndMaskMode(selected, maskMode);
-                // sync with button
-                maskToggle.setSelected(selected.isDataMaskDefault());
+            // Re-picking the current type is a no-op: the combo fires even for a same-item
+            // selection, and applying the default then would stomp a manual mask override,
+            // reset the zoom, and push a spurious undo entry.
+            if (selected == null || selected == plotPanel.getPlotType()) {
+                return;
             }
+            plotPanel.setPlotTypeAndMaskMode(selected, selected.isDataMaskDefault() ? ALL : NONE);
+            // Reflect the panel's resulting state rather than recomputing the policy here.
+            maskToggle.setSelected(plotPanel.getMaskMode() == ALL);
         });
         toolbar.add(plotTypeCombo);
         return this;

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -27,41 +27,6 @@ import java.awt.Dimension;
  */
 class PlotToolbarBuilder {
 
-    // === Toolbar sizing (shared with StatsToolbarBuilder) ===
-    static final int BUTTON_ICON_SIZE = 14;
-    static final Dimension WIDE_DROPDOWN_SIZE = new Dimension(150, 25);
-    static final Dimension NARROW_DROPDOWN_SIZE = new Dimension(80, 25);
-    static final int HORIZONTAL_SPACING = 5;
-    // Shared square footprint for every icon/toggle button on this toolbar, so save,
-    // undo/redo, palette, mask, auto-Y, coordinates and legend all line up identically
-    // rather than each sizing itself off its own icon/border combination.
-    static final Dimension BUTTON_SIZE = new Dimension(28, 28);
-
-    /**
-     * Aggregation period options for time series data (shared with
-     * {@link StatsToolbarBuilder}).
-     */
-    static final String[] AGGREGATION_OPTIONS = {
-        "Original",
-        "Daily",
-        "Monthly",
-        "Annual (Jan-Dec)",
-        "Annual (Feb-Jan)",
-        "Annual (Mar-Feb)",
-        "Annual (Apr-Mar)",
-        "Annual (May-Apr)",
-        "Annual (Jun-May)",
-        "Annual (Jul-Jun)",
-        "Annual (Aug-Jul)",
-        "Annual (Sep-Aug)",
-        "Annual (Oct-Sep)",
-        "Annual (Nov-Oct)",
-        "Annual (Dec-Nov)"
-    };
-
-    /** Aggregation method options (shared with {@link StatsToolbarBuilder}). */
-    static final String[] AGGREGATION_METHOD_OPTIONS = {"Sum", "Min", "Max", "Mean"};
-
     /**
      * Plot type options, derived from {@link PlotType} so its display names have one
      * owner — the enum constants themselves — rather than a hand-maintained copy here.
@@ -142,24 +107,24 @@ class PlotToolbarBuilder {
     PlotToolbarBuilder addAggregationControls() {
         // Resolution label
         toolbar.add(new JLabel("Resolution:"));
-        toolbar.add(Box.createHorizontalStrut(HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
         // Aggregation period dropdown
-        aggregationPeriodCombo = createDropdown(AGGREGATION_OPTIONS,
-            WIDE_DROPDOWN_SIZE, "Aggregation");
+        aggregationPeriodCombo = createDropdown(ToolbarConstants.AGGREGATION_OPTIONS,
+            ToolbarConstants.WIDE_DROPDOWN_SIZE, "Aggregation");
         // Set initial value from current PlotPanel state
         aggregationPeriodCombo.setSelectedItem(plotPanel.getAggregationPeriod().getDisplayName());
         aggregationPeriodCombo.addActionListener(e -> applyAggregation());
         toolbar.add(aggregationPeriodCombo);
 
         // "by" label
-        toolbar.add(Box.createHorizontalStrut(HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
         toolbar.add(new JLabel("by"));
-        toolbar.add(Box.createHorizontalStrut(HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
         // Aggregation method dropdown
-        aggregationMethodCombo = createDropdown(AGGREGATION_METHOD_OPTIONS,
-            NARROW_DROPDOWN_SIZE, "Aggregation method");
+        aggregationMethodCombo = createDropdown(ToolbarConstants.AGGREGATION_METHOD_OPTIONS,
+            ToolbarConstants.NARROW_DROPDOWN_SIZE, "Aggregation method");
         // Set initial value from current PlotPanel state
         aggregationMethodCombo.setSelectedItem(plotPanel.getAggregationMethod().getDisplayName());
         aggregationMethodCombo.addActionListener(e -> applyAggregation());
@@ -200,11 +165,11 @@ class PlotToolbarBuilder {
     PlotToolbarBuilder addPlotTypeDropdown() {
         // Plot Type label
         toolbar.add(new JLabel("Plot Type:"));
-        toolbar.add(Box.createHorizontalStrut(HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
         // Plot type dropdown
         plotTypeCombo = createDropdown(PLOT_TYPE_OPTIONS,
-            WIDE_DROPDOWN_SIZE, "Plot type");
+            ToolbarConstants.WIDE_DROPDOWN_SIZE, "Plot type");
         // Set initial value from current PlotPanel state
         plotTypeCombo.setSelectedItem(plotPanel.getPlotType().getDisplayName());
         plotTypeCombo.addActionListener(e -> {
@@ -220,7 +185,7 @@ class PlotToolbarBuilder {
 
     PlotToolbarBuilder addYSpaceDropdown() {
         ySpaceCombo = createDropdown(Y_SPACE_OPTIONS,
-            NARROW_DROPDOWN_SIZE, "Y-axis scale");
+            ToolbarConstants.NARROW_DROPDOWN_SIZE, "Y-axis scale");
         // Set initial value from current PlotPanel state
         ySpaceCombo.setSelectedItem(plotPanel.getYAxisScale().getDisplayName());
         ySpaceCombo.addActionListener(e -> {
@@ -300,25 +265,25 @@ class PlotToolbarBuilder {
 
     /** Creates a standard icon button. */
     private JButton createIconButton(FontAwesomeSolid icon, String tooltip, Runnable action) {
-        JButton button = new JButton(FontIcon.of(icon, BUTTON_ICON_SIZE));
+        JButton button = new JButton(FontIcon.of(icon, ToolbarConstants.BUTTON_ICON_SIZE));
         button.setToolTipText(tooltip);
         button.setFocusable(false);
-        button.setPreferredSize(BUTTON_SIZE);
-        button.setMinimumSize(BUTTON_SIZE);
-        button.setMaximumSize(BUTTON_SIZE);
+        button.setPreferredSize(ToolbarConstants.BUTTON_SIZE);
+        button.setMinimumSize(ToolbarConstants.BUTTON_SIZE);
+        button.setMaximumSize(ToolbarConstants.BUTTON_SIZE);
         button.addActionListener(e -> action.run());
         return button;
     }
 
     /** Creates a standard toggle button. */
     private JToggleButton createToggleButton(FontAwesomeSolid icon, String tooltip, boolean initialState) {
-        JToggleButton button = new JToggleButton(FontIcon.of(icon, BUTTON_ICON_SIZE));
+        JToggleButton button = new JToggleButton(FontIcon.of(icon, ToolbarConstants.BUTTON_ICON_SIZE));
         button.setToolTipText(tooltip);
         button.setFocusable(false);
         button.setSelected(initialState);
-        button.setPreferredSize(BUTTON_SIZE);
-        button.setMinimumSize(BUTTON_SIZE);
-        button.setMaximumSize(BUTTON_SIZE);
+        button.setPreferredSize(ToolbarConstants.BUTTON_SIZE);
+        button.setMinimumSize(ToolbarConstants.BUTTON_SIZE);
+        button.setMaximumSize(ToolbarConstants.BUTTON_SIZE);
         return button;
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -179,6 +179,8 @@ class PlotToolbarBuilder {
             PlotType selected = (PlotType) plotTypeCombo.getSelectedItem();
             if (selected != null) {
                 plotPanel.setPlotType(selected);
+                // sync with button
+                maskToggle.setSelected(selected.isDataMaskDefault());
             }
         });
         toolbar.add(plotTypeCombo);

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -32,14 +32,6 @@ import static com.kalix.ide.flowviz.stats.MaskMode.NONE;
  */
 class PlotToolbarBuilder {
 
-    /**
-     * Plot type options, derived from {@link PlotType} so its display names have one
-     * owner — the enum constants themselves — rather than a hand-maintained copy here.
-     */
-    private static final String[] PLOT_TYPE_OPTIONS = java.util.Arrays.stream(PlotType.values())
-        .map(PlotType::getDisplayName)
-        .toArray(String[]::new);
-
     /** Y-axis scale options. */
     private static final String[] Y_SPACE_OPTIONS = {"Linear", "Log", "Sqrt"};
 

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarBuilder.java
@@ -3,6 +3,7 @@ package com.kalix.ide.windows;
 import com.kalix.ide.flowviz.PlotPanel;
 import com.kalix.ide.flowviz.transform.AggregationMethod;
 import com.kalix.ide.flowviz.transform.AggregationPeriod;
+import com.kalix.ide.flowviz.transform.PlotType;
 import com.kalix.ide.flowviz.transform.YAxisScale;
 import com.kalix.ide.preferences.PreferenceKeys;
 
@@ -61,8 +62,13 @@ class PlotToolbarBuilder {
     /** Aggregation method options (shared with {@link StatsToolbarBuilder}). */
     static final String[] AGGREGATION_METHOD_OPTIONS = {"Sum", "Min", "Max", "Mean"};
 
-    /** Plot type options. */
-    private static final String[] PLOT_TYPE_OPTIONS = {"Values", "Cumulative Values", "Difference", "Cumulative Difference", "Exceedance", "Double Mass", "Residual Mass"};
+    /**
+     * Plot type options, derived from {@link PlotType} so its display names have one
+     * owner — the enum constants themselves — rather than a hand-maintained copy here.
+     */
+    private static final String[] PLOT_TYPE_OPTIONS = java.util.Arrays.stream(PlotType.values())
+        .map(PlotType::getDisplayName)
+        .toArray(String[]::new);
 
     /** Y-axis scale options. */
     private static final String[] Y_SPACE_OPTIONS = {"Linear", "Log", "Sqrt"};
@@ -204,8 +210,7 @@ class PlotToolbarBuilder {
         plotTypeCombo.addActionListener(e -> {
             String selected = (String) plotTypeCombo.getSelectedItem();
             if (selected != null) {
-                com.kalix.ide.flowviz.transform.PlotType type =
-                    com.kalix.ide.flowviz.transform.PlotType.fromDisplayName(selected);
+                PlotType type = PlotType.fromDisplayName(selected);
                 plotPanel.setPlotType(type);
             }
         });

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarController.java
@@ -1,5 +1,7 @@
 package com.kalix.ide.windows;
 
+import com.kalix.ide.flowviz.transform.PlotType;
+
 import javax.swing.JComboBox;
 import javax.swing.JToggleButton;
 
@@ -11,14 +13,14 @@ import javax.swing.JToggleButton;
 class PlotToolbarController {
     private final JComboBox<String> aggregationPeriodCombo;
     private final JComboBox<String> aggregationMethodCombo;
-    private final JComboBox<String> plotTypeCombo;
+    private final JComboBox<PlotType> plotTypeCombo;
     private final JComboBox<String> ySpaceCombo;
     private final JToggleButton maskToggle;
     private final JToggleButton autoYToggle;
 
     PlotToolbarController(JComboBox<String> aggregationPeriodCombo,
                           JComboBox<String> aggregationMethodCombo,
-                          JComboBox<String> plotTypeCombo,
+                          JComboBox<PlotType> plotTypeCombo,
                           JComboBox<String> ySpaceCombo,
                           JToggleButton maskToggle,
                           JToggleButton autoYToggle) {
@@ -37,13 +39,20 @@ class PlotToolbarController {
     void updateFromState(com.kalix.ide.flowviz.PlotState state) {
         setSilently(aggregationPeriodCombo, state.getAggregationPeriod().getDisplayName());
         setSilently(aggregationMethodCombo, state.getAggregationMethod().getDisplayName());
-        setSilently(plotTypeCombo, state.getPlotType().getDisplayName());
+        setSilently(plotTypeCombo, state.getPlotType());
         setSilently(ySpaceCombo, state.getYAxisScale().getDisplayName());
         setSilently(maskToggle, state.getMaskMode() == com.kalix.ide.flowviz.stats.MaskMode.ALL);
         setSilently(autoYToggle, state.isAutoYMode());
     }
 
     private static void setSilently(JComboBox<String> combo, String value) {
+        java.awt.event.ActionListener[] listeners = combo.getActionListeners();
+        for (var l : listeners) combo.removeActionListener(l);
+        combo.setSelectedItem(value);
+        for (var l : listeners) combo.addActionListener(l);
+    }
+
+    private static void setSilently(JComboBox<PlotType> combo, PlotType value) {
         java.awt.event.ActionListener[] listeners = combo.getActionListeners();
         for (var l : listeners) combo.removeActionListener(l);
         combo.setSelectedItem(value);

--- a/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarController.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/PlotToolbarController.java
@@ -48,21 +48,30 @@ class PlotToolbarController {
     private static void setSilently(JComboBox<String> combo, String value) {
         java.awt.event.ActionListener[] listeners = combo.getActionListeners();
         for (var l : listeners) combo.removeActionListener(l);
-        combo.setSelectedItem(value);
-        for (var l : listeners) combo.addActionListener(l);
+        try {
+            combo.setSelectedItem(value);
+        } finally {
+            for (var l : listeners) combo.addActionListener(l);
+        }
     }
 
     private static void setSilently(JComboBox<PlotType> combo, PlotType value) {
         java.awt.event.ActionListener[] listeners = combo.getActionListeners();
         for (var l : listeners) combo.removeActionListener(l);
-        combo.setSelectedItem(value);
-        for (var l : listeners) combo.addActionListener(l);
+        try {
+            combo.setSelectedItem(value);
+        } finally {
+            for (var l : listeners) combo.addActionListener(l);
+        }
     }
 
     private static void setSilently(JToggleButton toggle, boolean selected) {
         java.awt.event.ActionListener[] listeners = toggle.getActionListeners();
         for (var l : listeners) toggle.removeActionListener(l);
-        toggle.setSelected(selected);
-        for (var l : listeners) toggle.addActionListener(l);
+        try {
+            toggle.setSelected(selected);
+        } finally {
+            for (var l : listeners) toggle.addActionListener(l);
+        }
     }
 }

--- a/kalixide/src/main/java/com/kalix/ide/windows/StatsToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/StatsToolbarBuilder.java
@@ -23,9 +23,9 @@ import java.io.File;
 
 /**
  * Builder for a stats tab's toolbar (save, aggregation, mask controls), extracted
- * from {@link VisualizationTabManager}. Sizing and the aggregation option lists are
- * shared with {@link PlotToolbarBuilder} so the two toolbars stay visually and
- * behaviourally consistent.
+ * from {@link VisualizationTabManager}. Sizing and the aggregation option lists come from
+ * {@link ToolbarConstants}, also used by {@link PlotToolbarBuilder}, so the two toolbars stay
+ * visually and behaviourally consistent.
  */
 class StatsToolbarBuilder {
     private final JToolBar toolbar;
@@ -55,24 +55,24 @@ class StatsToolbarBuilder {
     StatsToolbarBuilder addAggregationControls() {
         // Resolution label
         toolbar.add(new JLabel("Resolution:"));
-        toolbar.add(Box.createHorizontalStrut(PlotToolbarBuilder.HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
         // Aggregation period dropdown
-        aggregationPeriodCombo = createDropdown(PlotToolbarBuilder.AGGREGATION_OPTIONS,
-            PlotToolbarBuilder.WIDE_DROPDOWN_SIZE, "Aggregation");
+        aggregationPeriodCombo = createDropdown(ToolbarConstants.AGGREGATION_OPTIONS,
+            ToolbarConstants.WIDE_DROPDOWN_SIZE, "Aggregation");
         // Set initial selection from tab info
         aggregationPeriodCombo.setSelectedItem(tabInfo.statsPeriod.getDisplayName());
         aggregationPeriodCombo.addActionListener(e -> applyAggregation());
         toolbar.add(aggregationPeriodCombo);
 
         // "by" label
-        toolbar.add(Box.createHorizontalStrut(PlotToolbarBuilder.HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
         toolbar.add(new JLabel("by"));
-        toolbar.add(Box.createHorizontalStrut(PlotToolbarBuilder.HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
         // Aggregation method dropdown
-        aggregationMethodCombo = createDropdown(PlotToolbarBuilder.AGGREGATION_METHOD_OPTIONS,
-            PlotToolbarBuilder.NARROW_DROPDOWN_SIZE, "Aggregation method");
+        aggregationMethodCombo = createDropdown(ToolbarConstants.AGGREGATION_METHOD_OPTIONS,
+            ToolbarConstants.NARROW_DROPDOWN_SIZE, "Aggregation method");
         // Set initial selection from tab info
         aggregationMethodCombo.setSelectedItem(tabInfo.statsMethod.getDisplayName());
         aggregationMethodCombo.addActionListener(e -> applyAggregation());
@@ -83,14 +83,14 @@ class StatsToolbarBuilder {
 
     StatsToolbarBuilder addMaskControls() {
         // Mask label
-        toolbar.add(Box.createHorizontalStrut(PlotToolbarBuilder.HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
         toolbar.add(new JLabel("Mask:"));
-        toolbar.add(Box.createHorizontalStrut(PlotToolbarBuilder.HORIZONTAL_SPACING));
+        toolbar.add(Box.createHorizontalStrut(ToolbarConstants.HORIZONTAL_SPACING));
 
         // Mask mode dropdown
         String[] maskOptions = {"All", "Each", "None"};
         JComboBox<String> maskCombo = createDropdown(maskOptions,
-            PlotToolbarBuilder.NARROW_DROPDOWN_SIZE, "Mask mode for bivariate statistics");
+            ToolbarConstants.NARROW_DROPDOWN_SIZE, "Mask mode for bivariate statistics");
 
         // Set initial selection from stats model
         if (tabInfo.statsModel != null) {
@@ -206,12 +206,12 @@ class StatsToolbarBuilder {
 
     /** Creates a standard icon button. */
     private JButton createIconButton(FontAwesomeSolid icon, String tooltip, Runnable action) {
-        JButton button = new JButton(FontIcon.of(icon, PlotToolbarBuilder.BUTTON_ICON_SIZE));
+        JButton button = new JButton(FontIcon.of(icon, ToolbarConstants.BUTTON_ICON_SIZE));
         button.setToolTipText(tooltip);
         button.setFocusable(false);
-        button.setPreferredSize(PlotToolbarBuilder.BUTTON_SIZE);
-        button.setMinimumSize(PlotToolbarBuilder.BUTTON_SIZE);
-        button.setMaximumSize(PlotToolbarBuilder.BUTTON_SIZE);
+        button.setPreferredSize(ToolbarConstants.BUTTON_SIZE);
+        button.setMinimumSize(ToolbarConstants.BUTTON_SIZE);
+        button.setMaximumSize(ToolbarConstants.BUTTON_SIZE);
         button.addActionListener(e -> action.run());
         return button;
     }

--- a/kalixide/src/main/java/com/kalix/ide/windows/ToolbarConstants.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/ToolbarConstants.java
@@ -1,0 +1,45 @@
+package com.kalix.ide.windows;
+
+import java.awt.Dimension;
+
+/**
+ * Sizing and shared option lists for the plot and stats toolbars ({@link PlotToolbarBuilder},
+ * {@link StatsToolbarBuilder}), pulled into one place so the two builders draw from a single
+ * definition instead of one owning the constants and the other reaching across as
+ * {@code PlotToolbarBuilder.FIELD}. Same pattern as {@link com.kalix.ide.constants.UIConstants}.
+ */
+public final class ToolbarConstants {
+
+    // Prevent instantiation
+    private ToolbarConstants() {
+        throw new UnsupportedOperationException("Constants class should not be instantiated");
+    }
+
+    public static final int BUTTON_ICON_SIZE = 14;
+    static final Dimension WIDE_DROPDOWN_SIZE = new Dimension(150, 25);
+    static final Dimension NARROW_DROPDOWN_SIZE = new Dimension(80, 25);
+    public static final int HORIZONTAL_SPACING = 5;
+    static final Dimension BUTTON_SIZE = new Dimension(28, 28);
+
+    /** Aggregation period options for time series data. */
+    static final String[] AGGREGATION_OPTIONS = {
+        "Original",
+        "Daily",
+        "Monthly",
+        "Annual (Jan-Dec)",
+        "Annual (Feb-Jan)",
+        "Annual (Mar-Feb)",
+        "Annual (Apr-Mar)",
+        "Annual (May-Apr)",
+        "Annual (Jun-May)",
+        "Annual (Jul-Jun)",
+        "Annual (Aug-Jul)",
+        "Annual (Sep-Aug)",
+        "Annual (Oct-Sep)",
+        "Annual (Nov-Oct)",
+        "Annual (Dec-Nov)"
+    };
+
+    /** Aggregation method options. */
+    static final String[] AGGREGATION_METHOD_OPTIONS = {"Sum", "Min", "Max", "Mean"};
+}

--- a/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/windows/VisualizationTabManager.java
@@ -473,6 +473,17 @@ public class VisualizationTabManager {
             plotPanel.addLegendSeries(ref);
         }
 
+        // Copy history from source plot tab (Chrome-style duplicate), or push initial state.
+        // Done BEFORE the toolbar is built: copyHistoryFrom restores the source's current
+        // state (mask mode included, which TabSettings doesn't carry), and the toolbar
+        // controls initialise by reading the panel — building first left them showing
+        // defaults that disagreed with the restored plot.
+        if (settings.sourcePlotPanel != null) {
+            plotPanel.copyHistoryFrom(settings.sourcePlotPanel);
+        } else {
+            plotPanel.pushState();
+        }
+
         // Create container panel with toolbar
         JPanel containerPanel = new JPanel(new BorderLayout());
         JToolBar toolbar = createPlotToolbar(plotPanel, settings.autoYMode, settings.showCoordinates);
@@ -493,13 +504,6 @@ public class VisualizationTabManager {
         // Select the new tab (only when duplicating, not for initial default tabs)
         if (settings.selectedSeries != null) {
             tabbedPane.setSelectedIndex(index);
-        }
-
-        // Copy history from source plot tab (Chrome-style duplicate), or push initial state
-        if (settings.sourcePlotPanel != null) {
-            plotPanel.copyHistoryFrom(settings.sourcePlotPanel);
-        } else {
-            plotPanel.pushState();
         }
 
         return plotPanel;

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/transform/PlotTypeTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/transform/PlotTypeTest.java
@@ -1,0 +1,29 @@
+package com.kalix.ide.flowviz.transform;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins {@link PlotType#isDataMaskDefault()} to the mapping issue #369 specifies:
+ * overlapping-data masking defaults ON for the cumulative/derived plot types and
+ * OFF for the direct-value types.
+ */
+class PlotTypeTest {
+
+    @Test
+    void dataMaskDefaultMatchesIssue369() {
+        assertFalse(PlotType.VALUES.isDataMaskDefault());
+        assertTrue(PlotType.CUMULATIVE.isDataMaskDefault());
+        assertFalse(PlotType.DIFFERENCE.isDataMaskDefault());
+        assertTrue(PlotType.CUMULATIVE_DIFFERENCE.isDataMaskDefault());
+        assertTrue(PlotType.EXCEEDANCE.isDataMaskDefault());
+        assertTrue(PlotType.DOUBLE_MASS.isDataMaskDefault());
+        assertTrue(PlotType.RESIDUAL_MASS.isDataMaskDefault());
+
+        assertEquals(7, PlotType.values().length,
+            "a new plot type must decide its mask default here too");
+    }
+}


### PR DESCRIPTION
- Shared logic/constants extraction (general cleanup/refactoring).
- Toolbar dropdown uses custom cell renderer, which displays right-aligned icons indicating data masking on by default or not. The dropdown's closed-box preview (the part you click) does not show the icon, only the opened dropdown's rows. 
- Selection is synced to main mask button.
- Icon choice: mask consistent with existing button, "BAN" icon is easily readable.
  - An intermediate attempt had a layered slashed mask icon, but this was difficult to read.
- Only one state change pushed to the change history (new function combining "Plot type change" and "Mask mode change" functionality)

Closes #369.