### PR TITLE
(#394) [FEATURE] Symlog plot type

### DIFF
--- a/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizPanel.java
@@ -345,6 +345,19 @@ public class FlowVizPanel extends JPanel {
             return;
         }
 
+        // The cached global minimum ignores the scale's domain: on LOG it may be zero or
+        // negative, and padding from that gives NaN bounds and a blank view. Fit to the
+        // smallest showable value instead, as auto-Y does, or to the default view when
+        // nothing is showable.
+        double domainFloor = yAxisScale.domainFloor();
+        if (minValue <= domainFloor) {
+            minValue = smallestAbove(displayDataSet, domainFloor);
+            if (minValue == null) {
+                createDefaultViewport();
+                return;
+            }
+        }
+
         // Clamp minimum value for log scale to prevent zooming too far out
         // Hydrological models often produce tiny values (e.g., 1e-12) that are meaningless
         // This only affects auto-zoom; manual zoom/pan can still access the full range
@@ -375,6 +388,19 @@ public class FlowVizPanel extends JPanel {
         XAxisType xAxisType = determineXAxisType();
         currentViewport = new ViewPort(startTime, endTime, minValue, maxValue,
                                      plotArea.x, plotArea.y, plotArea.width, plotArea.height, yAxisScale, xAxisType);
+    }
+
+    /** The smallest valid value above {@code floor} across every series, or null if none. */
+    private static Double smallestAbove(DataSet dataSet, double floor) {
+        double smallest = Double.POSITIVE_INFINITY;
+        for (TimeSeriesData series : dataSet.getAllSeries()) {
+            double[] values = series.getValues();
+            boolean[] validPoints = series.getValidPoints();
+            for (int i = 0; i < series.getPointCount(); i++) {
+                if (validPoints[i] && values[i] > floor && values[i] < smallest) smallest = values[i];
+            }
+        }
+        return smallest == Double.POSITIVE_INFINITY ? null : smallest;
     }
 
     private void createDefaultViewport() {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizPanel.java
@@ -953,11 +953,8 @@ public class FlowVizPanel extends JPanel {
         }
         long span = currentViewport.getTimeRangeMs();
         long newStart = timeMs - span / 2;
-        double[] valueBounds = currentViewport.valueBoundsCentredOn(value); // no-op when on screen
-        currentViewport = new ViewPort(newStart, newStart + span, valueBounds[0], valueBounds[1],
-            currentViewport.getPlotX(), currentViewport.getPlotY(),
-            currentViewport.getPlotWidth(), currentViewport.getPlotHeight(),
-            yAxisScale, determineXAxisType());
+        currentViewport = currentViewport.centreValueAxisOn(value) // no-op when on screen
+            .withTimeRange(newStart, newStart + span);
         userViewportTouched = true;
         viewportCoalesceTimer.restart(); // one history entry, like a pan
         repaint();

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizPanel.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizPanel.java
@@ -391,13 +391,13 @@ public class FlowVizPanel extends JPanel {
 
     /**
      * Applies padding to Y-axis range in the appropriate transformed space.
-     * Works for all scale types (LINEAR, LOG, SQRT) by applying padding in transformed
+     * Works for every scale in {@link YAxisScale} by applying padding in transformed
      * space and then inverse transforming back to data space. This ensures consistent
      * visual spacing regardless of scale type.
      *
      * @param minValue The minimum Y value before padding
      * @param maxValue The maximum Y value before padding
-     * @param yAxisScale The Y-axis scale type (LINEAR, LOG, or SQRT)
+     * @param yAxisScale The Y-axis scale to pad in
      * @param paddingFraction The fraction of range to use as padding (e.g., 0.05 for 5%)
      * @return Array of [paddedMin, paddedMax]
      */

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizToolbarBuilder.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/FlowVizToolbarBuilder.java
@@ -33,6 +33,7 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -51,7 +52,7 @@ import java.util.function.Consumer;
 class FlowVizToolbarBuilder {
 
     /** Y-axis scale options. */
-    private static final String[] Y_SPACE_OPTIONS = {"Linear", "Log", "Sqrt"};
+    private static final String[] Y_SPACE_OPTIONS = Arrays.stream(YAxisScale.values()).map(YAxisScale::getDisplayName).toArray(String[]::new);
 
     private final JToolBar toolbar;
     private final VisualizationTabManager.TabInfo tabInfo;

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -571,15 +571,10 @@ public class PlotInteractionManager {
         ViewPort currentViewport = viewportSupplier.get();
         YAxisScale yAxisScale = currentViewport != null ? currentViewport.getYAxisScale() : YAxisScale.LINEAR;
 
-        // Exclusive lower bound of the current scale's domain - values at or below it have no
-        // position on the axis. Resolved once here rather than per point: the loop below runs on
-        // every mouse event while panning, so the domain check has to cost one compare, not a
-        // branch on scale. NEGATIVE_INFINITY makes the check vacuously false for scales that
-        // accept every value.
-        double domainFloor = switch (yAxisScale) {
-            case LOG -> 0.0;                                          // log10 needs y > 0
-            case LINEAR, SQRT, SYMLOG -> Double.NEGATIVE_INFINITY;    // defined everywhere
-        };
+        // Values at or below the scale's domain floor have no position on the axis (LOG:
+        // y <= 0). The scale owns the rule; resolved once here so the per-point check in
+        // the loop below stays one compare.
+        double domainFloor = yAxisScale.domainFloor();
 
         double minValue = Double.POSITIVE_INFINITY;
         double maxValue = Double.NEGATIVE_INFINITY;

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -571,6 +571,16 @@ public class PlotInteractionManager {
         ViewPort currentViewport = viewportSupplier.get();
         YAxisScale yAxisScale = currentViewport != null ? currentViewport.getYAxisScale() : YAxisScale.LINEAR;
 
+        // Exclusive lower bound of the current scale's domain - values at or below it have no
+        // position on the axis. Resolved once here rather than per point: the loop below runs on
+        // every mouse event while panning, so the domain check has to cost one compare, not a
+        // branch on scale. NEGATIVE_INFINITY makes the check vacuously false for scales that
+        // accept every value.
+        double domainFloor = switch (yAxisScale) {
+            case LOG -> 0.0;                                          // log10 needs y > 0
+            case LINEAR, SQRT, SYMLOG -> Double.NEGATIVE_INFINITY;    // defined everywhere
+        };
+
         double minValue = Double.POSITIVE_INFINITY;
         double maxValue = Double.NEGATIVE_INFINITY;
         boolean hasValidData = false;
@@ -594,7 +604,7 @@ public class PlotInteractionManager {
 
                 // Skip NaN and values invalid for current scale
                 if (Double.isNaN(value)) continue;
-                if (yAxisScale == YAxisScale.LOG && value <= 0) continue; // LOG requires positive values
+                if (value <= domainFloor) continue; // Outside the scale's domain
 
                 minValue = Math.min(minValue, value);
                 maxValue = Math.max(maxValue, value);

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/PlotInteractionManager.java
@@ -422,15 +422,9 @@ public class PlotInteractionManager {
             updateViewportWithFittedY(startTime, endTime);
         } else if (isYAxisOnlyZoom) {
             // Ctrl/Cmd+Scroll: Y-axis only, the value under the mouse stays put
-            long startTime = currentViewport.getStartTimeMs();
-            long endTime = currentViewport.getEndTimeMs();
-            double[] valueBounds = currentViewport.valueBoundsZoomedAbout(wheelZoomFactor, e.getY());
-
             Rectangle plotArea = plotAreaSupplier.get();
-            ViewPort newViewport = new ViewPort(startTime, endTime, valueBounds[0], valueBounds[1],
-                                              plotArea.x, plotArea.y, plotArea.width, plotArea.height,
-                                              currentViewport.getYAxisScale(), currentViewport.getXAxisType());
-            viewportUpdater.accept(newViewport);
+            viewportUpdater.accept(currentViewport.zoomValueAxis(wheelZoomFactor, e.getY())
+                .withPlotArea(plotArea.x, plotArea.y, plotArea.width, plotArea.height));
         } else {
             // Standard zoom: both axes, the point under the mouse stays put
             long mouseTime = currentViewport.screenXToTime(e.getX());
@@ -448,13 +442,10 @@ public class PlotInteractionManager {
             long startTime = mouseTime - (long) (newTimeRange * mouseTimeRatio);
             long endTime = startTime + newTimeRange;
 
-            double[] valueBounds = currentViewport.valueBoundsZoomedAbout(wheelZoomFactor, e.getY());
-
             Rectangle plotArea = plotAreaSupplier.get();
-            ViewPort newViewport = new ViewPort(startTime, endTime, valueBounds[0], valueBounds[1],
-                                              plotArea.x, plotArea.y, plotArea.width, plotArea.height,
-                                              currentViewport.getYAxisScale(), currentViewport.getXAxisType());
-            viewportUpdater.accept(newViewport);
+            viewportUpdater.accept(currentViewport.zoomValueAxis(wheelZoomFactor, e.getY())
+                .withTimeRange(startTime, endTime)
+                .withPlotArea(plotArea.x, plotArea.y, plotArea.width, plotArea.height));
         }
 
         parentComponent.repaint();

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
@@ -42,6 +42,8 @@ public class AxisRenderer {
     private static final double LOG_TICK_EPSILON = 1e-9;
     /** How far the threshold marker is shifted from the grid colour, towards the foreground. */
     private static final int THRESHOLD_CONTRAST_SHIFT = 80;
+    private static final BasicStroke THRESHOLD_STROKE = new BasicStroke(GRID_STROKE_WIDTH,
+        BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, DashStyle.DASHED.dashArray(), 0.0f);
 
     private final TemporalAxisCalculator temporalCalculator;
 
@@ -225,7 +227,8 @@ public class AxisRenderer {
      * <p>LINEAR and SQRT space ticks evenly in transformed space, so they land evenly on
      * screen. LOG places them at values a modeller reads as round (see {@link #logTicks});
      * even spacing in log space would label 10^0.5 as 31.62 whenever the nice interval
-     * fell below one decade -- correct positions, unreadable numbers.</p>
+     * fell below one decade -- correct positions, unreadable numbers. SYMLOG does the same
+     * per region (see {@link #symlogTicks}).</p>
      *
      * @param viewport The current viewport
      * @return List of value tick positions (in data space)
@@ -245,7 +248,8 @@ public class AxisRenderer {
         YAxisScale yAxisScale = viewport.getYAxisScale();
         return switch (yAxisScale) {
             case LINEAR, SQRT -> evenTicks(transformedMin, transformedMax, numTicks, yAxisScale::inverseTransform);
-            case LOG -> logTicks(transformedMin, transformedMax, numTicks);
+            case LOG -> logTicks(transformedMin, transformedMax, numTicks, 0);
+            case SYMLOG -> symlogTicks(transformedMin, transformedMax, numTicks);
         };
     }
 
@@ -279,13 +283,17 @@ public class AxisRenderer {
      * @param transformedMin viewport minimum, in decades
      * @param transformedMax viewport maximum, in decades
      * @param numTicks target tick count for the plot height
+     * @param decadeAnchor the decade the coarse steps count from, so a step of two decades
+     *        still lands there: 0 for LOG (1, 100, 10^4), 1 for SYMLOG's log region
+     *        (10, 1000, 10^5), which keeps the seam at 10 ticked whatever the zoom
      */
-    private List<Double> logTicks(double transformedMin, double transformedMax, int numTicks) {
+    private List<Double> logTicks(double transformedMin, double transformedMax, int numTicks, double decadeAnchor) {
         double decades = transformedMax - transformedMin;
         double decadeInterval = roundToNiceValueInterval(decades / (numTicks - 1));
         if (decadeInterval >= 1) {
             // A whole number of decades per tick: even spacing lands exactly on 10^k
-            return evenTicks(transformedMin, transformedMax, numTicks, t -> Math.pow(10, t));
+            return evenTicks(transformedMin - decadeAnchor, transformedMax - decadeAnchor, numTicks,
+                t -> Math.pow(10, t + decadeAnchor));
         }
 
         // Less than a decade per tick: subdivide each decade with round mantissas, the
@@ -320,14 +328,75 @@ public class AxisRenderer {
         for (int decade = firstDecade; decade <= lastDecade; decade++) {
             double base = Math.pow(10, decade);
             for (double mantissa : mantissas) {
-                double transformed = decade + Math.log10(mantissa);
-                if (transformed >= transformedMin - LOG_TICK_EPSILON
-                        && transformed <= transformedMax + LOG_TICK_EPSILON) {
+                if (inRange(decade + Math.log10(mantissa), transformedMin, transformedMax)) {
                     ticks.add(mantissa * base);
                 }
             }
         }
         return ticks;
+    }
+
+    /**
+     * Ticks for a SYMLOG axis: each log region gets LOG's round placement counted from the
+     * seam, so +/-L is ticked whatever the zoom; the linear region between gets even
+     * data-space steps; and the target count is split between the regions by the share of
+     * the axis each occupies, so density stays comparable with the other scales.
+     */
+    private List<Double> symlogTicks(double transformedMin, double transformedMax, int numTicks) {
+        YAxisScale scale = YAxisScale.SYMLOG;
+        double seam = scale.transform(scale.linearThreshold().orElseThrow());
+        double span = transformedMax - transformedMin;
+        List<Double> ticks = new ArrayList<>();
+
+        // Positive log region, and the negative one as its mirror image
+        double positiveLo = Math.max(seam, transformedMin);
+        if (transformedMax > positiveLo) {
+            int budget = regionBudget(numTicks, (transformedMax - positiveLo) / span);
+            for (double tick : logTicks(positiveLo, transformedMax, budget, seam)) {
+                if (inRange(Math.log10(tick), positiveLo, transformedMax)) ticks.add(tick);
+            }
+        }
+        double negativeLo = Math.max(seam, -transformedMax);
+        double negativeHi = -transformedMin;
+        if (negativeHi > negativeLo) {
+            int budget = regionBudget(numTicks, (negativeHi - negativeLo) / span);
+            for (double tick : logTicks(negativeLo, negativeHi, budget, seam)) {
+                if (inRange(Math.log10(tick), negativeLo, negativeHi)) ticks.add(-tick);
+            }
+        }
+
+        // Linear region, in data space
+        double linearLo = Math.max(-seam, transformedMin);
+        double linearHi = Math.min(seam, transformedMax);
+        if (linearHi > linearLo) {
+            int budget = regionBudget(numTicks, (linearHi - linearLo) / span);
+            double lo = scale.inverseTransform(linearLo);
+            double hi = scale.inverseTransform(linearHi);
+            for (double tick : evenTicks(lo, hi, budget, DoubleUnaryOperator.identity())) {
+                if (inRange(scale.transform(tick), linearLo, linearHi)) ticks.add(tick);
+            }
+        }
+
+        // The seam belongs to two regions; keep one copy
+        ticks.sort(null);
+        List<Double> distinct = new ArrayList<>(ticks.size());
+        for (double tick : ticks) {
+            if (distinct.isEmpty() || !sameTick(distinct.get(distinct.size() - 1), tick)) distinct.add(tick);
+        }
+        return distinct;
+    }
+
+    /** A region's share of the tick budget, never below the two a nice interval needs. */
+    private static int regionBudget(int numTicks, double share) {
+        return Math.max(2, (int) Math.round(numTicks * share));
+    }
+
+    private static boolean inRange(double transformed, double transformedMin, double transformedMax) {
+        return transformed >= transformedMin - LOG_TICK_EPSILON && transformed <= transformedMax + LOG_TICK_EPSILON;
+    }
+
+    private static boolean sameTick(double a, double b) {
+        return Math.abs(a - b) <= LOG_TICK_EPSILON * Math.max(1.0, Math.abs(a));
     }
 
     /**
@@ -355,49 +424,58 @@ public class AxisRenderer {
             }
         }
 
-        // Draw horizontal grid lines aligned with value axis ticks
+        // Draw horizontal grid lines aligned with value axis ticks. A row the scale's
+        // threshold marker owns is left to it, so the dashed cue never sits on a solid line.
+        int[] thresholdRows = thresholdRows(viewport);
         for (Double tickValue : axisInfo.valueTicks) {
             int screenY = viewport.valueToScreenY(tickValue);
-            if (screenY >= plotY && screenY <= plotY + plotHeight) {
-                g2d.drawLine(plotX, screenY, plotX + plotWidth, screenY);
+            if (screenY != thresholdRows[0] && screenY != thresholdRows[1]) {
+                drawHorizontalLine(g2d, viewport, screenY);
             }
         }
     }
 
     /**
-     * Marks the linear-region boundaries of a scale that has one (currently only
-     * {@link YAxisScale#SYMLOG}) with a dashed horizontal line at +/-L.
-     *
-     * <p>Without this the change in axis behaviour at the threshold is invisible: the same
-     * vertical distance means a fixed increment below it and a decade above it. Draws nothing
-     * for scales with no linear region, and each line is clipped away individually once the
-     * viewport is panned past it.</p>
+     * Screen rows of the scale's linear-region thresholds, +L and -L, or two off-plot rows
+     * for a scale without one. Always two entries so callers need no emptiness check.
+     */
+    private int[] thresholdRows(ViewPort viewport) {
+        OptionalDouble threshold = viewport.getYAxisScale().linearThreshold();
+        if (threshold.isEmpty()) {
+            return new int[] {Integer.MIN_VALUE, Integer.MIN_VALUE};
+        }
+        double linearThreshold = threshold.getAsDouble();
+        return new int[] {viewport.valueToScreenY(linearThreshold), viewport.valueToScreenY(-linearThreshold)};
+    }
+
+    /** Draws a plot-wide horizontal line at {@code screenY} if it lies inside the plot area. */
+    private void drawHorizontalLine(Graphics2D g2d, ViewPort viewport, int screenY) {
+        int plotY = viewport.getPlotY();
+        if (screenY >= plotY && screenY <= plotY + viewport.getPlotHeight()) {
+            int plotX = viewport.getPlotX();
+            g2d.drawLine(plotX, screenY, plotX + viewport.getPlotWidth(), screenY);
+        }
+    }
+
+    /**
+     * Marks where the scale changes behaviour: a dashed plot-wide line at +L and -L for a
+     * scale with a linear region (SYMLOG), nothing for the rest. Drawn whether or not the
+     * grid is, and in place of the grid line on its row (see {@link #drawGrid}): without
+     * the cue 5 to 10 and 10 to 100 read as equal steps.
      *
      * @param g2d Graphics context
      * @param viewport Current viewport
      * @param colors The current theme's plot colours (resolved once per paint)
      */
     public void drawScaleThresholds(Graphics2D g2d, ViewPort viewport, PlotColors colors) {
-        OptionalDouble threshold = viewport.getYAxisScale().linearThreshold();
-        if (threshold.isEmpty()) return;
+        if (viewport.getYAxisScale().linearThreshold().isEmpty()) return;
 
         // Derived from the grid role rather than a theme key of its own, so the marker keeps
         // the grid's relationship to the background in every theme while reading as deliberate.
         g2d.setColor(PlotColors.shiftForContrast(colors.grid, colors.background, THRESHOLD_CONTRAST_SHIFT));
-        g2d.setStroke(new BasicStroke(GRID_STROKE_WIDTH, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER,
-            10.0f, DashStyle.DASHED.dashArray(), 0.0f));
-
-        int plotX = viewport.getPlotX();
-        int plotY = viewport.getPlotY();
-        int plotWidth = viewport.getPlotWidth();
-        int plotHeight = viewport.getPlotHeight();
-
-        double linearThreshold = threshold.getAsDouble();
-        for (double value : new double[]{linearThreshold, -linearThreshold}) {
-            int screenY = viewport.valueToScreenY(value);
-            if (screenY >= plotY && screenY <= plotY + plotHeight) {
-                g2d.drawLine(plotX, screenY, plotX + plotWidth, screenY);
-            }
+        g2d.setStroke(THRESHOLD_STROKE);
+        for (int row : thresholdRows(viewport)) {
+            drawHorizontalLine(g2d, viewport, row);
         }
     }
 

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
@@ -32,11 +32,11 @@ public class AxisRenderer {
     private static final int VALUE_LABEL_OFFSET = 8;
     private static final int TIME_TITLE_OFFSET = 40;
 
-    /** Round mantissas to place within each decade of a LOG axis, coarsest set first. */
+    /** Round mantissas to place within each decade of a LOG axis, densest set first. */
     private static final double[][] LOG_DECADE_SUBDIVISIONS = {
-        {1},
-        {1, 2, 5},
         {1, 2, 3, 4, 5, 6, 7, 8, 9},
+        {1, 2, 5},
+        {1},
     };
     /** Slack for a tick sitting on a viewport edge, in decades (log10 rounding). */
     private static final double LOG_TICK_EPSILON = 1e-9;
@@ -249,7 +249,7 @@ public class AxisRenderer {
         return switch (yAxisScale) {
             case LINEAR, SQRT -> evenTicks(transformedMin, transformedMax, numTicks, yAxisScale::inverseTransform);
             case LOG -> logTicks(transformedMin, transformedMax, numTicks, 0);
-            case SYMLOG -> symlogTicks(transformedMin, transformedMax, numTicks);
+            case SYMLOG -> symlogTicks(transformedMin, transformedMax, numTicks, viewport.getPlotHeight());
         };
     }
 
@@ -275,10 +275,13 @@ public class AxisRenderer {
     }
 
     /**
-     * Ticks for a LOG axis, at values a modeller reads as round: whole decades when the
-     * view spans many; 1-2-5 or 1..9 within each decade when it spans few; and plain
-     * data-space steps once it spans less than a factor of about two, where those
-     * mantissas run out and log is near enough linear that even spacing reads fine.
+     * Ticks for a LOG axis, at values a modeller reads as round: the densest round
+     * placement that fits the tick budget, from every integer mantissa within a decade,
+     * through 1-2-5 and whole decades, out to every 2, 5, 10... decades over a wide view.
+     * One placement denser when the fitting one would leave fewer than two labels (a
+     * short plot over a decade or so), and plain data-space steps once the view spans less
+     * than a factor of about two, where those mantissas run out and log is near enough
+     * linear that even spacing reads fine.
      *
      * @param transformedMin viewport minimum, in decades
      * @param transformedMax viewport maximum, in decades
@@ -288,22 +291,15 @@ public class AxisRenderer {
      *        (10, 1000, 10^5), which keeps the seam at 10 ticked whatever the zoom
      */
     private List<Double> logTicks(double transformedMin, double transformedMax, int numTicks, double decadeAnchor) {
-        double decades = transformedMax - transformedMin;
-        double decadeInterval = roundToNiceValueInterval(decades / (numTicks - 1));
-        if (decadeInterval >= 1) {
-            // A whole number of decades per tick: even spacing lands exactly on 10^k
-            return evenTicks(transformedMin - decadeAnchor, transformedMax - decadeAnchor, numTicks,
-                t -> Math.pow(10, t + decadeAnchor));
-        }
-
-        // Less than a decade per tick: subdivide each decade with round mantissas, the
-        // densest set that still fits the target count (the same budget the even
-        // algorithm works to, so spacing stays comparable across scales)
-        List<Double> ticks = new ArrayList<>();
-        for (double[] mantissas : LOG_DECADE_SUBDIVISIONS) {
-            List<Double> candidate = decadeTicks(transformedMin, transformedMax, mantissas);
-            if (candidate.size() > numTicks + 1) break;
-            ticks = candidate;
+        List<Double> denser = null;
+        List<Double> ticks;
+        for (int level = 0; ; level++) {
+            List<Double> candidate = logTickCandidate(level, transformedMin, transformedMax, decadeAnchor);
+            if (candidate.size() <= numTicks + 1) {
+                ticks = candidate.size() < 2 && denser != null ? denser : candidate;
+                break;
+            }
+            denser = candidate;
         }
         if (ticks.size() >= MIN_TARGET_TICKS) return ticks;
 
@@ -315,9 +311,37 @@ public class AxisRenderer {
         double maxValue = Math.pow(10, transformedMax);
         List<Double> evenSteps = new ArrayList<>();
         for (double step : evenTicks(minValue, maxValue, numTicks, DoubleUnaryOperator.identity())) {
-            if (step >= minValue && step <= maxValue) evenSteps.add(step);
+            // Judged in transformed space with the usual slack: pow(10, log10(3.2)) is
+            // 3.2000000000000006, and an exact compare dropped a tick sitting on the edge
+            if (inRange(Math.log10(step), transformedMin, transformedMax)) evenSteps.add(step);
         }
         return evenSteps.size() > ticks.size() ? evenSteps : ticks;
+    }
+
+    /**
+     * The round-value placements for a LOG axis, densest first: the mantissa sets of
+     * {@link #LOG_DECADE_SUBDIVISIONS}, then whole decades every 2, 5, 10, 20, 50...
+     * Tick counts never increase with the level, so the first level within budget is the
+     * densest that fits, and some level always fits since the coarse steps grow without bound.
+     */
+    private List<Double> logTickCandidate(int level, double transformedMin, double transformedMax, double decadeAnchor) {
+        if (level < LOG_DECADE_SUBDIVISIONS.length) {
+            return decadeTicks(transformedMin, transformedMax, LOG_DECADE_SUBDIVISIONS[level]);
+        }
+        int coarse = level - LOG_DECADE_SUBDIVISIONS.length;
+        double step = (coarse % 2 == 0 ? 2 : 5) * Math.pow(10, coarse / 2);
+        return coarseDecadeTicks(transformedMin, transformedMax, step, decadeAnchor);
+    }
+
+    /** Every {@code 10^(anchor + k * step)} within [transformedMin, transformedMax], ascending. */
+    private List<Double> coarseDecadeTicks(double transformedMin, double transformedMax, double step, double decadeAnchor) {
+        List<Double> ticks = new ArrayList<>();
+        long first = (long) Math.ceil((transformedMin - decadeAnchor - LOG_TICK_EPSILON) / step);
+        long last = (long) Math.floor((transformedMax - decadeAnchor + LOG_TICK_EPSILON) / step);
+        for (long k = first; k <= last; k++) {
+            ticks.add(Math.pow(10, decadeAnchor + k * step));
+        }
+        return ticks;
     }
 
     /** Every {@code mantissa x 10^k} within [transformedMin, transformedMax], ascending. */
@@ -340,35 +364,32 @@ public class AxisRenderer {
      * Ticks for a SYMLOG axis: each log region gets LOG's round placement counted from the
      * seam, so +/-L is ticked whatever the zoom; the linear region between gets even
      * data-space steps; and the target count is split between the regions by the share of
-     * the axis each occupies, so density stays comparable with the other scales.
+     * the axis each occupies, so density stays comparable with the other scales. A region
+     * too thin to hold a label is left unticked rather than given two labels on top of
+     * each other.
      */
-    private List<Double> symlogTicks(double transformedMin, double transformedMax, int numTicks) {
+    private List<Double> symlogTicks(double transformedMin, double transformedMax, int numTicks, int plotHeight) {
         YAxisScale scale = YAxisScale.SYMLOG;
-        double seam = scale.transform(scale.linearThreshold().orElseThrow());
+        double threshold = scale.linearThreshold().orElseThrow();
+        double seam = scale.transform(threshold);
         double span = transformedMax - transformedMin;
+        double pixelsPerUnit = plotHeight / span;
         List<Double> ticks = new ArrayList<>();
 
-        // Positive log region, and the negative one as its mirror image
-        double positiveLo = Math.max(seam, transformedMin);
-        if (transformedMax > positiveLo) {
-            int budget = regionBudget(numTicks, (transformedMax - positiveLo) / span);
-            for (double tick : logTicks(positiveLo, transformedMax, budget, seam)) {
-                if (inRange(Math.log10(tick), positiveLo, transformedMax)) ticks.add(tick);
-            }
-        }
-        double negativeLo = Math.max(seam, -transformedMax);
-        double negativeHi = -transformedMin;
-        if (negativeHi > negativeLo) {
-            int budget = regionBudget(numTicks, (negativeHi - negativeLo) / span);
-            for (double tick : logTicks(negativeLo, negativeHi, budget, seam)) {
-                if (inRange(Math.log10(tick), negativeLo, negativeHi)) ticks.add(-tick);
+        // The log regions, the negative one as the positive one's mirror image
+        for (int sign : new int[] {1, -1}) {
+            double lo = Math.max(seam, sign > 0 ? transformedMin : -transformedMax);
+            double hi = sign > 0 ? transformedMax : -transformedMin;
+            if ((hi - lo) * pixelsPerUnit >= VALUE_AXIS_MIN_SPACING) {
+                int budget = regionBudget(numTicks, (hi - lo) / span);
+                for (double tick : logTicks(lo, hi, budget, seam)) ticks.add(sign * tick);
             }
         }
 
-        // Linear region, in data space
+        // The linear region, in data space
         double linearLo = Math.max(-seam, transformedMin);
         double linearHi = Math.min(seam, transformedMax);
-        if (linearHi > linearLo) {
+        if ((linearHi - linearLo) * pixelsPerUnit >= VALUE_AXIS_MIN_SPACING) {
             int budget = regionBudget(numTicks, (linearHi - linearLo) / span);
             double lo = scale.inverseTransform(linearLo);
             double hi = scale.inverseTransform(linearHi);
@@ -377,11 +398,14 @@ public class AxisRenderer {
             }
         }
 
-        // The seam belongs to two regions; keep one copy
+        // The seam belongs to two regions. Snap it to exactly +/-L, so the grid can tell
+        // the marker's row from a neighbour by value, then keep one copy. Only exact
+        // duplicates go: a tolerance would eat neighbouring ticks on a view of tiny values.
+        ticks.replaceAll(tick -> isThreshold(tick, threshold) ? Math.copySign(threshold, tick) : tick);
         ticks.sort(null);
         List<Double> distinct = new ArrayList<>(ticks.size());
         for (double tick : ticks) {
-            if (distinct.isEmpty() || !sameTick(distinct.get(distinct.size() - 1), tick)) distinct.add(tick);
+            if (distinct.isEmpty() || distinct.get(distinct.size() - 1) != tick) distinct.add(tick);
         }
         return distinct;
     }
@@ -395,8 +419,9 @@ public class AxisRenderer {
         return transformed >= transformedMin - LOG_TICK_EPSILON && transformed <= transformedMax + LOG_TICK_EPSILON;
     }
 
-    private static boolean sameTick(double a, double b) {
-        return Math.abs(a - b) <= LOG_TICK_EPSILON * Math.max(1.0, Math.abs(a));
+    /** Whether {@code value} is the linear-region threshold, +L or -L, within tick slack. */
+    private static boolean isThreshold(double value, double threshold) {
+        return Math.abs(Math.abs(value) - threshold) <= LOG_TICK_EPSILON * threshold;
     }
 
     /**
@@ -424,28 +449,14 @@ public class AxisRenderer {
             }
         }
 
-        // Draw horizontal grid lines aligned with value axis ticks. A row the scale's
-        // threshold marker owns is left to it, so the dashed cue never sits on a solid line.
-        int[] thresholdRows = thresholdRows(viewport);
-        for (Double tickValue : axisInfo.valueTicks) {
-            int screenY = viewport.valueToScreenY(tickValue);
-            if (screenY != thresholdRows[0] && screenY != thresholdRows[1]) {
-                drawHorizontalLine(g2d, viewport, screenY);
-            }
-        }
-    }
-
-    /**
-     * Screen rows of the scale's linear-region thresholds, +L and -L, or two off-plot rows
-     * for a scale without one. Always two entries so callers need no emptiness check.
-     */
-    private int[] thresholdRows(ViewPort viewport) {
+        // Draw horizontal grid lines aligned with value axis ticks. The tick at a scale's
+        // threshold (+/-L) is the marker's, decided by value rather than by pixel row so
+        // the dashed cue never sits on, or one pixel off, a solid line.
         OptionalDouble threshold = viewport.getYAxisScale().linearThreshold();
-        if (threshold.isEmpty()) {
-            return new int[] {Integer.MIN_VALUE, Integer.MIN_VALUE};
+        for (Double tickValue : axisInfo.valueTicks) {
+            if (threshold.isPresent() && isThreshold(tickValue, threshold.getAsDouble())) continue;
+            drawHorizontalLine(g2d, viewport, viewport.valueToScreenY(tickValue));
         }
-        double linearThreshold = threshold.getAsDouble();
-        return new int[] {viewport.valueToScreenY(linearThreshold), viewport.valueToScreenY(-linearThreshold)};
     }
 
     /** Draws a plot-wide horizontal line at {@code screenY} if it lies inside the plot area. */
@@ -468,15 +479,16 @@ public class AxisRenderer {
      * @param colors The current theme's plot colours (resolved once per paint)
      */
     public void drawScaleThresholds(Graphics2D g2d, ViewPort viewport, PlotColors colors) {
-        if (viewport.getYAxisScale().linearThreshold().isEmpty()) return;
+        OptionalDouble threshold = viewport.getYAxisScale().linearThreshold();
+        if (threshold.isEmpty()) return;
 
         // Derived from the grid role rather than a theme key of its own, so the marker keeps
         // the grid's relationship to the background in every theme while reading as deliberate.
         g2d.setColor(PlotColors.shiftForContrast(colors.grid, colors.background, THRESHOLD_CONTRAST_SHIFT));
         g2d.setStroke(THRESHOLD_STROKE);
-        for (int row : thresholdRows(viewport)) {
-            drawHorizontalLine(g2d, viewport, row);
-        }
+        double linearThreshold = threshold.getAsDouble();
+        drawHorizontalLine(g2d, viewport, viewport.valueToScreenY(linearThreshold));
+        drawHorizontalLine(g2d, viewport, viewport.valueToScreenY(-linearThreshold));
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
@@ -1,5 +1,6 @@
 package com.kalix.ide.flowviz.rendering;
 
+import com.kalix.ide.flowviz.style.DashStyle;
 import com.kalix.ide.flowviz.transform.YAxisScale;
 import com.kalix.ide.utils.TimeFormatUtil;
 
@@ -9,6 +10,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalDouble;
 import java.util.function.DoubleUnaryOperator;
 
 import static com.kalix.ide.flowviz.transform.PlotTypeTransformer.PERCENTILE_SCALE;
@@ -38,6 +40,8 @@ public class AxisRenderer {
     };
     /** Slack for a tick sitting on a viewport edge, in decades (log10 rounding). */
     private static final double LOG_TICK_EPSILON = 1e-9;
+    /** How far the threshold marker is shifted from the grid colour, towards the foreground. */
+    private static final int THRESHOLD_CONTRAST_SHIFT = 80;
 
     private final TemporalAxisCalculator temporalCalculator;
 
@@ -354,6 +358,43 @@ public class AxisRenderer {
         // Draw horizontal grid lines aligned with value axis ticks
         for (Double tickValue : axisInfo.valueTicks) {
             int screenY = viewport.valueToScreenY(tickValue);
+            if (screenY >= plotY && screenY <= plotY + plotHeight) {
+                g2d.drawLine(plotX, screenY, plotX + plotWidth, screenY);
+            }
+        }
+    }
+
+    /**
+     * Marks the linear-region boundaries of a scale that has one (currently only
+     * {@link YAxisScale#SYMLOG}) with a dashed horizontal line at +/-L.
+     *
+     * <p>Without this the change in axis behaviour at the threshold is invisible: the same
+     * vertical distance means a fixed increment below it and a decade above it. Draws nothing
+     * for scales with no linear region, and each line is clipped away individually once the
+     * viewport is panned past it.</p>
+     *
+     * @param g2d Graphics context
+     * @param viewport Current viewport
+     * @param colors The current theme's plot colours (resolved once per paint)
+     */
+    public void drawScaleThresholds(Graphics2D g2d, ViewPort viewport, PlotColors colors) {
+        OptionalDouble threshold = viewport.getYAxisScale().linearThreshold();
+        if (threshold.isEmpty()) return;
+
+        // Derived from the grid role rather than a theme key of its own, so the marker keeps
+        // the grid's relationship to the background in every theme while reading as deliberate.
+        g2d.setColor(PlotColors.shiftForContrast(colors.grid, colors.background, THRESHOLD_CONTRAST_SHIFT));
+        g2d.setStroke(new BasicStroke(GRID_STROKE_WIDTH, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER,
+            10.0f, DashStyle.DASHED.dashArray(), 0.0f));
+
+        int plotX = viewport.getPlotX();
+        int plotY = viewport.getPlotY();
+        int plotWidth = viewport.getPlotWidth();
+        int plotHeight = viewport.getPlotHeight();
+
+        double linearThreshold = threshold.getAsDouble();
+        for (double value : new double[]{linearThreshold, -linearThreshold}) {
+            int screenY = viewport.valueToScreenY(value);
             if (screenY >= plotY && screenY <= plotY + plotHeight) {
                 g2d.drawLine(plotX, screenY, plotX + plotWidth, screenY);
             }

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
@@ -448,9 +448,13 @@ public class AxisRenderer {
         return transformed >= transformedMin - LOG_TICK_EPSILON && transformed <= transformedMax + LOG_TICK_EPSILON;
     }
 
-    /** Whether {@code value} is the linear-region threshold, +L or -L, within tick slack. */
+    /**
+     * Whether {@code value} is the linear-region threshold, +L or -L, allowing the ulp of
+     * drift an even step accumulates (9.6 + 8 x 0.05 is 10.000000000000002) and no more,
+     * so a real tick a hair from the seam is never mistaken for it.
+     */
     private static boolean isThreshold(double value, double threshold) {
-        return Math.abs(Math.abs(value) - threshold) <= LOG_TICK_EPSILON * threshold;
+        return Math.abs(Math.abs(value) - threshold) <= 4 * Math.ulp(threshold);
     }
 
     /**
@@ -480,10 +484,11 @@ public class AxisRenderer {
 
         // Draw horizontal grid lines aligned with value axis ticks. The tick at a scale's
         // threshold (+/-L) is the marker's, decided by value rather than by pixel row so
-        // the dashed cue never sits on, or one pixel off, a solid line.
+        // the dashed cue never sits on, or one pixel off, a solid line. Exact: the tick
+        // placement snaps the seam tick to exactly +/-L.
         OptionalDouble threshold = viewport.getYAxisScale().linearThreshold();
         for (Double tickValue : axisInfo.valueTicks) {
-            if (threshold.isPresent() && isThreshold(tickValue, threshold.getAsDouble())) continue;
+            if (threshold.isPresent() && Math.abs(tickValue) == threshold.getAsDouble()) continue;
             drawHorizontalLine(g2d, viewport, viewport.valueToScreenY(tickValue));
         }
     }

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/AxisRenderer.java
@@ -40,6 +40,10 @@ public class AxisRenderer {
     };
     /** Slack for a tick sitting on a viewport edge, in decades (log10 rounding). */
     private static final double LOG_TICK_EPSILON = 1e-9;
+    /** Widest LOG view (in decades, a factor of ~3) on which even data-space steps still read evenly. */
+    private static final double LOG_EVEN_STEPS_MAX_DECADES = 0.5;
+    /** Coarse decade steps, 1-2-5 per decade: 2, 5, 10, 20, 50... so no rung is more than 2.5x the last. */
+    private static final double[] COARSE_DECADE_STEPS = {2, 5, 10};
     /** How far the threshold marker is shifted from the grid colour, towards the foreground. */
     private static final int THRESHOLD_CONTRAST_SHIFT = 80;
     private static final BasicStroke THRESHOLD_STROKE = new BasicStroke(GRID_STROKE_WIDTH,
@@ -301,12 +305,14 @@ public class AxisRenderer {
             }
             denser = candidate;
         }
-        if (ticks.size() >= MIN_TARGET_TICKS) return ticks;
+        double decades = transformedMax - transformedMin;
+        if (ticks.size() >= MIN_TARGET_TICKS || decades >= LOG_EVEN_STEPS_MAX_DECADES) return ticks;
 
         // Under a factor of ~2 end to end even 1..9 gives too few (9.5..19 holds only
         // 10): even data-space steps do better there, and log is near enough linear
-        // that their spacing reads fine. Keep the round set when the steps do no better
-        // (a tiny budget over a wide span), so a step never lands on 0 or off-plot.
+        // that their spacing reads fine. Only there: over a wide view on a short plot the
+        // steps would all crowd into the top decade, so a sparse round pair is kept. Keep
+        // the round set too when the steps do no better, so a step never lands on 0.
         double minValue = Math.pow(10, transformedMin);
         double maxValue = Math.pow(10, transformedMax);
         List<Double> evenSteps = new ArrayList<>();
@@ -322,14 +328,17 @@ public class AxisRenderer {
      * The round-value placements for a LOG axis, densest first: the mantissa sets of
      * {@link #LOG_DECADE_SUBDIVISIONS}, then whole decades every 2, 5, 10, 20, 50...
      * Tick counts never increase with the level, so the first level within budget is the
-     * densest that fits, and some level always fits since the coarse steps grow without bound.
+     * densest that fits, and some level always fits since the coarse steps grow without
+     * bound. No rung is more than 2.5x the one before, which bounds how far over budget
+     * "one placement denser" can land.
      */
     private List<Double> logTickCandidate(int level, double transformedMin, double transformedMax, double decadeAnchor) {
         if (level < LOG_DECADE_SUBDIVISIONS.length) {
             return decadeTicks(transformedMin, transformedMax, LOG_DECADE_SUBDIVISIONS[level]);
         }
         int coarse = level - LOG_DECADE_SUBDIVISIONS.length;
-        double step = (coarse % 2 == 0 ? 2 : 5) * Math.pow(10, coarse / 2);
+        double step = COARSE_DECADE_STEPS[coarse % COARSE_DECADE_STEPS.length]
+            * Math.pow(10, coarse / COARSE_DECADE_STEPS.length);
         return coarseDecadeTicks(transformedMin, transformedMax, step, decadeAnchor);
     }
 
@@ -366,9 +375,24 @@ public class AxisRenderer {
      * data-space steps; and the target count is split between the regions by the share of
      * the axis each occupies, so density stays comparable with the other scales. A region
      * too thin to hold a label is left unticked rather than given two labels on top of
-     * each other.
+     * each other -- unless that leaves the axis with too few labels altogether (a short
+     * plot), when every region is ticked regardless.
      */
     private List<Double> symlogTicks(double transformedMin, double transformedMax, int numTicks, int plotHeight) {
+        List<Double> ticks = symlogRegionTicks(transformedMin, transformedMax, numTicks, plotHeight, VALUE_AXIS_MIN_SPACING);
+        if (ticks.size() < MIN_TARGET_TICKS) {
+            ticks = symlogRegionTicks(transformedMin, transformedMax, numTicks, plotHeight, 0);
+        }
+        return ticks;
+    }
+
+    /**
+     * The SYMLOG regions' ticks, skipping any region under {@code minRegionPixels} tall.
+     * When the linear region is skipped the two seam ticks sit within a label of each
+     * other, so they collapse to a single 0.
+     */
+    private List<Double> symlogRegionTicks(double transformedMin, double transformedMax, int numTicks,
+                                           int plotHeight, int minRegionPixels) {
         YAxisScale scale = YAxisScale.SYMLOG;
         double threshold = scale.linearThreshold().orElseThrow();
         double seam = scale.transform(threshold);
@@ -380,7 +404,7 @@ public class AxisRenderer {
         for (int sign : new int[] {1, -1}) {
             double lo = Math.max(seam, sign > 0 ? transformedMin : -transformedMax);
             double hi = sign > 0 ? transformedMax : -transformedMin;
-            if ((hi - lo) * pixelsPerUnit >= VALUE_AXIS_MIN_SPACING) {
+            if ((hi - lo) * pixelsPerUnit >= minRegionPixels) {
                 int budget = regionBudget(numTicks, (hi - lo) / span);
                 for (double tick : logTicks(lo, hi, budget, seam)) ticks.add(sign * tick);
             }
@@ -389,7 +413,8 @@ public class AxisRenderer {
         // The linear region, in data space
         double linearLo = Math.max(-seam, transformedMin);
         double linearHi = Math.min(seam, transformedMax);
-        if ((linearHi - linearLo) * pixelsPerUnit >= VALUE_AXIS_MIN_SPACING) {
+        boolean linearShown = (linearHi - linearLo) * pixelsPerUnit >= minRegionPixels;
+        if (linearShown) {
             int budget = regionBudget(numTicks, (linearHi - linearLo) / span);
             double lo = scale.inverseTransform(linearLo);
             double hi = scale.inverseTransform(linearHi);
@@ -402,6 +427,10 @@ public class AxisRenderer {
         // the marker's row from a neighbour by value, then keep one copy. Only exact
         // duplicates go: a tolerance would eat neighbouring ticks on a view of tiny values.
         ticks.replaceAll(tick -> isThreshold(tick, threshold) ? Math.copySign(threshold, tick) : tick);
+        if (!linearShown && ticks.contains(threshold) && ticks.contains(-threshold)) {
+            ticks.removeIf(tick -> tick == threshold || tick == -threshold);
+            ticks.add(0.0);
+        }
         ticks.sort(null);
         List<Double> distinct = new ArrayList<>(ticks.size());
         for (double tick : ticks) {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/TimeSeriesRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/TimeSeriesRenderer.java
@@ -81,6 +81,9 @@ public class TimeSeriesRenderer {
         // Draw grid
         if (showGrid) {
             axisRenderer.drawGrid(g2d, viewport, axisInfo, colors);
+
+            // Mark where a symmetric-log axis switches from linear to logarithmic.
+            axisRenderer.drawScaleThresholds(g2d, viewport, colors);
         }
 
         // Draw axes

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/TimeSeriesRenderer.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/TimeSeriesRenderer.java
@@ -81,10 +81,11 @@ public class TimeSeriesRenderer {
         // Draw grid
         if (showGrid) {
             axisRenderer.drawGrid(g2d, viewport, axisInfo, colors);
-
-            // Mark where a symmetric-log axis switches from linear to logarithmic.
-            axisRenderer.drawScaleThresholds(g2d, viewport, colors);
         }
+
+        // Mark where a symmetric-log axis switches from linear to logarithmic. Part of the
+        // axis, not the grid: without it 5->10 and 10->100 read as equal steps.
+        axisRenderer.drawScaleThresholds(g2d, viewport, colors);
 
         // Draw axes
         axisRenderer.drawAxes(g2d, viewport, axisInfo, colors);

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/ViewPort.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/rendering/ViewPort.java
@@ -172,61 +172,58 @@ public class ViewPort {
         long timeRange = endTimeMs - startTimeMs;
         long centerTimeMs = startTimeMs + timeRange / 2;
         long newTimeRange = (long) (timeRange / factor);
-        double[] valueBounds = valueBoundsZoomedAbout(factor, 0.5);
-
-        return new ViewPort(centerTimeMs - newTimeRange / 2, centerTimeMs + newTimeRange / 2,
-                          valueBounds[0], valueBounds[1],
-                          plotX, plotY, plotWidth, plotHeight, yAxisScale, xAxisType);
+        return zoomValueAxis(factor, 0.5)
+            .withTimeRange(centerTimeMs - newTimeRange / 2, centerTimeMs + newTimeRange / 2);
     }
 
     /**
-     * Value bounds after zooming the value axis by {@code factor} (above 1 zooms in) about
-     * the value under {@code screenY}, which stays put on screen -- the wheel-zoom
-     * contract. Computed in transformed space so the anchor holds on every scale. Returns
-     * the current bounds unchanged when the zoomed span is not showable
-     * (see {@link #valueBoundsFor}).
+     * This view with the value axis zoomed by {@code factor} (above 1 zooms in) about the
+     * value under {@code screenY}, which stays put on screen -- the wheel-zoom contract.
+     * Computed in transformed space so the anchor holds on every scale. Returns this view
+     * unchanged when the zoomed span is not showable (see {@link #withValueBoundsFrom}).
      */
-    public double[] valueBoundsZoomedAbout(double factor, int screenY) {
+    public ViewPort zoomValueAxis(double factor, int screenY) {
         double ratio = plotHeight == 0 ? 0.5 : (double) (plotY + plotHeight - screenY) / plotHeight;
-        return valueBoundsZoomedAbout(factor, ratio);
+        return zoomValueAxis(factor, ratio);
     }
 
     /** As above, anchored at {@code ratio} of the way up the plot (0 bottom, 1 top). */
-    private double[] valueBoundsZoomedAbout(double factor, double ratio) {
+    private ViewPort zoomValueAxis(double factor, double ratio) {
         double transformedMin = getTransformedMin();
         double transformedMax = getTransformedMax();
         double anchor = transformedMin + ratio * (transformedMax - transformedMin);
         double newTransformedRange = (transformedMax - transformedMin) / factor;
         double newTransformedMin = anchor - newTransformedRange * ratio;
-        return valueBoundsFor(newTransformedMin, newTransformedMin + newTransformedRange);
+        return withValueBoundsFrom(newTransformedMin, newTransformedMin + newTransformedRange);
     }
 
     /**
-     * Value bounds re-centred on {@code value} when it is off-screen, keeping the span in
-     * transformed space so the zoom level survives on every scale (a log axis keeps its
-     * decade count, not its data-space width). Returns the current bounds unchanged when
-     * {@code value} is already on screen, is not showable on this scale (non-finite, or
-     * non-positive on LOG), or the centred span would not be (see {@link #valueBoundsFor}).
+     * This view with the value axis re-centred on {@code value} when it is off-screen,
+     * keeping the span in transformed space so the zoom level survives on every scale (a
+     * log axis keeps its decade count, not its data-space width). Returns this view
+     * unchanged when {@code value} is already on screen, is not showable on this scale
+     * (non-finite, or non-positive on LOG), or the centred span would not be
+     * (see {@link #withValueBoundsFrom}).
      *
      * <p>"On screen" is judged in transformed space, against the axis as drawn: on LOG with
      * a non-positive stored minimum the drawn range is the fallback, not the stored bounds,
      * and a data-space compare would call a point below the plot visible.</p>
      */
-    public double[] valueBoundsCentredOn(double value) {
+    public ViewPort centreValueAxisOn(double value) {
         double transformedValue = yAxisScale.transform(value);
         double transformedMin = getTransformedMin();
         double transformedMax = getTransformedMax();
         boolean offScreen = transformedValue < transformedMin || transformedValue > transformedMax;
         if (!offScreen || !Double.isFinite(transformedValue)) {
-            return new double[] {minValue, maxValue};
+            return this;
         }
         double halfSpan = (transformedMax - transformedMin) / 2;
-        return valueBoundsFor(transformedValue - halfSpan, transformedValue + halfSpan);
+        return withValueBoundsFrom(transformedValue - halfSpan, transformedValue + halfSpan);
     }
 
     /**
-     * Data-space value bounds for a span given in transformed space, or the current
-     * bounds when that span no longer maps to values the scale can show. LOG's inverse
+     * This view with value bounds given as a span in transformed space, or this view
+     * unchanged when that span no longer maps to values the scale can show. LOG's inverse
      * is {@code 10^t}, which overflows to infinity past ~308 decades and underflows to
      * zero (invalid for LOG) past ~-323. Installing either blanks the axis and leaves the
      * viewport stuck, because every later step is computed from the broken bounds
@@ -235,18 +232,23 @@ public class ViewPort {
      * stops. An inverted or empty result is refused for the same reason. Every zoom, pan
      * and recentre of the value axis goes through here.
      */
-    private double[] valueBoundsFor(double transformedMin, double transformedMax) {
+    private ViewPort withValueBoundsFrom(double transformedMin, double transformedMax) {
         double newMinValue = yAxisScale.inverseTransform(transformedMin);
         double newMaxValue = yAxisScale.inverseTransform(transformedMax);
         if (!isShowable(newMinValue) || !isShowable(newMaxValue) || newMinValue >= newMaxValue) {
-            return new double[] {minValue, maxValue};
+            return this;
         }
-        return new double[] {newMinValue, newMaxValue};
+        return withValueBounds(newMinValue, newMaxValue);
     }
 
-    /** Finite, and inside the scale's domain (LOG cannot show zero or negatives). */
+    /** Finite, and inside the scale's domain: the one rule, owned by {@link YAxisScale#domainFloor}. */
     private boolean isShowable(double value) {
-        return Double.isFinite(value) && !Double.isNaN(yAxisScale.transform(value));
+        return Double.isFinite(value) && value > yAxisScale.domainFloor();
+    }
+
+    private ViewPort withValueBounds(double minValue, double maxValue) {
+        return new ViewPort(startTimeMs, endTimeMs, minValue, maxValue,
+                          plotX, plotY, plotWidth, plotHeight, yAxisScale, xAxisType);
     }
 
     /**
@@ -272,10 +274,12 @@ public class ViewPort {
         // Delta in transformed space (positive deltaPixelsY = pan up = increase values)
         double deltaTransformed = deltaPixelsY * transformedRange / (double) plotHeight;
 
-        double[] valueBounds = valueBoundsFor(transformedMin + deltaTransformed,
-                                              transformedMax + deltaTransformed);
+        return withValueBoundsFrom(transformedMin + deltaTransformed, transformedMax + deltaTransformed)
+            .withTimeRange(newStartTime, newEndTime);
+    }
 
-        return new ViewPort(newStartTime, newEndTime, valueBounds[0], valueBounds[1],
+    public ViewPort withTimeRange(long startTimeMs, long endTimeMs) {
+        return new ViewPort(startTimeMs, endTimeMs, minValue, maxValue,
                           plotX, plotY, plotWidth, plotHeight, yAxisScale, xAxisType);
     }
 
@@ -294,10 +298,8 @@ public class ViewPort {
         ViewPort rescaled = new ViewPort(startTimeMs, endTimeMs, minValue, maxValue,
                           plotX, plotY, plotWidth, plotHeight, yAxisScale, xAxisType);
         if (rescaled.isShowable(minValue) && rescaled.isShowable(maxValue)) return rescaled;
-        return new ViewPort(startTimeMs, endTimeMs,
-                          yAxisScale.inverseTransform(rescaled.getTransformedMin()),
-                          yAxisScale.inverseTransform(rescaled.getTransformedMax()),
-                          plotX, plotY, plotWidth, plotHeight, yAxisScale, xAxisType);
+        return rescaled.withValueBounds(yAxisScale.inverseTransform(rescaled.getTransformedMin()),
+                                        yAxisScale.inverseTransform(rescaled.getTransformedMax()));
     }
 
     public ViewPort withXAxisType(XAxisType xAxisType) {

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/transform/YAxisScale.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/transform/YAxisScale.java
@@ -18,8 +18,8 @@ public enum YAxisScale {
     /**
      * Symmetric log - linear on [-L, L] and log_10 outside it, with L = 10.
      * Inspired by, but not the same as, matplotlib's symlog. This implementation
-     * keeps log10(10**n) on integral positions so the axis ticks read as 10, 100,
-     * etc.
+     * keeps log10(10**n) on integral positions, and the linear zone on exactly one
+     * decade of transformed space, so the axis reads as -100, -10, 0, 10, 100.
      */
     SYMLOG("Symlog")
     ;
@@ -53,10 +53,27 @@ public enum YAxisScale {
      * region, which is every other scale at present.
      *
      * <p>Exposed so renderers can mark where the axis changes behaviour without holding a
-     * second copy of the constant; this enum stays the sole owner of each scale's parameters.</p>
+     * second copy of the constant; this enum stays the sole owner of each scale's parameters.
+     * An exhaustive switch, so a new scale has to decide here whether it has a region to mark.</p>
      */
     public OptionalDouble linearThreshold() {
-        return this == SYMLOG ? OptionalDouble.of(SYMLOG_THRESHOLD) : OptionalDouble.empty();
+        return switch (this) {
+            case SYMLOG -> OptionalDouble.of(SYMLOG_THRESHOLD);
+            case LINEAR, LOG, SQRT -> OptionalDouble.empty();
+        };
+    }
+
+    /**
+     * Exclusive lower bound of this scale's domain: values at or below it have no position
+     * on the axis, and {@link #transform} returns NaN for them. NEGATIVE_INFINITY for scales
+     * defined everywhere, so {@code value <= domainFloor()} rejects no finite value and a
+     * per-point domain check costs one compare whatever the scale.
+     */
+    public double domainFloor() {
+        return switch (this) {
+            case LOG -> 0.0;                                          // log10 needs y > 0
+            case LINEAR, SQRT, SYMLOG -> Double.NEGATIVE_INFINITY;    // defined everywhere
+        };
     }
 
     /**

--- a/kalixide/src/main/java/com/kalix/ide/flowviz/transform/YAxisScale.java
+++ b/kalixide/src/main/java/com/kalix/ide/flowviz/transform/YAxisScale.java
@@ -1,5 +1,7 @@
 package com.kalix.ide.flowviz.transform;
 
+import java.util.OptionalDouble;
+
 /**
  * Y-axis scale transformations for plot display.
  */
@@ -11,7 +13,29 @@ public enum YAxisScale {
     LOG("Log"),
 
     /** Square root scale. */
-    SQRT("Sqrt");
+    SQRT("Sqrt"),
+
+    /**
+     * Symmetric log - linear on [-L, L] and log_10 outside it, with L = 10.
+     * Inspired by, but not the same as, matplotlib's symlog. This implementation
+     * keeps log10(10**n) on integral positions so the axis ticks read as 10, 100,
+     * etc.
+     */
+    SYMLOG("Symlog")
+    ;
+
+    /** SYMLOG linear threshold: |y| below this is drawn linearly. */
+    private static final double SYMLOG_THRESHOLD = 10.0;
+
+    /** Transformed position of the threshold - where the two SYMLOG branches meet. */
+    private static final double SYMLOG_LOG_THRESHOLD = Math.log10(SYMLOG_THRESHOLD);
+
+    /**
+     * Slope of the SYMLOG linear branch. Derived, not chosen: continuity at +/-L
+     * requires L * slope == log10(L), so the linear zone occupies exactly one decade
+     * of transformed space either side of zero.
+     */
+    private static final double SYMLOG_LINEAR_SLOPE = SYMLOG_LOG_THRESHOLD / SYMLOG_THRESHOLD;
 
     private final String displayName;
 
@@ -21,6 +45,18 @@ public enum YAxisScale {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    /**
+     * The linear-region threshold L, for scales that have one - the magnitude below which
+     * values are drawn linearly rather than logarithmically. Empty for scales with no such
+     * region, which is every other scale at present.
+     *
+     * <p>Exposed so renderers can mark where the axis changes behaviour without holding a
+     * second copy of the constant; this enum stays the sole owner of each scale's parameters.</p>
+     */
+    public OptionalDouble linearThreshold() {
+        return this == SYMLOG ? OptionalDouble.of(SYMLOG_THRESHOLD) : OptionalDouble.empty();
     }
 
     /**
@@ -43,6 +79,15 @@ public enum YAxisScale {
                     yield -Math.sqrt(-y);
                 }
             }
+            case SYMLOG -> {
+                if (y >= SYMLOG_THRESHOLD) {
+                    yield Math.log10(y);
+                } else if (y <= -SYMLOG_THRESHOLD) {
+                    yield -Math.log10(-y);
+                } else {
+                    yield y * SYMLOG_LINEAR_SLOPE;
+                }
+            }
         };
     }
 
@@ -62,6 +107,15 @@ public enum YAxisScale {
                     yield transformedY * transformedY;
                 } else {
                     yield -(transformedY * transformedY);
+                }
+            }
+            case SYMLOG -> {
+                if (transformedY >= SYMLOG_LOG_THRESHOLD) {
+                    yield Math.pow(10, transformedY);
+                } else if (transformedY <= -SYMLOG_LOG_THRESHOLD) {
+                    yield -Math.pow(10, -transformedY);
+                } else {
+                    yield transformedY / SYMLOG_LINEAR_SLOPE;
                 }
             }
         };

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/FlowVizPanelZoomToFitTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/FlowVizPanelZoomToFitTest.java
@@ -1,0 +1,43 @@
+package com.kalix.ide.flowviz;
+
+import com.kalix.ide.flowviz.data.DataSet;
+import com.kalix.ide.flowviz.data.DatasetSeries;
+import com.kalix.ide.flowviz.data.TimeSeriesData;
+import com.kalix.ide.flowviz.rendering.ViewPort;
+import com.kalix.ide.flowviz.transform.YAxisScale;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins that zoom-to-fit honours the scale's domain the way auto-Y does: on LOG a series
+ * that touches zero fits to its smallest positive value rather than padding from NaN.
+ */
+class FlowVizPanelZoomToFitTest {
+
+    private static final long DAY = 86_400_000L;
+
+    @Test
+    void logZoomToFitSkipsValuesTheScaleCannotShow() {
+        FlowVizPanel panel = new FlowVizPanel();
+        DataSet dataSet = new DataSet();
+        DatasetSeries ref = new DatasetSeries("/tmp/x.csv", "flow");
+        // All below the default small-value clamp, so only the domain rule can save the fit
+        dataSet.addSeries(ref, new TimeSeriesData(
+            new long[] {0, DAY, 2 * DAY}, new double[] {0.0, 0.5, 0.9}));
+        panel.setDataSet(dataSet);
+        panel.setVisibleSeries(List.of(ref));
+        panel.setYAxisScale(YAxisScale.LOG);
+        panel.refreshData(true);
+
+        panel.zoomToFit();
+
+        ViewPort v = panel.viewportForTests();
+        assertTrue(Double.isFinite(v.getMinValue()) && Double.isFinite(v.getMaxValue()), "finite bounds: " + v);
+        assertTrue(v.getMinValue() > 0 && v.getMinValue() <= 0.5, "fits to the smallest positive value: " + v);
+        assertTrue(v.getMaxValue() >= 0.9, "reaches the maximum: " + v);
+    }
+}

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
@@ -152,6 +152,33 @@ class AxisRendererValueTicksTest {
             () -> assertTrue(renderer.calculateAxisInfo(sliver).timeTicks.size() <= 4 * 7 + 1));
     }
 
+    private List<Double> symlogTicks(double min, double max, int plotHeight) {
+        return renderer.calculateValueTicks(viewport(min, max, plotHeight, YAxisScale.SYMLOG));
+    }
+
+    /** The seam at +/-10 is ticked even when the coarse step is two decades. */
+    @Test
+    void symlogTicksAreRoundOnBothSidesAndAlwaysTickTheSeam() {
+        assertTicks(List.of(-1e5, -1e3, -10.0, 0.0, 10.0, 1e3, 1e5), symlogTicks(-1e6, 1e6, TALL));
+    }
+
+    /** Auto-Y on data 0..500: the linear zone gets even steps, the log zone round mantissas. */
+    @Test
+    void symlogTicksSplitTheBudgetBetweenLinearAndLogRegions() {
+        List<Double> ticks = symlogTicks(YAxisScale.SYMLOG.inverseTransform(-0.135), YAxisScale.SYMLOG.inverseTransform(2.834), TALL);
+        assertTicks(List.of(0.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0), ticks);
+    }
+
+    @Test
+    void symlogTicksInsideTheLinearRegionMatchLinear() {
+        assertTicks(List.of(-4.0, -2.0, 0.0, 2.0, 4.0), symlogTicks(-5, 5, TALL));
+    }
+
+    @Test
+    void symlogTicksOnOneSideOnlyStayOnThatSide() {
+        assertTicks(List.of(-1e6, -1e5, -1e4, -1e3, -100.0), symlogTicks(-1e6, -100, TALL));
+    }
+
     @Test
     void linearTicksKeepTheirEvenNiceSteps() {
         List<Double> ticks = renderer.calculateValueTicks(viewport(0, 100, TALL, YAxisScale.LINEAR));

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
@@ -34,7 +34,11 @@ class AxisRendererValueTicksTest {
     }
 
     private static void assertTicks(List<Double> expected, List<Double> actual) {
-        assertEquals(expected.size(), actual.size(), "tick count for " + actual);
+        assertTicks(expected, actual, "tick count");
+    }
+
+    private static void assertTicks(List<Double> expected, List<Double> actual, String why) {
+        assertEquals(expected.size(), actual.size(), why + " for " + actual);
         for (int i = 0; i < expected.size(); i++) {
             assertEquals(expected.get(i), actual.get(i), Math.abs(expected.get(i)) * EPS, "tick " + i + " of " + actual);
         }
@@ -88,6 +92,14 @@ class AxisRendererValueTicksTest {
         assertTicks(List.of(10.0, 20.0, 50.0, 100.0), logTicks(10, 100, 200));
     }
 
+    /** Whole decades would leave one label on a short plot over 1.78..56; 1-2-5 is taken over budget. */
+    @Test
+    void logTicksGoOneDenserRatherThanLeaveASingleLabel() {
+        assertTicks(List.of(2.0, 5.0, 10.0, 20.0, 50.0), logTicks(1.78, 56, 120));
+        assertTicks(List.of(1.0, 10.0), logTicks(0.4, 79, 120), "two decade labels fit and suffice");
+        assertTicks(List.of(100.0, 1e4, 1e6), logTicks(3.7, 3.7e6, 120), "coarse steps still count from 1");
+    }
+
     @Test
     void logTicksAreRoundAtEveryZoomAndHeight() {
         double[] starts = {0.0123, 0.5, 1, 3.7, 47, 1e5};
@@ -99,7 +111,9 @@ class AxisRendererValueTicksTest {
                     List<Double> ticks = logTicks(start, start * Math.pow(10, span), height);
                     int budget = Math.max(3, Math.min(10, height / 40));
                     assertTrue(ticks.size() >= 2, "too few ticks: " + ticks);
-                    assertTrue(ticks.size() <= budget + 2, "too many ticks for " + height + "px: " + ticks);
+                    // One placement over budget is allowed only when the fitting one left a single
+                    // label, which can only happen on a short plot with the 1-2-5 set (six at most)
+                    assertTrue(ticks.size() <= Math.max(budget + 2, 6), "too many ticks for " + height + "px: " + ticks);
                     ticks.forEach(AxisRendererValueTicksTest::assertRoundMantissa);
                 }
             }
@@ -172,6 +186,38 @@ class AxisRendererValueTicksTest {
     @Test
     void symlogTicksInsideTheLinearRegionMatchLinear() {
         assertTicks(List.of(-4.0, -2.0, 0.0, 2.0, 4.0), symlogTicks(-5, 5, TALL));
+    }
+
+    /** A bound just past the seam gave the sliver a two-tick budget: 9.5 and 10 drawn on top of each other. */
+    @Test
+    void symlogTicksSkipARegionTooThinForALabel() {
+        List<Double> ticks = symlogTicks(9.5, 1e6, TALL);
+        assertEquals(10.0, ticks.get(0), 0.0, "the seam opens the axis: " + ticks);
+        List<Double> mirrored = symlogTicks(-1e6, 10.5, TALL);
+        assertEquals(10.0, mirrored.get(mirrored.size() - 1), 0.0, "the seam closes the axis: " + mirrored);
+    }
+
+    /** The seam tick is snapped to exactly +/-L whichever region produced it, so the grid can spot it by value. */
+    @Test
+    void symlogSeamTicksAreExact() {
+        List<Double> ticks = symlogTicks(YAxisScale.SYMLOG.inverseTransform(-0.135), YAxisScale.SYMLOG.inverseTransform(2.834), TALL);
+        assertTrue(ticks.contains(10.0), "exactly 10.0, not 9.999999999999998: " + ticks);
+        assertTrue(symlogTicks(-1e6, 1e6, TALL).contains(-10.0));
+    }
+
+    /** Dedup once ate neighbouring ticks within an absolute 1e-9; a view of tiny values must tick like Linear. */
+    @Test
+    void symlogTicksOnTinyValuesMatchLinear() {
+        List<Double> linear = renderer.calculateValueTicks(viewport(0, 5e-9, TALL, YAxisScale.LINEAR));
+        assertEquals(6, linear.size(), linear.toString());
+        assertTicks(linear, symlogTicks(0, 5e-9, TALL));
+    }
+
+    /** pow(10, log10(97)) is not 97; an exact edge compare dropped the edge tick. */
+    @Test
+    void logTicksKeepATickSittingOnTheViewportEdge() {
+        assertTicks(List.of(97.0, 98.0, 99.0, 100.0, 101.0, 102.0, 103.0), logTicks(97, 103, TALL));
+        assertTicks(List.of(3.2, 3.25, 3.3, 3.35, 3.4), logTicks(3.2, 3.4, TALL));
     }
 
     @Test

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
@@ -205,6 +205,14 @@ class AxisRendererValueTicksTest {
         assertTrue(symlogTicks(-1e6, 1e6, TALL).contains(-10.0));
     }
 
+    /** The seam snap absorbs an ulp of step drift, not real ticks a hair from 10. */
+    @Test
+    void symlogSeamSnapLeavesTicksNearTheSeamAlone() {
+        List<Double> ticks = symlogTicks(9.99999999, 10.00000001, TALL);
+        assertEquals(1, ticks.stream().filter(t -> t == 10.0).count(), "one exact seam tick: " + ticks);
+        assertTrue(ticks.size() >= 5, "the neighbouring ticks survive: " + ticks);
+    }
+
     /** Dedup once ate neighbouring ticks within an absolute 1e-9; a view of tiny values must tick like Linear. */
     @Test
     void symlogTicksOnTinyValuesMatchLinear() {

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/AxisRendererValueTicksTest.java
@@ -112,7 +112,7 @@ class AxisRendererValueTicksTest {
                     int budget = Math.max(3, Math.min(10, height / 40));
                     assertTrue(ticks.size() >= 2, "too few ticks: " + ticks);
                     // One placement over budget is allowed only when the fitting one left a single
-                    // label, which can only happen on a short plot with the 1-2-5 set (six at most)
+                    // label; with no rung more than 2.5x the last that is six ticks at most
                     assertTrue(ticks.size() <= Math.max(budget + 2, 6), "too many ticks for " + height + "px: " + ticks);
                     ticks.forEach(AxisRendererValueTicksTest::assertRoundMantissa);
                 }
@@ -218,6 +218,31 @@ class AxisRendererValueTicksTest {
     void logTicksKeepATickSittingOnTheViewportEdge() {
         assertTicks(List.of(97.0, 98.0, 99.0, 100.0, 101.0, 102.0, 103.0), logTicks(97, 103, TALL));
         assertTicks(List.of(3.2, 3.25, 3.3, 3.35, 3.4), logTicks(3.2, 3.4, TALL));
+    }
+
+    /** Gating every region at 40 px left a short Symlog plot with markers but no labels at all. */
+    @Test
+    void symlogTicksOnAShortPlotStillLabelTheAxis() {
+        assertTicks(List.of(5.0, 10.0, 20.0), symlogTicks(5, 20, 60));
+        assertTicks(List.of(-1000.0, -100.0, -10.0, 0.0, 10.0, 100.0, 1000.0), symlogTicks(-1000, 1000, 100));
+    }
+
+    /** With the linear zone a pixel wide the seam pair would print 10 and -10 on top of each other. */
+    @Test
+    void symlogSeamPairCollapsesToZeroWhenTheLinearZoneIsSkipped() {
+        assertTicks(List.of(-1e101, 0.0, 1e101), symlogTicks(-1e200, 1e200, 120));
+    }
+
+    /** Coarse steps go 2, 5, 10, 20...; a 2-5-20 ladder made "one denser" land four times over budget. */
+    @Test
+    void logCoarseStepsClimbByAtMostTwoAndAHalf() {
+        assertTicks(List.of(1.0, 1e10, 1e20, 1e30), logTicks(1, 1e30, 200));
+    }
+
+    /** Even data steps are for narrow views only; over 15 decades they all crowd into the top one. */
+    @Test
+    void logEvenStepsAreNotTakenOverAWideView() {
+        assertTicks(List.of(1.0, 1e5), logTicks(1.26e-5, 7.9e9, 200));
     }
 
     @Test

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/ViewPortValueAxisTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/rendering/ViewPortValueAxisTest.java
@@ -5,6 +5,7 @@ import com.kalix.ide.flowviz.transform.YAxisScale;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -22,11 +23,6 @@ class ViewPortValueAxisTest {
         return new ViewPort(0, DAY, min, max, 0, 0, 600, HEIGHT, scale, XAxisType.TIME);
     }
 
-    private static ViewPort withValueBounds(ViewPort v, double[] bounds) {
-        return new ViewPort(v.getStartTimeMs(), v.getEndTimeMs(), bounds[0], bounds[1],
-            v.getPlotX(), v.getPlotY(), v.getPlotWidth(), v.getPlotHeight(), v.getYAxisScale(), v.getXAxisType());
-    }
-
     private static double decades(ViewPort v) {
         return v.getTransformedMax() - v.getTransformedMin();
     }
@@ -37,7 +33,7 @@ class ViewPortValueAxisTest {
         int screenY = 100;   // three quarters up: value 75
         assertEquals(75.0, v.screenYToValue(screenY), 1e-12);
 
-        ViewPort zoomed = withValueBounds(v, v.valueBoundsZoomedAbout(2.0, screenY));
+        ViewPort zoomed = v.zoomValueAxis(2.0, screenY);
         assertEquals(37.5, zoomed.getMinValue(), 1e-12);
         assertEquals(87.5, zoomed.getMaxValue(), 1e-12);
         assertEquals(75.0, zoomed.screenYToValue(screenY), 1e-12, "the anchor value stays under the cursor");
@@ -49,7 +45,7 @@ class ViewPortValueAxisTest {
         int screenY = 100;   // three quarters up: 10^3
         assertEquals(1000.0, v.screenYToValue(screenY), 1000 * REL);
 
-        ViewPort zoomed = withValueBounds(v, v.valueBoundsZoomedAbout(2.0, screenY));
+        ViewPort zoomed = v.zoomValueAxis(2.0, screenY);
         assertEquals(2.0, decades(zoomed), REL, "the decade span halves");
         assertEquals(1000.0, zoomed.screenYToValue(screenY), 1000 * REL, "the anchor value stays under the cursor");
     }
@@ -59,16 +55,15 @@ class ViewPortValueAxisTest {
     void runawayWheelZoomOutStopsAtTheLastShowableViewAndCanZoomBackIn() {
         ViewPort v = viewport(1, 1e250, YAxisScale.LOG);
         for (int notch = 0; notch < 60; notch++) {
-            double[] bounds = v.valueBoundsZoomedAbout(1 / 1.1, HEIGHT / 2);
-            assertTrue(Double.isFinite(bounds[0]) && Double.isFinite(bounds[1]), "notch " + notch + " installed a non-finite bound");
-            v = withValueBounds(v, bounds);
+            v = v.zoomValueAxis(1 / 1.1, HEIGHT / 2);
+            assertTrue(Double.isFinite(v.getMinValue()) && Double.isFinite(v.getMaxValue()), "notch " + notch + " installed a non-finite bound");
         }
         double span = decades(v);
         assertTrue(span > 250, "the view grew before the overflow step was refused: " + span);
         assertTrue(v.getTransformedMax() < 308.3, "the top never exceeds what 10^t can represent: " + v);
         assertTrue(v.getTransformedMin() > -323.3, "the bottom never underflows to zero: " + v);
 
-        ViewPort zoomedIn = withValueBounds(v, v.valueBoundsZoomedAbout(1.1, HEIGHT / 2));
+        ViewPort zoomedIn = v.zoomValueAxis(1.1, HEIGHT / 2);
         assertEquals(span / 1.1, decades(zoomedIn), REL * span, "zooming back in works from the stopped view");
     }
 
@@ -113,7 +108,7 @@ class ViewPortValueAxisTest {
         assertEquals(-14.0, v.getTransformedMin(), REL, "six decades below the maximum");
         assertEquals(-8.0, v.getTransformedMax(), REL);
 
-        ViewPort zoomed = withValueBounds(v, v.valueBoundsZoomedAbout(1.1, HEIGHT / 2));
+        ViewPort zoomed = v.zoomValueAxis(1.1, HEIGHT / 2);
         assertTrue(zoomed.getMinValue() < zoomed.getMaxValue(), "the step keeps the axis upright: " + zoomed);
 
         assertEquals(-6.0, viewport(0, 100, YAxisScale.LOG).getTransformedMin(), REL, "the usual floor when the maximum allows it");
@@ -124,32 +119,28 @@ class ViewPortValueAxisTest {
     @Test
     void stepsThatWouldInvertTheAxisAreRefused() {
         ViewPort inverted = viewport(10, 1, YAxisScale.LINEAR);   // only reachable internally
-        double[] bounds = inverted.valueBoundsZoomedAbout(2.0, HEIGHT / 2);
-        assertEquals(10.0, bounds[0]);
-        assertEquals(1.0, bounds[1]);
+        ViewPort refused = inverted.zoomValueAxis(2.0, HEIGHT / 2);
+        assertEquals(10.0, refused.getMinValue());
+        assertEquals(1.0, refused.getMaxValue());
     }
 
     @Test
     void centringIsANoOpForAValueAlreadyOnScreen() {
-        double[] linear = viewport(0, 100, YAxisScale.LINEAR).valueBoundsCentredOn(50);
-        assertEquals(0.0, linear[0]);
-        assertEquals(100.0, linear[1]);
-        double[] log = viewport(1, 100, YAxisScale.LOG).valueBoundsCentredOn(100);
-        assertEquals(1.0, log[0]);
-        assertEquals(100.0, log[1]);
+        ViewPort linear = viewport(0, 100, YAxisScale.LINEAR);
+        assertSame(linear, linear.centreValueAxisOn(50));
+        ViewPort log = viewport(1, 100, YAxisScale.LOG);
+        assertSame(log, log.centreValueAxisOn(100));
     }
 
     /** On LOG with a non-positive stored minimum the axis draws 1e-6..max: judge visibility against that. */
     @Test
     void centringJudgesVisibilityAgainstTheAxisAsDrawn() {
         ViewPort v = viewport(-5, 100, YAxisScale.LOG);   // draws 1e-6..100
-        double[] bounds = v.valueBoundsCentredOn(1e-9);   // above -5 in data space, below the plot on screen
-        assertEquals(1e-13, bounds[0], 1e-13 * REL);
-        assertEquals(1e-5, bounds[1], 1e-5 * REL);
+        ViewPort centred = v.centreValueAxisOn(1e-9);   // above -5 in data space, below the plot on screen
+        assertEquals(1e-13, centred.getMinValue(), 1e-13 * REL);
+        assertEquals(1e-5, centred.getMaxValue(), 1e-5 * REL);
 
-        double[] visible = v.valueBoundsCentredOn(1e-3);
-        assertEquals(-5.0, visible[0]);
-        assertEquals(100.0, visible[1]);
+        assertSame(v, v.centreValueAxisOn(1e-3), "already on screen");
     }
 
     /** Switching to LOG used to keep a stored -5 while the axis drew 1e-6, so copy-axis and set-limits lied. */
@@ -167,13 +158,11 @@ class ViewPortValueAxisTest {
 
     @Test
     void centringKeepsTheSpanInTransformedSpace() {
-        ViewPort log = withValueBounds(viewport(1, 100, YAxisScale.LOG),
-            viewport(1, 100, YAxisScale.LOG).valueBoundsCentredOn(5000));
+        ViewPort log = viewport(1, 100, YAxisScale.LOG).centreValueAxisOn(5000);
         assertEquals(500.0, log.getMinValue(), 500 * REL);
         assertEquals(50_000.0, log.getMaxValue(), 50_000 * REL);
 
-        ViewPort linear = withValueBounds(viewport(0, 100, YAxisScale.LINEAR),
-            viewport(0, 100, YAxisScale.LINEAR).valueBoundsCentredOn(5000));
+        ViewPort linear = viewport(0, 100, YAxisScale.LINEAR).centreValueAxisOn(5000);
         assertEquals(4950.0, linear.getMinValue(), 1e-9);
         assertEquals(5050.0, linear.getMaxValue(), 1e-9);
     }
@@ -181,11 +170,11 @@ class ViewPortValueAxisTest {
     @Test
     void centringLeavesTheViewAloneForAValueTheScaleCannotShow() {
         ViewPort log = viewport(1, 100, YAxisScale.LOG);
-        assertEquals(1.0, log.valueBoundsCentredOn(-5)[0]);
-        assertEquals(100.0, log.valueBoundsCentredOn(0)[1]);
+        assertSame(log, log.centreValueAxisOn(-5));
+        assertSame(log, log.centreValueAxisOn(0));
 
         ViewPort linear = viewport(0, 100, YAxisScale.LINEAR);
-        assertEquals(0.0, linear.valueBoundsCentredOn(Double.NaN)[0]);
-        assertEquals(100.0, linear.valueBoundsCentredOn(Double.POSITIVE_INFINITY)[1]);
+        assertSame(linear, linear.centreValueAxisOn(Double.NaN));
+        assertSame(linear, linear.centreValueAxisOn(Double.POSITIVE_INFINITY));
     }
 }

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/transform/YAxisScaleTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/transform/YAxisScaleTest.java
@@ -81,8 +81,8 @@ class YAxisScaleTest {
         double previous = Double.NEGATIVE_INFINITY;
         for (double y = -50.0; y <= 50.0; y += 0.0009) {
             double transformed = YAxisScale.SYMLOG.transform(y);
-            assertTrue(transformed > previous,
-                "SYMLOG is not strictly increasing at y=" + y);
+            double at = y;
+            assertTrue(transformed > previous, () -> "SYMLOG is not strictly increasing at y=" + at);
             previous = transformed;
         }
     }
@@ -123,9 +123,19 @@ class YAxisScaleTest {
                 assertTrue(threshold.isEmpty(), scale + " should have no linear region");
             }
         }
+    }
 
-        assertEquals(4, YAxisScale.values().length,
-            "a new scale must decide here whether it has a linear region to mark");
+    @Test
+    void onlyLogRestrictsTheDomain() {
+        // Auto-Y drops values at or below the floor with one compare, so for the scales
+        // defined everywhere the floor must sit below every finite value.
+        assertEquals(0.0, YAxisScale.LOG.domainFloor(), 0.0);
+        for (YAxisScale scale : new YAxisScale[] {YAxisScale.LINEAR, YAxisScale.SQRT, YAxisScale.SYMLOG}) {
+            assertEquals(Double.NEGATIVE_INFINITY, scale.domainFloor(), scale + " is defined everywhere");
+            assertFalse(-Double.MAX_VALUE <= scale.domainFloor(), scale + " must keep the most negative finite value");
+        }
+        assertTrue(0.0 <= YAxisScale.LOG.domainFloor(), "LOG drops zero");
+        assertFalse(Double.MIN_VALUE <= YAxisScale.LOG.domainFloor(), "LOG keeps the smallest positive value");
     }
 
     @Test

--- a/kalixide/src/test/java/com/kalix/ide/flowviz/transform/YAxisScaleTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/flowviz/transform/YAxisScaleTest.java
@@ -1,0 +1,149 @@
+package com.kalix.ide.flowviz.transform;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.OptionalDouble;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the properties every {@link YAxisScale} has to hold for the plot to be readable, and
+ * that were previously guaranteed only by comments.
+ *
+ * <p>The load-bearing one is SYMLOG's continuity: its two branches meet only because the
+ * linear slope is derived as {@code log10(L) / L}. Hard-code a slope that disagrees with the
+ * threshold and the axis silently gains a step discontinuity at +/-L - series jump, and
+ * screen position stops being a monotone function of value. Nothing else in the codebase
+ * would fail.</p>
+ */
+class YAxisScaleTest {
+
+    /** Values spanning the magnitudes hydrological series actually carry, both signs. */
+    private static final double[] SAMPLE_VALUES = {
+        1e-12, 1e-6, 0.001, 0.5, 1.0, 9.999, 10.0, 10.001, 42.0, 1e3, 1e6, 1e9
+    };
+
+    @Test
+    void transformRoundTripsForEveryScale() {
+        for (YAxisScale scale : YAxisScale.values()) {
+            for (double magnitude : SAMPLE_VALUES) {
+                for (double y : new double[]{magnitude, -magnitude}) {
+                    double transformed = scale.transform(y);
+                    if (Double.isNaN(transformed)) continue; // outside this scale's domain
+
+                    double back = scale.inverseTransform(transformed);
+                    assertEquals(y, back, Math.abs(y) * 1e-12,
+                        scale + " failed to round-trip " + y);
+                }
+            }
+        }
+    }
+
+    @Test
+    void symlogBranchesMeetAtTheThreshold() {
+        double threshold = YAxisScale.SYMLOG.linearThreshold().orElseThrow();
+
+        // Approach the seam from inside the linear region and from inside the log region.
+        double justBelow = YAxisScale.SYMLOG.transform(threshold - Math.ulp(threshold));
+        double atSeam = YAxisScale.SYMLOG.transform(threshold);
+        assertEquals(atSeam, justBelow, 1e-9, "SYMLOG is discontinuous at +L");
+
+        double justAbove = YAxisScale.SYMLOG.transform(-threshold + Math.ulp(threshold));
+        double atNegativeSeam = YAxisScale.SYMLOG.transform(-threshold);
+        assertEquals(atNegativeSeam, justAbove, 1e-9, "SYMLOG is discontinuous at -L");
+    }
+
+    @Test
+    void symlogLinearRegionSpansExactlyOneDecade() {
+        // The whole point of the derived slope: the linear zone occupies the same screen
+        // distance as one decade of the log region, so ticks land on exact powers of ten.
+        assertEquals(1.0, YAxisScale.SYMLOG.transform(10.0), 0.0);
+        assertEquals(-1.0, YAxisScale.SYMLOG.transform(-10.0), 0.0);
+        assertEquals(2.0, YAxisScale.SYMLOG.transform(100.0), 1e-15);
+        assertEquals(0.0, YAxisScale.SYMLOG.transform(0.0), 0.0);
+
+        // ...and back again, so axis ticks generated at integer transformed positions
+        // inverse-transform to round decades rather than to offset values.
+        assertEquals(10.0, YAxisScale.SYMLOG.inverseTransform(1.0), 1e-12);
+        assertEquals(100.0, YAxisScale.SYMLOG.inverseTransform(2.0), 1e-12);
+        assertEquals(-10.0, YAxisScale.SYMLOG.inverseTransform(-1.0), 1e-12);
+    }
+
+    @Test
+    void symlogIsStrictlyMonotonicThroughZeroAndBothSeams() {
+        // Screen position must be a monotone function of value, or panning reorders the data.
+        double previous = Double.NEGATIVE_INFINITY;
+        for (double y = -50.0; y <= 50.0; y += 0.0009) {
+            double transformed = YAxisScale.SYMLOG.transform(y);
+            assertTrue(transformed > previous,
+                "SYMLOG is not strictly increasing at y=" + y);
+            previous = transformed;
+        }
+    }
+
+    @Test
+    void symlogAcceptsEveryFiniteValueAndPropagatesNonFinite() {
+        // Unlike LOG, SYMLOG has no domain restriction - autoscale relies on this when it
+        // skips the non-positive filter for scales other than LOG.
+        for (double magnitude : SAMPLE_VALUES) {
+            assertFalse(Double.isNaN(YAxisScale.SYMLOG.transform(magnitude)));
+            assertFalse(Double.isNaN(YAxisScale.SYMLOG.transform(-magnitude)));
+        }
+        assertTrue(Double.isNaN(YAxisScale.SYMLOG.transform(Double.NaN)));
+        assertEquals(Double.POSITIVE_INFINITY, YAxisScale.SYMLOG.transform(Double.POSITIVE_INFINITY));
+        assertEquals(Double.NEGATIVE_INFINITY, YAxisScale.SYMLOG.transform(Double.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    void logRejectsNonPositiveValues() {
+        assertTrue(Double.isNaN(YAxisScale.LOG.transform(0.0)));
+        assertTrue(Double.isNaN(YAxisScale.LOG.transform(-1.0)));
+        assertEquals(3.0, YAxisScale.LOG.transform(1000.0), 1e-12);
+    }
+
+    @Test
+    void sqrtIsSignedSoNegativeSpaceStaysReachable() {
+        assertEquals(3.0, YAxisScale.SQRT.transform(9.0), 1e-12);
+        assertEquals(-3.0, YAxisScale.SQRT.transform(-9.0), 1e-12);
+    }
+
+    @Test
+    void onlySymlogReportsALinearThreshold() {
+        for (YAxisScale scale : YAxisScale.values()) {
+            OptionalDouble threshold = scale.linearThreshold();
+            if (scale == YAxisScale.SYMLOG) {
+                assertEquals(10.0, threshold.orElseThrow(), 0.0);
+            } else {
+                assertTrue(threshold.isEmpty(), scale + " should have no linear region");
+            }
+        }
+
+        assertEquals(4, YAxisScale.values().length,
+            "a new scale must decide here whether it has a linear region to mark");
+    }
+
+    @Test
+    void displayNamesAreUniqueAndRoundTrip() {
+        // Both the toolbar dropdown and the context-menu radio group select by display name,
+        // so a duplicate would make one of two scales unselectable.
+        Set<String> seen = new HashSet<>();
+        for (YAxisScale scale : YAxisScale.values()) {
+            assertNotNull(scale.getDisplayName());
+            assertTrue(seen.add(scale.getDisplayName()),
+                "duplicate display name: " + scale.getDisplayName());
+            assertSame(scale, YAxisScale.fromDisplayName(scale.getDisplayName()));
+        }
+    }
+
+    @Test
+    void unknownDisplayNameFallsBackToLinear() {
+        assertSame(YAxisScale.LINEAR, YAxisScale.fromDisplayName("Symlog10"));
+        assertSame(YAxisScale.LINEAR, YAxisScale.fromDisplayName(""));
+    }
+}


### PR DESCRIPTION
Adds a new PlotType - symmetric log (base 10) with thresholds at $\pm 10$, inspired by matplotlib's symlog.
- This is morally derived from matplotlib's symlog (specific to $L=10$).
- I decided on using linear interval [-10,10] so that the values lined up exactly - setting the linear interval to be [-1,1] would require additional rescaling and translation of the output. 

`FlowVizToolbarBuilder.Y_SPACE_OPTIONS` now derives all options from the statically available Enum

Added an experimental dash to the grid indicating the threshold at which symlog switches from linear to logarithmic.
