### PR TITLE
Data viewer: an extraction pass reads only the session's indexed extent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
         working-directory: kalixide
         shell: bash
         run: ./gradlew check --no-daemon
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-test-results-${{ matrix.platform }}
+          path: kalixide/build/test-results/test/*.xml
 
   python-test:
     name: Python ${{ matrix.python-version }} (${{ matrix.platform }})

--- a/kalixide/build.gradle.kts
+++ b/kalixide/build.gradle.kts
@@ -110,6 +110,12 @@ tasks.test {
     // HeadlessException passes on a developer's Mac and fails only after push — which is
     // exactly how DocumentWorkspaceViewTest reached main red.
     systemProperty("java.awt.headless", "true")
+    testLogging {
+        // CI keeps only the console, and "AssertionFailedError at Foo.java:208" cannot
+        // say what was expected or what was seen. Failures print in full.
+        events("failed")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
 }
 
 tasks.processResources {

--- a/kalixide/src/main/java/com/kalix/ide/dataview/ColumnSeriesExtractor.java
+++ b/kalixide/src/main/java/com/kalix/ide/dataview/ColumnSeriesExtractor.java
@@ -78,6 +78,17 @@ public final class ColumnSeriesExtractor {
      * @param dialect         its sniffed dialect
      * @param dataStartOffset byte offset where tabular data begins (past any BOM
      *                        or extended format header)
+     * @param dataEndOffset   exclusive end of the region the caller's index vouches
+     *                        for — the session's indexed byte count. The pass reads
+     *                        exactly {@code [dataStartOffset, dataEndOffset)} and never
+     *                        continues into bytes written after that index was built,
+     *                        so a rewrite landing mid-read cannot be stitched onto the
+     *                        old file's rows (a series of one file's row 1 and another's
+     *                        row 2 once reached the plot this way). Bytes past the extent
+     *                        are the next index pass's business, and that pass triggers
+     *                        the next extraction. Counting mirrors the indexer's: a row
+     *                        left unterminated at the extent's end is a row only when
+     *                        the extent is the whole file.
      * @param skipHeaderRow   whether the first data-region row is a header
      * @param columnIndices   0-based column indices to extract (column 0 is the
      *                        date axis, always read — do not request it)
@@ -86,9 +97,10 @@ public final class ColumnSeriesExtractor {
      *                        row-count pre-check can be stale while indexing runs)
      * @param cancelled       polled per data row; a cancelled extraction returns
      *                        {@code null} and its partial work is discarded
-     * @return the result, or {@code null} when cancelled
+     * @return the result; or {@code null} when cancelled, or when the file no longer
+     *         holds the extent (it shrank under us, so the index it came from is stale)
      */
