### PR TITLE
Add storage_gated node type with defined spillway_gated_release (For Discussion)

### DIFF
--- a/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
+++ b/src/io/ini_model_io_versions/ini_doc_model_io_0_0_1.rs
@@ -54,6 +54,7 @@ pub(crate) const NODE_STATIC_F64_PROPERTIES: &[(&str, &str)] = &[
     ("routing", "x"),
     ("routing", "typical_regulated_flow"),
     ("storage", "initial_volume"),
+    ("storage_gated", "initial_volume")
 ];
 
 pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<std::path::PathBuf>) -> Result<Model, KalixIoError> {
@@ -733,9 +734,10 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                     }
                     NodeEnum::SplitterNode(n)
                 }
-                "storage" => {
+                type_str @ ("storage" | "storage_gated") => {
                     let mut n = StorageNode::new();
                     n.name = node_name.to_string();
+                    n.is_gated = type_str == "storage_gated";
                     for (name, ini_property) in ini_section.properties {
                         let name_lower = name.to_lowercase();
                         let v = require_non_empty(&ini_property.value, &name, ini_property.line_number).map_err(KalixIoError::Validate)?;
@@ -837,6 +839,13 @@ pub fn ini_doc_to_model_0_0_1(ini_doc: IniDocument, working_directory: Option<st
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
                         } else if name_lower == "target_level" {
                             n.target_level = DynamicInput::from_string(v, &mut model.data_cache, true, self_ctx)
+                                .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
+                        } else if name_lower == "spillway_gated_release" {
+                            if !n.is_gated {
+                                return Err(KalixIoError::Validate(format!("Error on line {}: 'spillway_gated_release' is only valid for 'storage_gated' nodes (node ('{})'",
+                                    ini_property.line_number, node_name)));
+                            }
+                            n.spillway_gated_release = DynamicInput::from_string(v, &mut model.data_cache, true, self_ctx)
                                 .map_err(|e| KalixIoError::Parse(format!("Error on line {}: {}", ini_property.line_number, e)))?;
                         } else if name_lower == "dimensions" {
                             n.dimensions = Table::from_csv_string(v, 4, false)
@@ -1443,12 +1452,13 @@ pub fn render_canonical_0_0_1(model: &Model) -> IniDocument {
             NodeEnum::StorageNode(n) => {
                 let section_name = format!("node.{}", n.name);
                 ini_doc.set_property(section_name.as_str(), "loc", n.location.to_string().as_str());
-                ini_doc.set_property(section_name.as_str(), "type", "storage");
+                ini_doc.set_property(section_name.as_str(), "type", if n.is_gated { "storage_gated" } else { "storage" });
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "evap", &n.evap_mm_input.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "rain", &n.rain_mm_input.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "seep", &n.seep_mm_input.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "pond_demand", &n.pond_demand_input.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "target_level", &n.target_level.to_string());
+                set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "spillway_gated_release", &n.spillway_gated_release.to_string());
                 set_property_if_not_empty(&mut ini_doc, section_name.as_str(), "exists", &n.exists.to_string());
                 for (i, ds_force_release) in n.ds_force_release_input.iter().enumerate() {
                     let property_name = format!("ds_{}_force_release", i + 1);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1186,6 +1186,7 @@ impl Model {
             "order_control",
             "loss",
             "storage",
+            "storage_gated",
             "routing",
             "splitter",
             "confluence",

--- a/src/nodes/node_enum.rs
+++ b/src/nodes/node_enum.rs
@@ -57,7 +57,7 @@ impl NodeEnum {
             NodeEnum::InflowNode(_) => "inflow",
             NodeEnum::RoutingNode(_) => "routing",
             NodeEnum::SacramentoNode(_) => "sacramento",
-            NodeEnum::StorageNode(_) => "storage",
+            NodeEnum::StorageNode(n) => { if n.is_gated { "storage_gated" } else { "storage" } },
             NodeEnum::OrderControlNode(_) => "order_control",
         };
         name.to_string()

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -173,6 +173,13 @@ impl StorageNode {
         }
     }
 
+    /// Cap the spill at the water actually available. Only gated storages need
+    /// this: table spill is zero at the empty row and rises with volume, so it
+    /// can never exceed contents, whereas a gated release is set independently.
+    fn cap_spill(&self, spill: f64, w: f64) -> f64 {
+        if self.is_gated { spill.min(w.max(0.0)) } else { spill }
+    }
+
     /// Determine whether the release at the outlet should be the forced release optionally
     /// supplied by the user or the order determined by the model.
     fn check_forced_release(
@@ -326,8 +333,8 @@ impl StorageNode {
         -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64)
     {
         let area = self.dimensions.interpolate_row(row, VOLU, AREA, v);
-        let spill = self.spill_at_vol(row, v, gated_spill);
         let w = v_working + net_rain_mm * area;
+        let spill = self.cap_spill(self.spill_at_vol(row, v, gated_spill), w);
         let mut flows = self.rating_releases_at(v, spill);
         let v_final = (w - spill - flows.iter().sum::<f64>()).max(0.0);
         flows[0] += spill;
@@ -342,8 +349,8 @@ impl StorageNode {
         -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64)
     {
         let area = self.dimensions.interpolate_row(row, VOLU, AREA, t);
-        let spill = self.spill_at_vol(row, t, gated_spill);
         let w = v_working + net_rain_mm * area;
+        let spill = self.cap_spill(self.spill_at_vol(row, t, gated_spill), w);
         let mut flows = self.rating_releases_at(t, spill);
         let mut residual = (w - spill - t) - flows.iter().sum::<f64>();
         for (i, flow) in flows.iter_mut().enumerate() {
@@ -375,8 +382,8 @@ impl StorageNode {
     {
         let floor_vol = self.dimensions.get_value(0, VOLU);
         let area = self.dimensions.get_value(0, AREA);
-        let spill = self.spill_at_row(0, gated_spill);
         let w = v_working + net_rain_mm * area;
+        let spill = self.cap_spill(self.spill_at_row(0, gated_spill), w);
         let mut remaining = (w - spill).max(0.0);
         let mut flows = [0.0; MAX_DS_LINKS];
         for (i, f) in flows.iter_mut().enumerate() {
@@ -698,7 +705,8 @@ impl StorageNode {
 
         // Evaluate the solution point and allocate.
         let area = self.dimensions.interpolate_row(row, VOLU, AREA, v_solved);
-        let spill = self.spill_at_vol(row, v_solved, gated_spill);
+        let w = v_initial + net_rain_mm * area;
+        let spill = self.cap_spill(self.spill_at_vol(row, v_solved, gated_spill), w);
 
         let mut ds_flows = [0.0; MAX_DS_LINKS];
         let v_final;
@@ -735,6 +743,7 @@ impl StorageNode {
             // v_final = W - spill - sum(granted) so volume and flows
             // reconcile exactly — mass balance closes by construction.
             let w = v_initial + net_rain_mm * area;
+            let spill = self.cap_spill(self.spill_at_vol(row, v_solved, gated_spill), w);
             let mut remaining = (w - spill).max(0.0);
             let d1 = (dues[0] - spill).max(0.0);
             for (flow, due) in ds_flows.iter_mut().zip([d1, dues[1], dues[2], dues[3]].iter()) {

--- a/src/nodes/storage_node.rs
+++ b/src/nodes/storage_node.rs
@@ -48,6 +48,8 @@ pub struct StorageNode {
     pub target_level: DynamicInput,
     pub exists: DynamicInput,
     pub ds_force_release_input: [DynamicInput; MAX_DS_LINKS],
+    pub is_gated: bool,
+    pub spillway_gated_release: DynamicInput,
 
     // Internal state only
     usflow: f64,
@@ -138,6 +140,7 @@ impl StorageNode {
     //
     // Terminology for ds_1 flows:
     // - "ds_1_spill": uncontrolled overflow via the spillway, counts towards ds_1 orders
+    //   or if gated, controlled discharge via the spillway.
     // - "ds_1_outlet": controlled outlet flow, supplements spill to meet ds_1
     //                  orders, or optionally forced by user input
     // - "ds_1" (total): ds_1_spill + ds_1_outlet
@@ -150,6 +153,25 @@ impl StorageNode {
     // with any outlet curve solve via solve_rating below; storages without
     // take the plain unconstrained solve, bit-identical with the historical
     // solver.
+
+    /// Spill at a table row. Gated storages ignore the SPIL column entirely
+    /// and release whatever the gated spillway rule supplies.
+    fn spill_at_row(&self, row: usize, gated_spill: f64) -> f64 {
+        if self.is_gated {
+            gated_spill
+        } else {
+            self.dimensions.get_value(row, SPIL).max(0.0)
+        }
+    }
+
+    /// Spill at an arbitrary volume inside `row`'s segment.
+    fn spill_at_vol(&self, row: usize, v: f64, gated_spill: f64) -> f64 {
+        if self.is_gated {
+            gated_spill
+        } else {
+            self.dimensions.interpolate_row(row, VOLU, SPIL, v).max(0.0)
+        }
+    }
 
     /// Determine whether the release at the outlet should be the forced release optionally
     /// supplied by the user or the order determined by the model.
@@ -300,11 +322,11 @@ impl StorageNode {
 
     /// Attribution at a solved volume v inside (or beyond) segment `row`:
     /// releases from the rating at v, v_final closing the balance exactly.
-    fn rating_attribution(&self, v: f64, row: usize, v_working: f64, net_rain_mm: f64)
+    fn rating_attribution(&self, v: f64, row: usize, v_working: f64, net_rain_mm: f64, gated_spill: f64)
         -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64)
     {
         let area = self.dimensions.interpolate_row(row, VOLU, AREA, v);
-        let spill = self.dimensions.interpolate_row(row, VOLU, SPIL, v).max(0.0);
+        let spill = self.spill_at_vol(row, v, gated_spill);
         let w = v_working + net_rain_mm * area;
         let mut flows = self.rating_releases_at(v, spill);
         let v_final = (w - spill - flows.iter().sum::<f64>()).max(0.0);
@@ -316,11 +338,11 @@ impl StorageNode {
     /// (from-below) releases, and whoever steps up at t shares the residual
     /// in priority order, each capped by its from-above capacity — the
     /// generalized solution of the jump.
-    fn rating_park_at(&self, t: f64, row: usize, v_working: f64, net_rain_mm: f64)
+    fn rating_park_at(&self, t: f64, row: usize, v_working: f64, net_rain_mm: f64, gated_spill: f64)
         -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64)
     {
         let area = self.dimensions.interpolate_row(row, VOLU, AREA, t);
-        let spill = self.dimensions.interpolate_row(row, VOLU, SPIL, t).max(0.0);
+        let spill = self.spill_at_vol(row, t, gated_spill);
         let w = v_working + net_rain_mm * area;
         let mut flows = self.rating_releases_at(t, spill);
         let mut residual = (w - spill - t) - flows.iter().sum::<f64>();
@@ -348,12 +370,12 @@ impl StorageNode {
     /// Demand exceeds everything available: drain to the table floor, and cap
     /// releases by the water actually there, in priority order. Each outlet's
     /// capacity is taken just above the floor (it flowed while draining down).
-    fn rating_floor(&self, v_working: f64, net_rain_mm: f64)
+    fn rating_floor(&self, v_working: f64, net_rain_mm: f64, gated_spill: f64)
         -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64)
     {
         let floor_vol = self.dimensions.get_value(0, VOLU);
         let area = self.dimensions.get_value(0, AREA);
-        let spill = self.dimensions.get_value(0, SPIL).max(0.0);
+        let spill = self.spill_at_row(0, gated_spill);
         let w = v_working + net_rain_mm * area;
         let mut remaining = (w - spill).max(0.0);
         let mut flows = [0.0; MAX_DS_LINKS];
@@ -372,7 +394,7 @@ impl StorageNode {
     /// the (monotone, jumpy) rating error, then walk the segment's threshold
     /// pieces in order — bisecting a continuous piece that crosses zero, or
     /// parking on a threshold whose jump swallows the root.
-    fn solve_rating(&self, v_working: f64, net_rain_mm: f64, nrows: usize, start_row: usize)
+    fn solve_rating(&self, v_working: f64, net_rain_mm: f64, gated_spill: f64, nrows: usize, start_row: usize)
         -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64)
     {
         // Hot-path precompute: sanitized demands, step capacities, and
@@ -397,7 +419,7 @@ impl StorageNode {
         let compute_error = |row: usize| -> f64 {
             let v = self.dimensions.get_value(row, VOLU);
             let area = self.dimensions.get_value(row, AREA);
-            let spill = self.dimensions.get_value(row, SPIL).max(0.0);
+            let spill = self.spill_at_row(row, gated_spill);
             v - (v_working + net_rain_mm * area - outflow_at(v, spill))
         };
 
@@ -447,20 +469,20 @@ impl StorageNode {
         }
         let istop = hi;
         if istop == 0 {
-            return self.rating_floor(v_working, net_rain_mm);
+            return self.rating_floor(v_working, net_rain_mm, gated_spill);
         }
         let row = istop - 1;
         let error_prev = if row == lo { error_lo } else { compute_error(row) };
         if error_prev >= 0.0 {
-            return self.rating_floor(v_working, net_rain_mm);
+            return self.rating_floor(v_working, net_rain_mm, gated_spill);
         }
 
         let v_lo = self.dimensions.get_value(row, VOLU);
         let v_hi = self.dimensions.get_value(istop, VOLU);
         let area_lo = self.dimensions.get_value(row, AREA);
         let area_hi = self.dimensions.get_value(istop, AREA);
-        let spill_lo = self.dimensions.get_value(row, SPIL).max(0.0);
-        let spill_hi = self.dimensions.get_value(istop, SPIL).max(0.0);
+        let spill_lo = self.spill_at_row(row, gated_spill);
+        let spill_hi = self.spill_at_row(istop, gated_spill);
         let lerp = |v: f64| -> (f64, f64) {
             let x = (v - v_lo) / (v_hi - v_lo);
             (area_lo + (area_hi - area_lo) * x, (spill_lo + (spill_hi - spill_lo) * x).max(0.0))
@@ -601,7 +623,7 @@ impl StorageNode {
             if t > pos {
                 let e_left = err_at(t);
                 if e_pos < 0.0 && e_left >= 0.0 {
-                    return self.rating_attribution(solve_piece(pos, t, e_pos, e_left), row, v_working, net_rain_mm);
+                    return self.rating_attribution(solve_piece(pos, t, e_pos, e_left), row, v_working, net_rain_mm, gated_spill);
                 }
                 pos = t;
                 e_pos = e_left;
@@ -610,13 +632,13 @@ impl StorageNode {
                 let (_, spill_t) = lerp(t);
                 let jump = self.rating_jump_at(t, spill_t);
                 if e_pos + jump >= 0.0 {
-                    return self.rating_park_at(t, row, v_working, net_rain_mm);
+                    return self.rating_park_at(t, row, v_working, net_rain_mm, gated_spill);
                 }
                 e_pos += jump;
             }
         }
         if pos < v_hi && e_pos < 0.0 && error_hi >= 0.0 {
-            return self.rating_attribution(solve_piece(pos, v_hi, e_pos, error_hi), row, v_working, net_rain_mm);
+            return self.rating_attribution(solve_piece(pos, v_hi, e_pos, error_hi), row, v_working, net_rain_mm, gated_spill);
         }
 
         // Ceiling case (error still negative at the table top): the region
@@ -629,9 +651,9 @@ impl StorageNode {
         if e_start < 0.0 && e_probe > e_start {
             let x = -e_start / (e_probe - e_start);
             let v = start_v + (v_probe - start_v) * x;
-            return self.rating_attribution(v, row, v_working, net_rain_mm);
+            return self.rating_attribution(v, row, v_working, net_rain_mm, gated_spill);
         }
-        self.rating_attribution(v_hi, row, v_working, net_rain_mm)
+        self.rating_attribution(v_hi, row, v_working, net_rain_mm, gated_spill)
     }
 
     /// Solves the backward Euler equation for equilibrium volume in flow phase.
@@ -650,6 +672,7 @@ impl StorageNode {
         &mut self,
         v_initial: f64,
         net_rain_mm: f64,
+        gated_spill: f64,
         data_cache: &mut DataCache,
     ) -> (f64, [f64; MAX_DS_LINKS], f64, usize, f64) {
         let nrows = self.dimensions.nrows();
@@ -664,18 +687,18 @@ impl StorageNode {
         }
 
         if self.has_mol {
-            return self.solve_rating(v_initial, net_rain_mm, nrows, self.previous_istop);
+            return self.solve_rating(v_initial, net_rain_mm, gated_spill, nrows, self.previous_istop);
         }
 
         // Sanitized dues (NaN / non-positive => 0) — the raw values would
         // poison the equilibrium error or manufacture water.
         let dues = self.sanitized_dues();
         let (v_solved, row, legacy) =
-            self.solve_equilibrium(&dues, v_initial, net_rain_mm, nrows, self.previous_istop);
+            self.solve_equilibrium(&dues, v_initial, net_rain_mm, gated_spill, nrows, self.previous_istop);
 
         // Evaluate the solution point and allocate.
         let area = self.dimensions.interpolate_row(row, VOLU, AREA, v_solved);
-        let spill = self.dimensions.interpolate_row(row, VOLU, SPIL, v_solved).max(0.0);
+        let spill = self.spill_at_vol(row, v_solved, gated_spill);
 
         let mut ds_flows = [0.0; MAX_DS_LINKS];
         let v_final;
@@ -743,6 +766,7 @@ impl StorageNode {
         dues: &[f64; MAX_DS_LINKS],
         v_working: f64,
         net_rain_mm: f64,
+        gated_spill: f64,
         nrows: usize,
         start_row: usize,
     ) -> (f64, usize, bool) {
@@ -752,7 +776,7 @@ impl StorageNode {
                 dues,
                 self.dimensions.get_value(row, VOLU),
                 self.dimensions.get_value(row, AREA),
-                self.dimensions.get_value(row, SPIL).max(0.0),
+                self.spill_at_row(row, gated_spill),
                 v_working,
                 net_rain_mm,
             )
@@ -836,8 +860,8 @@ impl StorageNode {
         let v_hi = self.dimensions.get_value(istop, VOLU);
         let area_lo = self.dimensions.get_value(row, AREA);
         let area_hi = self.dimensions.get_value(istop, AREA);
-        let spill_lo = self.dimensions.get_value(row, SPIL).max(0.0);
-        let spill_hi = self.dimensions.get_value(istop, SPIL).max(0.0);
+        let spill_lo = self.spill_at_row(row, gated_spill);
+        let spill_hi = self.spill_at_row(istop, gated_spill);
 
         // Exact within-segment solve (including the ds_1 spill kink and, in
         // the ceiling case, extrapolation beyond the table top). The
@@ -999,9 +1023,17 @@ impl Node for StorageNode {
         }
         // Spill at the empty row would release water the storage doesn't
         // hold (the solver adds spill to ds_1 uncapped by contents).
-        if self.dimensions.get_value(0, SPIL) > 0_f64 {
+        if !self.is_gated && self.dimensions.get_value(0, SPIL) > 0_f64 {
             let message = format!("Error in node '{}'. Storage dimension table must begin with spill=0.", self.name);
             return Err(message);
+        }
+
+        // Gated storages must have a spillway_gated_release defined, otherwise error
+        if self.is_gated && matches!(self.spillway_gated_release, DynamicInput::None { .. }) {
+            return Err(format!(
+                "Error in node '{}'. Gated storage must have a spillway_gated_release defined.", 
+                self.name
+            ));
         }
 
         // Validate that volumes are strictly increasing (required for solver interpolation)
@@ -1265,9 +1297,18 @@ impl Node for StorageNode {
             
             // Net rainfall rate
             let net_rain_mm = rain_mm - evap_mm - seep_mm;
+
+            // If spillway is gated, get the target release volume and check valid else set to 0.0
+            let gated_spill = if self.is_gated {
+                let g = self.spillway_gated_release.get_value(data_cache);
+                if g.is_nan() || g <= 0.0 { 0.0 } else { g }
+            } else {
+                0.0
+            };
             
             // Solve backward Euler
-            let (v_final, ds_flows, spill, row, solver_area_km2) = self.solve_backward_euler(self.volume, net_rain_mm, data_cache);
+            let (v_final, ds_flows, spill, row, solver_area_km2) = 
+                self.solve_backward_euler(self.volume, net_rain_mm, gated_spill, data_cache);
             area_km2 = solver_area_km2;
             
             // Update warm-start cache for next timestep (expects upper bracket)


### PR DESCRIPTION
This PR demonstrates a potential pathway to #407 to be discussed. 

## Add `storage_gated` node type

**What this does**

Adds a new node type, `storage_gated`, for dams where spillway discharge is generally controlled by dam operating strategies rather than uncontrolled flows over a fixed crest.

A normal `storage` node works out spill from the 'Spill' column of the dimensions table. A `storage_gated` node ignores that column entirely and instead releases whatever a new property tells it to:

```ini
[node.my_dam]
type = storage_gated
spillway_gated_release = 100 # or a function or a look-table
dimensions = ... # noting that spill column is not used
```

The release can be a fixed number, a time series, a table, or a function — the same options already available for other parameters.

**Important: referencing the dam's own level**

If the gated release is driven by a rating curve on the dam's own level, the reference must be lagged one step, because of the backwards Euler formula (can this be checked):

```ini
spillway_gated_release = fn.release(node.test_dam.level[-1,0])
```

This is because the release is worked out at the start of the timestep, before the solver works out the new level. So it can only see yesterday's level, not today's. I think this is consistent with typical operating philosophy as an operator will set the gates based on the level in front of them, not the level that will result. But it does differ from how the ungated spill column works, where spill and level are solved together. 

**How it's implemented**

`storage_gated` reuses the existing `StorageNode` struct with a flag. Everywhere the solver previously read spill from the table, it now goes through a helper that returns either the table value or the gated release depending on the flag. Nothing else about the solver changed, so plain `storage` nodes behave exactly as before.

Also updated: the INI reader and writer, so gated storages survive a save/load round trip, and the validation rules — a gated node must define `spillway_gated_release`, and a plain node can't.

**What still needs doing**

No automated tests yet. I have done some testing and appears to be working, but some broader debugging would probably be needed.

Minor formatting for the ini file on the front-end.

** Note **

~~The gated release isn't limited by how much water is actually in the dam at the point it's requested. The solver's existing floor logic should clamp it, but hasn't been robustly tested.~~ refer [41e0e12](https://github.com/chasegan/Kalix/pull/411/commits/40e0e124c3dade441eadad465de17267048b79d8)