-    public static Result extract(Path file, CsvDialect dialect, long dataStartOffset,
+    public static Result extract(Path file, CsvDialect dialect, long dataStartOffset, long dataEndOffset,
                                  boolean skipHeaderRow, int[] columnIndices, long maxRows,
                                  BooleanSupplier cancelled) throws IOException {
         int maxWanted = 0;
@@ -111,6 +123,12 @@ public final class ColumnSeriesExtractor {
         boolean headerPending = skipHeaderRow;
 
         try (SeekableByteChannel channel = Files.newByteChannel(file, StandardOpenOption.READ)) {
+            long size = channel.size();
+            if (size < dataEndOffset) {
+                return null; // the indexed extent is gone: whoever indexed it is stale
+            }
+            boolean extentIsWholeFile = dataEndOffset == size;
+            long remaining = Math.max(0, dataEndOffset - dataStartOffset);
             channel.position(dataStartOffset);
             ByteBuffer buffer = ByteBuffer.allocate(CHUNK_BYTES);
             byte delimiter = (byte) dialect.delimiter();
@@ -124,7 +142,7 @@ public final class ColumnSeriesExtractor {
             boolean rowHasContent = false;
 
             reading:
-            while (true) {
+            while (remaining > 0) {
                 // Poll per chunk as well as per row: a runaway row (stray quote)
                 // has no row boundaries, and dispose() must still stop the pass.
                 if (cancelled != null && cancelled.getAsBoolean()) {
@@ -135,10 +153,14 @@ public final class ColumnSeriesExtractor {
                         "a field exceeds %,d bytes — likely an unbalanced quote", MAX_FIELD_BYTES));
                 }
                 buffer.clear();
+                if (remaining < buffer.capacity()) {
+                    buffer.limit((int) remaining); // never read past the extent
+                }
                 int n = channel.read(buffer);
                 if (n < 0) {
-                    break;
+                    return null; // shrank mid-read: same verdict as at open
                 }
+                remaining -= n;
                 buffer.flip();
                 for (int i = 0; i < n; i++) {
                     byte b = buffer.get(i);
@@ -195,8 +217,10 @@ public final class ColumnSeriesExtractor {
                 }
             }
 
-            // Final row without a trailing newline.
-            if (rowHasContent && out.size() <= maxRows) {
+            // A final row without a trailing newline is a row only where the file
+            // ends (the indexer's rule too). Cut short by the extent instead, it is a
+            // row the index has not finished; the pass that finishes it re-extracts.
+            if (rowHasContent && extentIsWholeFile && out.size() <= maxRows) {
                 dateText = endField(field, fieldIndex, slotByColumn, staged, dialect, dateText);
                 if (!headerPending && !consumeRow(state, dateText, staged, out)) {
                     return Result.refuse("the first column does not parse as dates");

--- a/kalixide/src/main/java/com/kalix/ide/dataview/DataVizView.java
+++ b/kalixide/src/main/java/com/kalix/ide/dataview/DataVizView.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -115,6 +116,8 @@ public final class DataVizView extends JPanel {
     /** Set by every extraction trigger; drained by the single extraction worker. */
     private final AtomicBoolean extractRequested = new AtomicBoolean(false);
     private final AtomicBoolean extractInFlight = new AtomicBoolean(false);
+    /** Passes run so far; a test seam for pinning that construction owes exactly one. */
+    private final AtomicInteger extractionPasses = new AtomicInteger();
     private volatile boolean disposed = false;
 
     public DataVizView(DataViewPanel tablePanel, DataViewSession session) {
@@ -226,10 +229,14 @@ public final class DataVizView extends JPanel {
 
     private void buildViz() {
         dataSet = new DataSet();
-        vizManager = new VisualizationTabManager(dataSet,
+        // Held locally until the first tab exists: the field is what the host
+        // callbacks and the extraction worker key on, and publishing it early let
+        // the first tab's activation schedule a pass from inside construction — a
+        // second, redundant pass the constructor then scheduled again on top.
+        VisualizationTabManager manager = new VisualizationTabManager(dataSet,
             new PaletteSeriesStyleResolver(new SeriesSlotManager(), PlotPaletteManager.getInstance()));
         LabelResolver labels = new DefaultLabelResolver(id -> null); // no runs here: dataset refs only
-        vizManager.setHost(new VizHost() {
+        manager.setHost(new VizHost() {
             @Override
             public LabelResolver labelResolver() {
                 return labels;
@@ -243,6 +250,9 @@ public final class DataVizView extends JPanel {
 
             @Override
             public void onActiveTabChanged() {
+                if (vizManager == null) {
+                    return; // still under construction: the constructor owes the first pass
+                }
                 // The header accents are this mount's "tree": reproject them, and
                 // fetch any selected column (undo/redo can restore one) whose data
                 // the pool doesn't hold yet.
@@ -268,10 +278,11 @@ public final class DataVizView extends JPanel {
         } else {
             defaultSelectionPending = true; // structure not indexed yet; owed on arrival
         }
-        FlowVizPanel firstPanel = vizManager.addPlotTabFromSettings(settings);
+        FlowVizPanel firstPanel = manager.addPlotTabFromSettings(settings);
         if (firstRef != null) {
             pendingZoomFit.put(firstPanel, firstRef); // fit once the default column's data lands
         }
+        vizManager = manager;
         installHeaderInteractions();
     }
 
@@ -425,6 +436,7 @@ public final class DataVizView extends JPanel {
         Thread worker = new Thread(() -> {
             try {
                 while (!disposed && extractRequested.getAndSet(false)) {
+                    extractionPasses.incrementAndGet();
                     extractOnce();
                 }
             } finally {
@@ -496,8 +508,14 @@ public final class DataVizView extends JPanel {
         ColumnSeriesExtractor.Result result = null;
         if (columnIndices.length > 0) {
             try {
+                // A pass is a projection of the session's INDEXED snapshot, so it reads
+                // exactly the bytes the index vouches for. Reading "the file as it is
+                // now" instead let a pass in flight during an in-place rewrite stitch
+                // the old file's rows onto the new one's; anything past the extent is
+                // the next index pass's business, and that pass triggers the next
+                // extraction through onProgress(complete).
                 result = ColumnSeriesExtractor.extract(
-                    target.filePath(), target.dialect(), target.dataStartOffset(),
+                    target.filePath(), target.dialect(), target.dataStartOffset(), target.indexedBytes(),
                     target.headerRowInData(), columnIndices, limit,
                     () -> disposed || session != target);
             } catch (IOException e) {
@@ -506,7 +524,7 @@ public final class DataVizView extends JPanel {
                 return;
             }
             if (result == null) {
-                return; // cancelled (disposed or session swapped): a new pass follows
+                return; // cancelled (disposed, session swapped) or the extent is gone: a new pass follows
             }
             if (result.refused()) {
                 publishRefusal(target, "Plot unavailable: " + result.refusal());
@@ -623,6 +641,10 @@ public final class DataVizView extends JPanel {
     }
 
     /** The private per-mount data pool — package-private, for tests. */
+    int extractionPassesForTests() {
+        return extractionPasses.get();
+    }
+
     DataSet dataSetForTests() {
         return dataSet;
     }

--- a/kalixide/src/test/java/com/kalix/ide/dataview/ColumnSeriesExtractorTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/dataview/ColumnSeriesExtractorTest.java
@@ -36,6 +36,14 @@ class ColumnSeriesExtractorTest {
         return file;
     }
 
+    /** Records the file, so a call site that writes inline can still pass its whole extent. */
+    private Path wholeFile;
+
+    private Path whole(Path file) {
+        wholeFile = file;
+        return file;
+    }
+
     private static long day(int year, int month, int dayOfMonth) {
         return LocalDate.of(year, month, dayOfMonth).toEpochDay() * 86_400_000L;
     }
@@ -49,7 +57,7 @@ class ColumnSeriesExtractorTest {
             2020-01-03,na,30,z
             """);
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {2, 1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {2, 1}, Long.MAX_VALUE, null);
         assertNotNull(r);
         assertFalse(r.refused());
         assertEquals(3, r.timestamps().length);
@@ -67,7 +75,7 @@ class ColumnSeriesExtractorTest {
     void nonNumericColumnBecomesNaNs() throws IOException {
         Path file = write("date,label\n2020-01-01,north\n2020-01-02,south\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertTrue(Double.isNaN(r.columns()[0][0]));
         assertTrue(Double.isNaN(r.columns()[0][1]));
@@ -77,7 +85,7 @@ class ColumnSeriesExtractorTest {
     void quotedThousandsGroupingParsesLikeTheImporter() throws IOException {
         Path file = write("date,flow\n2020-01-01,\"1,234.5\"\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertEquals(1234.5, r.columns()[0][0]);
     }
@@ -86,7 +94,7 @@ class ColumnSeriesExtractorTest {
     void badDateRowIsSkippedAndCounted() throws IOException {
         Path file = write("date,v\n2020-01-01,1\nnot-a-date,2\n2020-01-03,3\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertEquals(2, r.timestamps().length);
         assertEquals(1, r.badDateRows());
@@ -97,7 +105,7 @@ class ColumnSeriesExtractorTest {
     void blankLinesAreSkippedSilently() throws IOException {
         Path file = write("date,v\n2020-01-01,1\n\n2020-01-02,2\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertEquals(2, r.timestamps().length);
         assertEquals(0, r.badDateRows(), "a blank line is not a bad date");
@@ -110,7 +118,7 @@ class ColumnSeriesExtractorTest {
             content.append("row").append(i).append(",1\n");
         }
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            write(content.toString()), HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            whole(write(content.toString())), HEADERED, 0, Files.size(wholeFile), true, new int[] {1}, Long.MAX_VALUE, null);
         assertTrue(r.refused());
         assertNotNull(r.refusal());
     }
@@ -119,7 +127,7 @@ class ColumnSeriesExtractorTest {
     void headerlessFileStartsAtRowZero() throws IOException {
         Path file = write("2020-01-01,1\n2020-01-02,2\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERLESS, 0, false, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERLESS, 0, Files.size(file), false, new int[] {1}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertEquals(2, r.timestamps().length);
         assertEquals(1.0, r.columns()[0][0]);
@@ -129,7 +137,7 @@ class ColumnSeriesExtractorTest {
     void finalRowWithoutTrailingNewlineIsIncluded() throws IOException {
         Path file = write("date,v\n2020-01-01,1\n2020-01-02,2");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, null);
         assertEquals(2, r.timestamps().length);
         assertEquals(2.0, r.columns()[0][1]);
     }
@@ -138,7 +146,7 @@ class ColumnSeriesExtractorTest {
     void exceedingMaxRowsRefusesRatherThanTruncating() throws IOException {
         Path file = write("date,v\n2020-01-01,1\n2020-01-02,2\n2020-01-03,3\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, 2, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, 2, null);
         assertTrue(r.refused(), "a silent truncation would contradict the caller's pre-check");
         assertTrue(r.refusal().contains("more than 2"));
     }
@@ -147,7 +155,7 @@ class ColumnSeriesExtractorTest {
     void exactlyMaxRowsIsNotARefusal() throws IOException {
         Path file = write("date,v\n2020-01-01,1\n2020-01-02,2\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, 2, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, 2, null);
         assertFalse(r.refused());
         assertEquals(2, r.timestamps().length);
     }
@@ -156,7 +164,7 @@ class ColumnSeriesExtractorTest {
     void leadingNonDateRowsAreCountedOnceTheFormatIsFound() throws IOException {
         Path file = write("date,v\njunk,9\n2020-01-01,1\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertEquals(1, r.timestamps().length);
         assertEquals(1, r.badDateRows(), "the failed probe row was a dropped data row");
@@ -167,23 +175,94 @@ class ColumnSeriesExtractorTest {
         StringBuilder content = new StringBuilder("date,v\n2020-01-01,\"");
         content.append("x".repeat(ColumnSeriesExtractor.MAX_FIELD_BYTES + 300_000));
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            write(content.toString()), HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+            whole(write(content.toString())), HEADERED, 0, Files.size(wholeFile), true, new int[] {1}, Long.MAX_VALUE, null);
         assertTrue(r.refused());
         assertTrue(r.refusal().contains("quote"));
+    }
+
+    // === The indexed extent: a pass reads what the index vouched for, nothing else ===
+
+    @Test
+    void readsOnlyTheIndexedExtent() throws IOException {
+        // The index vouched for two rows; a third was appended since.
+        Path file = write("date,a\n2020-01-01,1\n2020-01-02,2\n");
+        long extent = Files.size(file);
+        Files.writeString(file, "date,a\n2020-01-01,1\n2020-01-02,2\n2020-01-03,3\n");
+
+        ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
+            file, HEADERED, 0, extent, true, new int[] {1}, Long.MAX_VALUE, null);
+        assertNotNull(r);
+        assertEquals(2, r.timestamps().length, "the appended row is the next index pass's business");
+        assertEquals(2.0, r.columns()[0][1]);
+    }
+
+    /**
+     * The race that made DataVizViewTest flaky: an index built on the 20-byte file,
+     * the file rewritten in place while a pass had read those 20 bytes and was about
+     * to read "the rest". The rest was the NEW file's row 2, and the plot showed a
+     * series of the old file's row 1 and the new file's row 2 ([1, 43]).
+     */
+    @Test
+    void aRewriteUnderTheExtentCannotStitchTwoFiles() throws IOException {
+        Path file = write("date,a\n2020-01-01,1\n");
+        long extent = Files.size(file);
+        Files.writeString(file, "date,a\n2020-01-01,42\n2020-01-02,43\n");
+
+        ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
+            file, HEADERED, 0, extent, true, new int[] {1}, Long.MAX_VALUE, null);
+        assertNotNull(r);
+        assertFalse(r.refused());
+        assertEquals(0, r.timestamps().length,
+            "the extent now ends inside a row; an unfinished row is not a row, and never another file's row 2");
+    }
+
+    @Test
+    void anExtentBeyondTheFileMeansTheIndexIsStale() throws IOException {
+        Path file = write("date,a\n2020-01-01,1\n2020-01-02,2\n");
+        long extent = Files.size(file);
+        Files.writeString(file, "date,a\n2020-01-01,1\n"); // shrank under the index
+
+        assertNull(ColumnSeriesExtractor.extract(
+            file, HEADERED, 0, extent, true, new int[] {1}, Long.MAX_VALUE, null),
+            "same verdict as a cancellation: this pass has nothing true to say");
+    }
+
+    @Test
+    void anUnterminatedRowCountsOnlyWhereTheFileEnds() throws IOException {
+        // Whole-file extent: the indexer counts the unterminated final row, so do we.
+        Path file = write("date,a\n2020-01-01,1\n2020-01-02,2");
+        long whole = Files.size(file);
+        assertEquals(2, ColumnSeriesExtractor.extract(
+            file, HEADERED, 0, whole, true, new int[] {1}, Long.MAX_VALUE, null).timestamps().length);
+
+        // Extent ending one byte short: the same row is now one the index has not
+        // finished, exactly as a mid-pass index would report it.
+        assertEquals(1, ColumnSeriesExtractor.extract(
+            file, HEADERED, 0, whole - 1, true, new int[] {1}, Long.MAX_VALUE, null).timestamps().length);
+    }
+
+    @Test
+    void anExtentBeforeTheDataRegionIsEmptyNotAnError() throws IOException {
+        Path file = write("date,a\n2020-01-01,1\n");
+        ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
+            file, HEADERED, 0, 0, true, new int[] {1}, Long.MAX_VALUE, null);
+        assertNotNull(r);
+        assertFalse(r.refused());
+        assertEquals(0, r.timestamps().length, "nothing indexed yet: nothing to project");
     }
 
     @Test
     void cancelledExtractionReturnsNull() throws IOException {
         Path file = write("date,v\n2020-01-01,1\n2020-01-02,2\n");
         assertNull(ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {1}, Long.MAX_VALUE, () -> true));
+            file, HEADERED, 0, Files.size(file), true, new int[] {1}, Long.MAX_VALUE, () -> true));
     }
 
     @Test
     void crlfAndQuotedDelimitersFollowTheTableGrammar() throws IOException {
         Path file = write("date,name,v\r\n2020-01-01,\"a,b\",7\r\n");
         ColumnSeriesExtractor.Result r = ColumnSeriesExtractor.extract(
-            file, HEADERED, 0, true, new int[] {2}, Long.MAX_VALUE, null);
+            file, HEADERED, 0, Files.size(file), true, new int[] {2}, Long.MAX_VALUE, null);
         assertFalse(r.refused());
         assertEquals(1, r.timestamps().length);
         assertEquals(7.0, r.columns()[0][0]);

--- a/kalixide/src/test/java/com/kalix/ide/dataview/DataVizViewTest.java
+++ b/kalixide/src/test/java/com/kalix/ide/dataview/DataVizViewTest.java
@@ -2,6 +2,7 @@ package com.kalix.ide.dataview;
 
 import com.kalix.ide.flowviz.VisualizationTabManager;
 import com.kalix.ide.flowviz.data.DatasetSeries;
+import com.kalix.ide.flowviz.data.TimeSeriesData;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -9,8 +10,10 @@ import org.junit.jupiter.api.io.TempDir;
 import javax.swing.SwingUtilities;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -42,16 +45,29 @@ class DataVizViewTest {
         return holder[0];
     }
 
+    /** The series as the pool holds it, for failure messages. */
+    private static String describe(TimeSeriesData series) {
+        return series == null ? "no series"
+            : "points=" + series.getPointCount()
+                + " timestamps=" + Arrays.toString(series.getTimestamps())
+                + " values=" + Arrays.toString(series.getValues());
+    }
+
     private DatasetSeries ref(String column) {
         return new DatasetSeries(session.filePath().toAbsolutePath().toString(), column);
     }
 
     /** Await-what-you-assert, draining the EDT between polls. */
     private static void await(BooleanSupplier condition, String what) throws Exception {
+        await(condition, what, () -> "");
+    }
+
+    /** As above; on timeout the message carries what the pool held, so a flake diagnoses itself. */
+    private static void await(BooleanSupplier condition, String what, Supplier<String> observed) throws Exception {
         long deadline = System.currentTimeMillis() + 8000;
         while (!condition.getAsBoolean()) {
             if (System.currentTimeMillis() > deadline) {
-                fail("timed out waiting for " + what);
+                fail("timed out waiting for " + what + "; observed " + observed.get());
             }
             Thread.sleep(20);
             if (!SwingUtilities.isEventDispatchThread()) {
@@ -78,6 +94,10 @@ class DataVizViewTest {
                 "first column extracted");
             assertTrue(view.vizManagerForTests().getTargetTabSelectedSeries().contains(ref("a")));
             assertFalse(view.dataSetForTests().hasSeries(ref("b")), "only the first column is plotted");
+            // The constructor owes the first pass and nothing else runs one: the first
+            // tab's activation used to schedule a second, redundant pass from inside
+            // construction, which is what put a read in flight to be torn by a rewrite.
+            assertEquals(1, view.extractionPassesForTests(), "construction runs exactly one extraction pass");
             assertEquals(2, view.dataSetForTests().getSeries(ref("a")).getPointCount());
         } finally {
             session.close();
@@ -203,10 +223,18 @@ class DataVizViewTest {
             await(() -> freshFinal.isIndexingComplete() && freshFinal.columnCount() > 0, "fresh session");
             SwingUtilities.invokeAndWait(() -> view.onSessionReplaced(freshFinal));
 
-            await(() -> view.dataSetForTests().getSeries(ref("a")) != null
-                && view.dataSetForTests().getSeries(ref("a")).getPointCount() == 2, "re-extraction");
-            assertEquals(42.0, view.dataSetForTests().getSeries(ref("a")).getValues()[0],
-                "the same ref now carries the fresh session's data");
+            // Await what is asserted - the fresh file's values - not a point count a
+            // torn series could satisfy first. The extractor's indexed-extent rule is
+            // what makes such a series impossible; this keeps the test honest about
+            // what it is waiting for and says what it saw if it ever waits in vain.
+            await(() -> {
+                TimeSeriesData series = view.dataSetForTests().getSeries(ref("a"));
+                return series != null && series.getPointCount() == 2 && series.getValues()[0] == 42.0;
+            }, "re-extraction of the fresh session's data",
+                () -> describe(view.dataSetForTests().getSeries(ref("a"))));
+            TimeSeriesData series = view.dataSetForTests().getSeries(ref("a"));
+            assertEquals(43.0, series.getValues()[1],
+                "the same ref now carries the fresh session's data; saw " + describe(series));
         } finally {
             session.close();
             if (fresh != null) {


### PR DESCRIPTION
# Overview
Fixes a real race in the data viewer's plot extraction, found by chasing the one-off CI failure in `DataVizViewTest.sessionRebuildReExtractsUnderTheSameRefs` (run #348).

# The bug
`ColumnSeriesExtractor` read "the file as it is now" in a chunk loop, while every other parameter it used (dialect, data start, header row) came from the session's index of a specific byte region. Rewrite the file in place between two of its reads and the second read returns the **new** file's tail, which the parser stitches onto the **old** file's rows. The document refresh path does exactly that (rewrite in place, then replace the session), so a plot could briefly show a series of one file's row 1 and another's row 2. The stale-session guard cannot catch it: the torn result is published against the old session *before* the swap.

A worktree harness with a 25 ms pause after the extractor's first chunk reproduced it 29/30 (values `[1.0, 43.0]`). A second, smaller defect made the window reachable: construction ran two extraction passes, so a redundant read was in flight when the file changed.

# The fix
A pass is a projection of the session's **indexed snapshot**. `extract()` takes the extent (the session's `indexedBytes`) and reads exactly `[dataStartOffset, dataEndOffset)`, never past it. Bytes beyond are the next index pass's business, and that pass already triggers the next extraction. Counting mirrors the indexer's own rule: an unterminated final row counts only when the extent is the whole file. A file shorter than the extent means the index is stale; the pass returns null like a cancellation. No delays, no size/mtime heuristics.

Construction now runs one pass: the manager field is assigned only once the first tab exists, and `onActiveTabChanged` returns early while it is null.

# Tests
- Five extractor tests pin the extent rule, including a direct replay of the tear.
- The view test pins one construction pass, awaits the value it asserts, and reports what the pool held on timeout.
- Verified with the reproducing harness: control 29/30 failures, fix 0/30 at 10/15/20/25 ms and under a two-step write; each half applied alone also 0/30.

# CI evidence
Gradle now prints failed tests in full (the log said only `AssertionFailedError at DataVizViewTest.java:208`), and the Java job uploads its JUnit XML on failure.

# Verification
`./gradlew check`: 1198 tests, 0 failures, Checkstyle clean.
